### PR TITLE
contrib/thermald: update SL4a readme

### DIFF
--- a/contrib/thermald/surface_laptop_4a/README.md
+++ b/contrib/thermald/surface_laptop_4a/README.md
@@ -30,7 +30,7 @@ sudo systemctl stop thermald.service
 Place thermal-conf.xml into the following directory:
 
 ```
-\etc\thermald\
+/etc/thermald/
 ```
 Restart thermald:
 


### PR DESCRIPTION
replace backslashes (\) with forward-slashes (/) for thermald config path.
Since all other paths in this document are using forward-slashes as file separators, this feels inconsistent.