### PR TITLE
Surface Go Touchscreen Battery Patch

### DIFF
--- a/patches/5.12/0009-surface-go-touchscreen.patch
+++ b/patches/5.12/0009-surface-go-touchscreen.patch
@@ -1,0 +1,38 @@
+From d999b52120c55d5b7f09c324b03cf7b21cfe8bb4 Mon Sep 17 00:00:00 2001
+From: Zoltan Tamas Vajda <zoltan.tamas.vajda@gmail.com>
+Date: Tue, 25 May 2021 21:32:11 +0200
+Subject: [PATCH] Added battery quirk for Surface Go touchscreen
+
+---
+ drivers/hid/hid-ids.h   | 1 +
+ drivers/hid/hid-input.c | 2 ++
+ 2 files changed, 3 insertions(+)
+
+diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
+index ba338973e968..bb976bb1b1c0 100644
+--- a/drivers/hid/hid-ids.h
++++ b/drivers/hid/hid-ids.h
+@@ -396,6 +396,7 @@
+ #define USB_DEVICE_ID_HP_X2_10_COVER	0x0755
+ #define I2C_DEVICE_ID_HP_SPECTRE_X360_15	0x2817
+ #define USB_DEVICE_ID_ASUS_UX550_TOUCHSCREEN	0x2706
++#define I2C_DEVICE_ID_SURFACE_GO_TOUCHSCREEN	0x261A
+ 
+ #define USB_VENDOR_ID_ELECOM		0x056e
+ #define USB_DEVICE_ID_ELECOM_BM084	0x0061
+diff --git a/drivers/hid/hid-input.c b/drivers/hid/hid-input.c
+index 236bccd37760..cc16f29e27a4 100644
+--- a/drivers/hid/hid-input.c
++++ b/drivers/hid/hid-input.c
+@@ -326,6 +326,8 @@ static const struct hid_device_id hid_battery_quirks[] = {
+ 	  HID_BATTERY_QUIRK_IGNORE },
+ 	{ HID_I2C_DEVICE(USB_VENDOR_ID_ELAN, I2C_DEVICE_ID_HP_SPECTRE_X360_15),
+ 	  HID_BATTERY_QUIRK_IGNORE },
++ 	{ HID_I2C_DEVICE(USB_VENDOR_ID_ELAN, I2C_DEVICE_ID_SURFACE_GO_TOUCHSCREEN),
++	  HID_BATTERY_QUIRK_IGNORE },
+ 	{}
+ };
+ 
+-- 
+2.30.2
+


### PR DESCRIPTION
The Elantech touchscreen/digitizer in the Surface Go mistakenly shows up as having capable of reporting battery (even though it actually cannot). This results in a "low battery" message popping up every time you try to use the pen. This patch adds a quirk allowing the kernel to ignore the the non-existent battery and get rid of the false low battery messages.