### PR TITLE
Alternative name "Surface Pro (5th Gen)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Follow the instructions below to install the latest kernel.
 * Surface Laptop Studio
 * Surface Pro 3
 * Surface Pro 4
-* Surface Pro 2017
+* Surface Pro (5th Gen) / Surface Pro 2017
 * Surface Pro 6
 * Surface Pro 7
 * Surface Pro 7+


### PR DESCRIPTION
The weird naming thing ms did when they came up with this device has always confused me. Some time ago, they renamed the device from "Surface Pro 2017" to "Surface Pro (5th Gen)".

You can see this on [this page](https://support.microsoft.com/en-us/topic/surface-pro-all-models-638a0c92-5d82-4a71-b5fb-4ef92ebbc71f) or (if the link is broken) by navigating to "All models" from [this page](https://support.microsoft.com/en-us/surface-pro)