### PR TITLE
Patch 1

### DIFF
--- a/contrib/thermald/example_config_SL1.xml
+++ b/contrib/thermald/example_config_SL1.xml
@@ -1,0 +1,24 @@
+<ThermalConfiguration>
+ <Platform>
+   <Name>Override CPU default passive</Name>
+   <ProductName>*</ProductName>
+   <Preference>QUIET</Preference>
+   <ThermalZones>
+     <ThermalZone>
+       <Type>cpu</Type>
+       <TripPoints>
+         <TripPoint>
+           <SensorType>x86_pkg_temp</SensorType>
+           <Temperature>90000</Temperature>
+           <type>max</type>
+         </TripPoint>
+         <TripPoint>
+	        <SensorType>GEN1</SensorType>
+			<Temperature>50000</Temperature>
+			<type>max</type>
+        </TripPoint>
+       </TripPoints>
+     </ThermalZone>
+ </ThermalZones>
+</Platform>
+</ThermalConfiguration>

--- a/contrib/thermald/example_config_SL1.xml
+++ b/contrib/thermald/example_config_SL1.xml
@@ -1,5 +1,5 @@
 <ThermalConfiguration>
- <Platform>
+<Platform>
    <Name>Override CPU default passive</Name>
    <ProductName>*</ProductName>
    <Preference>QUIET</Preference>
@@ -13,12 +13,12 @@
            <type>max</type>
          </TripPoint>
          <TripPoint>
-	        <SensorType>GEN1</SensorType>
-			<Temperature>50000</Temperature>
-			<type>max</type>
+	   <SensorType>GEN1</SensorType>
+	   <Temperature>50000</Temperature>
+	   <type>max</type>
         </TripPoint>
        </TripPoints>
      </ThermalZone>
- </ThermalZones>
+   </ThermalZones>
 </Platform>
 </ThermalConfiguration>


### PR DESCRIPTION
An updated thermal config for the surface laptop to keep the GEN1 sensors happy.
The commit message says it all: 
The surface Laptop 1 immediately throttles to 400MHz if the GEN1 sensors reaches 52°C. Every time my Surface Laptop was under heavy load for more than a few minutes my performance hit a brick wall. 
This config fixes this, it caps the CPU temp at 90°C and more importantly keeps GEN1 cooler than 50°C. 
I have stress tested this config extensively and have had no thermal throttling and stable temps. 
If you have any questions or concerns feel free to contact me. 

Kind regards,
jo