### PR TITLE
Update Fedora kernels to v6.11.6

### DIFF
--- a/pkg/fedora/kernel-surface/build-linux-surface.py
+++ b/pkg/fedora/kernel-surface/build-linux-surface.py
@@ -18,7 +18,7 @@ PACKAGE_NAME = "surface"
 ## Fedora tags: kernel-X.Y.Z
 ## Upstream tags: vX.Y.Z
 ##
-PACKAGE_TAG = "kernel-6.11.4-0"
+PACKAGE_TAG = "kernel-6.11.6-0"
 
 ##
 ## The release number of the modified kernel package.


### PR DESCRIPTION
Update the Fedora kernel to the latest stable version.

I have tested the build and so far I have not noticed any problems.

This fixes #1594.