### PR TITLE
sleep-script: IPTS: fix paths change

### DIFF
--- a/root/lib/systemd/system-sleep/sleep
+++ b/root/lib/systemd/system-sleep/sleep
@@ -21,14 +21,14 @@ case $1 in
     # modprobe -r mei_me
     # modprobe -r mei
     ## > Remove IPTS from i915 side
-    # for i in $(find /sys/kernel/debug/dri -name i915_intel_ipts_cleanup); do
+    # for i in $(find /sys/kernel/debug/dri -name i915_ipts_cleanup); do
     #   echo 1 > $i
     # done
     ;;
   post)   # re-load modules after resume
     ## IPTS: see notes below
     ## > Load IPTS from i915 side
-    # for i in $(find /sys/kernel/debug/dri -name i915_intel_ipts_init); do
+    # for i in $(find /sys/kernel/debug/dri -name i915_ipts_init); do
     #   echo 1 > $i
     # done
     ## > Load IPTS from ME side


### PR DESCRIPTION
Fixes file paths in accordance with linux-surface/kernel@b7c60a63bd916ab6c0e779d9b7a8d10b4f98a9e0