### PR TITLE
pkg: Fedora: fix scriptlets during reinstall

### DIFF
--- a/pkg/fedora/kernel-surface/kernel-surface.spec
+++ b/pkg/fedora/kernel-surface/kernel-surface.spec
@@ -337,7 +337,7 @@ EOF
 %clean
 rm -rf %{buildroot}
 
-%post
+%posttrans
 /bin/kernel-install add %{kernel_name} /lib/modules/%{kernel_name}/vmlinuz || exit $?
 
 %preun


### PR DESCRIPTION
## Problem
Running `sudo dnf reinstall kernel-surface` removes `vmlinuz`, `initramfs` and boot entry from `/boot`, effectively removing installed kernel (_not really, manually running `kernel-install` is a fix_)

## Cause
Fedora kernel package spec file used puts `kernel-install` to [%post](https://github.com/linux-surface/linux-surface/blob/master/pkg/fedora/kernel-surface/kernel-surface.spec#L340-L341). During a reinstall/upgrade, `%post` for new package runs [before](https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#ordering) `%postun` of old package. So when reinstalling same package, what happens is 
1. `kernel-install add ...` Install same version again
2. `kernel-install remove ...` remove the installed version, removing current kernel-surface from `/boot`

## Fix
Like [what fedora stock kernel do](https://src.fedoraproject.org/rpms/kernel/blob/rawhide/f/kernel.spec#_2814-2823), puts install of new package __after__ old package's removal.