### PR TITLE
contrib/thermald: Add config for the Surface Laptop Go 2

### DIFF
--- a/contrib/thermald/surface_laptop_go_2/thermal-conf.xml
+++ b/contrib/thermald/surface_laptop_go_2/thermal-conf.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ThermalConfiguration>
+  <Platform>
+    <Name>Intel Powered Laptop</Name>
+    <ProductName>*</ProductName>
+    <Preference>QUIET</Preference>
+    <ThermalZones>
+      <ThermalZone>
+        <Type>cpu</Type>
+        <TripPoints>
+          <TripPoint>
+            <SensorType>x86_pkg_temp</SensorType>
+            <Temperature>65000</Temperature>
+            <type>passive</type>
+            <ControlType>SEQUENTIAL</ControlType>
+            <CoolingDevice>
+              <index>1</index>
+              <type>intel_pstate</type>
+              <influence>100</influence>
+              <SamplingPeriod>10</SamplingPeriod>
+            </CoolingDevice>
+          </TripPoint>
+        </TripPoints>
+      </ThermalZone>
+    </ThermalZones>
+  </Platform>
+</ThermalConfiguration>


### PR DESCRIPTION
After trying dozens of suggestions around this repo and elsewhere online, this config is what took things from guaranteed excessive throttling every 5-10 minutes in 3D games (making them completely unplayable), to not seeing the issue at all for multiple hours of playing.

I have a corresponding wiki entry ready to go once this PR has been accepted.