### PR TITLE
Add SLG2 as supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Follow the instructions below to install the latest kernel.
 * Surface Laptop 3
 * Surface Laptop 4
 * Surface Laptop Go
+* Surface Laptop Go 2
 * Surface Laptop Studio
 * Surface Pro 3
 * Surface Pro 4


### PR DESCRIPTION
Add the Surface Laptop Go 2 to README.md as supported since functionality is now working with linux-surface>=5.18.10
This should be final piece sufficient to close #855 