### PR TITLE
Fixed surfacego-touchscreen systemd service

### DIFF
--- a/root/etc/systemd/system/surfacego-touchscreen.service
+++ b/root/etc/systemd/system/surfacego-touchscreen.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=Surface Go Touchscreen Power Management
+ConditionPathExists=/sys/devices/pci0000:00/0000:00:15.1/i2c_designware.1/power/control
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ConditionPathExists=/sys/devices/pci0000:00/0000:00:15.1/i2c_designware.1/power/control
-Exec=/bin/sh -c "echo on > /sys/devices/pci0000:00/0000:00:15.1/i2c_designware.1/power/control"
+ExecStart=/bin/sh -c "echo on > /sys/devices/pci0000:00/0000:00:15.1/i2c_designware.1/power/control"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- The ConditionPathExists attribute belongs in [Unit], not in [Service]
- Exec attribute is unknown.  Should use ExecStart for a oneshot service