### PR TITLE
contrib/fedora-default-kernel: Make more robust and add rEFInd support

### DIFF
--- a/contrib/fedora-default-kernel/README.md
+++ b/contrib/fedora-default-kernel/README.md
@@ -12,6 +12,8 @@ selection every time.
 ```bash
 $ sudo dnf install /usr/sbin/grubby
 $ sudo cp default-kernel.{path,service} /etc/systemd/system/
+$ sudo cp default-kernel.sh /usr/local/bin/default-kernel
+$ sudo chmod 755 /usr/local/bin/default-kernel
 $ sudo systemctl daemon-reload
 $ sudo systemctl enable --now default-kernel.path
 ```

--- a/contrib/fedora-default-kernel/default-kernel.service
+++ b/contrib/fedora-default-kernel/default-kernel.service
@@ -3,4 +3,4 @@ Description=linux-surface default kernel watchdog
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c "grubby --set-default /boot/vmlinuz*surface*"
+ExecStart=/usr/local/bin/default-kernel

--- a/contrib/fedora-default-kernel/default-kernel.sh
+++ b/contrib/fedora-default-kernel/default-kernel.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# get list of surface kernels with timestamp
+kernels=$(find /boot -maxdepth 1 -name "vmlinuz-*.surface.*" -printf '%T@\t%p\n')
+
+# sort by timestamp
+kernels=$(echo "${kernels}" | sort -n)
+
+# get latest kernel (last line) and extract path
+kernel=$(echo "${kernels}" | tail -n1 | cut -f2)
+
+echo $kernel
+
+# update GRUB config
+grubby --set-default "${kernel}"
+
+# update timestamp for rEFInd (ensure it's marked as latest across all kernels,
+# not just surface ones)
+touch "${kernel}"


### PR DESCRIPTION
Add a script to explicitly handle multiple Surface kernel versions being installed in parallel, sorting kernels by version and choosing the latest one.

Further, add support for rEFInd by updating the vmlinuz file timestamp to ensure it's always seen as the last modified file (which will be picked by rEFInd as the "default" kernel in that directory).