### PR TITLE
Added the Surface Go 2 to the supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Follow the instructions below to install the latest kernel.
 * Surface Book 2
 * Surface 3
 * Surface Go
+* Surface Go 2
 * Surface Laptop
 * Surface Laptop 2
 * Surface Laptop 3


### PR DESCRIPTION
The Surface Go 2 doesn't require the Surface Kernel (it's a very similar device to the original Surface Go) and everything is working nicely out of the box, apart from the cameras.

Please have a look at the [wiki page](https://github.com/linux-surface/linux-surface/wiki/Surface-Go-2) I wrote for the device.