### PR TITLE
a huge help on the laptop go gen 1 as well

### DIFF
--- a/contrib/thermald/surface_laptop_go_1/thermal-conf.xml
+++ b/contrib/thermald/surface_laptop_go_1/thermal-conf.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ThermalConfiguration>
+  <Platform>
+    <Name>Intel Powered Laptop</Name>
+    <ProductName>*</ProductName>
+    <Preference>QUIET</Preference>
+    <ThermalZones>
+      <ThermalZone>
+        <Type>cpu</Type>
+        <TripPoints>
+          <TripPoint>
+            <SensorType>x86_pkg_temp</SensorType>
+            <Temperature>65000</Temperature>
+            <type>passive</type>
+            <ControlType>SEQUENTIAL</ControlType>
+            <CoolingDevice>
+              <index>1</index>
+              <type>intel_pstate</type>
+              <influence>100</influence>
+              <SamplingPeriod>10</SamplingPeriod>
+            </CoolingDevice>
+          </TripPoint>
+        </TripPoints>
+      </ThermalZone>
+    </ThermalZones>
+  </Platform>
+</ThermalConfiguration>


### PR DESCRIPTION
This is a copy of the same file from the laptop go 2 folder. Prior to using this on my laptop go 1, google meet visual effects would result in the same behavior this file is designed to correct. Once I installed it per the instructions, I had no such problems despite running intentional multi core stress tests, using google meet visual effects with a group of people for an extended period, etc. Looks like it is compatible with both models of the Laptop Go.