### PR TITLE
Update example_config_SL1.xml

### DIFF
--- a/contrib/thermald/example_config_SL1.xml
+++ b/contrib/thermald/example_config_SL1.xml
@@ -1,24 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ThermalConfiguration>
-<Platform>
-   <Name>Override CPU default passive</Name>
-   <ProductName>*</ProductName>
-   <Preference>QUIET</Preference>
-   <ThermalZones>
-     <ThermalZone>
-       <Type>cpu</Type>
-       <TripPoints>
-         <TripPoint>
-           <SensorType>x86_pkg_temp</SensorType>
-           <Temperature>90000</Temperature>
-           <type>max</type>
-         </TripPoint>
-         <TripPoint>
-	   <SensorType>GEN1</SensorType>
-	   <Temperature>50000</Temperature>
-	   <type>max</type>
-        </TripPoint>
-       </TripPoints>
-     </ThermalZone>
-   </ThermalZones>
-</Platform>
+  <Platform>
+  <Name>Override</Name>
+  <ProductName>*</ProductName>
+  <Preference>QUIET</Preference>
+    <ThermalZones>
+      <ThermalZone>
+        <Type>test</Type>
+        <TripPoints>
+          <TripPoint>
+            <SensorType>GEN1</SensorType>
+            <Temperature>50000</Temperature>
+            <type>passive</type>
+            <CoolingDevice>
+              <index>1</index>
+              <type>Processor</type>
+              <influence> 100 </influence>
+              <SamplingPeriod> 4 </SamplingPeriod>
+              <TargetState> 1 </TargetState>
+            </CoolingDevice>
+          </TripPoint>
+          <TripPoint>
+            <SensorType>GEN1</SensorType>
+            <Temperature>51000</Temperature>
+            <type>max</type>
+            <CoolingDevice>
+              <index>1</index>
+              <type>Processor</type>
+              <influence> 100 </influence>
+              <SamplingPeriod> 5 </SamplingPeriod>
+              <TargetState> 4 </TargetState>
+            </CoolingDevice>
+          </TripPoint>
+        </TripPoints>
+      </ThermalZone>
+    </ThermalZones>
+    <CoolingDevices>
+      <CoolingDevice>
+        <Type>Processor</Type>
+        <MinState>0</MinState>
+        <IncDecStep>1</IncDecStep>
+        <ReadBack> 0 </ReadBack>
+        <MaxState>10</MaxState>
+        <DebouncePeriod>5</DebouncePeriod>
+      </CoolingDevice>
+    </CoolingDevices>
+  </Platform>
 </ThermalConfiguration>


### PR DESCRIPTION
After some testing I explicitly specified which cooling devices in /sys/class should be used. 
I found this config to be more reliable and predictable.
This config exclusively controls the temperature of GEN1 which keeps the cpu usually below 80°. 
 
Kind regards, 
Jo 