### PR TITLE
Update Arch packages to make it Manjaro compatible

### DIFF
--- a/pkg/arch/kernel-lts/PKGBUILD
+++ b/pkg/arch/kernel-lts/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=linux-surface-lts
 pkgver=4.19.157
-pkgrel=1
+pkgrel=2
 pkgdesc='LTS Linux'
 url="https://www.kernel.org/"
 arch=(x86_64)
@@ -99,6 +99,7 @@ _package() {
   depends=(coreutils kmod initramfs)
   optdepends=('crda: to set the correct wireless channels of your country'
               'linux-firmware: firmware images needed for some devices')
+  provides=("linux=${pkgver}")
 
   cd $_srcname
   local kernver="$(<version)"
@@ -131,6 +132,7 @@ _package() {
 
 _package-headers() {
   pkgdesc="Headers and scripts for building modules for the $pkgdesc kernel"
+  provides=("linux-headers=${pkgver}")
 
   cd $_srcname
   local builddir="$pkgdir/usr/lib/modules/$(<version)/build"

--- a/pkg/arch/kernel/PKGBUILD
+++ b/pkg/arch/kernel/PKGBUILD
@@ -3,8 +3,9 @@
 
 pkgbase=linux-surface
 pkgver=5.9.8.arch1
-pkgrel=1
+pkgrel=2
 pkgdesc='Linux'
+_shortver=${pkgver%.*}
 _fullver=${pkgver%.*}-${pkgver##*.}
 _srctag=v${_fullver}
 url="https://git.archlinux.org/linux.git/log/?h=$_srctag"
@@ -96,7 +97,7 @@ _package() {
   depends=(coreutils kmod initramfs)
   optdepends=('crda: to set the correct wireless channels of your country'
               'linux-firmware: firmware images needed for some devices')
-  provides=(VIRTUALBOX-GUEST-MODULES WIREGUARD-MODULE)
+  provides=(VIRTUALBOX-GUEST-MODULES WIREGUARD-MODULE linux=${_shortver})
   replaces=(virtualbox-guest-modules-arch wireguard-arch)
 
   cd $_srcname
@@ -127,6 +128,7 @@ _package() {
 
 _package-headers() {
   pkgdesc="Headers and scripts for building modules for the $pkgdesc kernel"
+  provides=("linux-headers=${_shortver}")
 
   cd $_srcname
   local builddir="$pkgdir/usr/lib/modules/$(<version)/build"


### PR DESCRIPTION
Hello! Thank you for the project!

The PR is an attempt to make Arch PKGBUILDs compatible with Manjaro. Without it I'm getting error currently:

```
:: installing linux-surface (5.9.8.arch1-1) breaks dependency 'linux>=3.4' required by manjaro-system
```

So I'm proposing to add `provides` keyword to PKGBUILD with appropriate linux version. Hope it okay, feel free to critisize/close :)