### PR TITLE
Expand on how to change `ExecStart=` in `thermald.service`

### DIFF
--- a/contrib/thermald/README.md
+++ b/contrib/thermald/README.md
@@ -14,4 +14,4 @@ Both XML files (`thermal-conf.xml` and `thermal-cpu-cdev-order-xml`) need to be 
 
 Newer thermald versions attempt to automatically load the configuration from ACPI.
 If you want to use a manual configuration with such a version, you may need to remove the `--adaptive` option from the systemd service `ExecStart` line.
-You can do so by running `sudo systemctl edit thermald.service`.
+You can do so by overwriting `thermald.service`. This file is present in `/lib/systemd/system/` (it may also be in `/usr/lib/systemd/system/`).

--- a/contrib/thermald/README.md
+++ b/contrib/thermald/README.md
@@ -14,4 +14,13 @@ Both XML files (`thermal-conf.xml` and `thermal-cpu-cdev-order-xml`) need to be 
 
 Newer thermald versions attempt to automatically load the configuration from ACPI.
 If you want to use a manual configuration with such a version, you may need to remove the `--adaptive` option from the systemd service `ExecStart` line.
-You can do so by overwriting `thermald.service`. This file is present in `/lib/systemd/system/` (it may also be in `/usr/lib/systemd/system/`).
+You can do so by running `sudo systemctl edit thermald.service`.
+
+Note that with `systemctl edit`, before the modified `ExecStart` line, you should add a new line containing `ExecStart=` and nothing on the right, like this:
+
+```
+ExecStart=
+ExecStart=<modified line>
+```
+
+This instructs to replace the existing `ExecStart` instead of adding a new one. Otherwise, you may get an error "Unit thermald.service has a bad unit file setting", and the command `systemctl status thermald.service` may prompt a message "Service has more than one ExecStart= setting".


### PR DESCRIPTION
Editing `ExecStart=` with `systemctl edit` did not work for me. Running `systemctl restart thermald.service` afterwards was giving errors every time with reason "Unit thermald.service has a bad unit file setting".

By running `systemctl status thermald.service`, I was reading this error:

```
thermald.service: Service has more than one ExecStart= setting, which is only allowed for Type=oneshot services. Refusing.
````

By looking through the Internet for solutions, I found a suggestion from a user saying that "The `ExecStart=` line cannot be modified with `systemctl edit`" (https://unix.stackexchange.com/questions/409354).

What worked was replacing the `thermald.service` file directly to `/etc/systemd/system/` and `/usr/lib/systemd/system/`, as suggested in [the README.md present in the folder containing example configurations for Surface Pro 5](https://github.com/linux-surface/linux-surface/blob/3e7516c945045218de7a56bff14e48ccb7819df5/contrib/thermald/surface_pro_5/README.md) from this repository.