### PR TITLE
Build Fedora in Actions without Secure boot

### DIFF
--- a/.github/scripts/package/fedora.sh
+++ b/.github/scripts/package/fedora.sh
@@ -45,7 +45,9 @@ build-packages)
     git config --global user.email "surfacebot@users.noreply.github.com"
 
     # Build source RPM packages
-    python3 build-linux-surface.py --mode srpm --ark-dir kernel-ark --outdir srpm
+    sbd="${SB_DISABLED:-}"
+    python3 build-linux-surface.py --mode srpm --ark-dir kernel-ark --outdir srpm \
+        ${sbd:+"--no-sb"}
 
     # Remove the kernel-ark tree to get as much free disk space as possible
     rm -rf kernel-ark

--- a/.github/workflows/fedora-39.yml
+++ b/.github/workflows/fedora-39.yml
@@ -49,8 +49,11 @@ jobs:
             bash ./.github/scripts/package/fedora.sh setup-secureboot
 
       - name: Build packages
+        env:
+          SB_DISABLED: ${{ vars.SB_DISABLED }}
         run: |
           bash ./.github/scripts/container/exec.sh \
+            -e SB_DISABLED \
             -- \
             bash ./.github/scripts/package/fedora.sh build-packages
 

--- a/.github/workflows/fedora-40.yml
+++ b/.github/workflows/fedora-40.yml
@@ -49,8 +49,11 @@ jobs:
             bash ./.github/scripts/package/fedora.sh setup-secureboot
 
       - name: Build packages
+        env:
+          SB_DISABLED: ${{ vars.SB_DISABLED }}
         run: |
           bash ./.github/scripts/container/exec.sh \
+            -e SB_DISABLED \
             -- \
             bash ./.github/scripts/package/fedora.sh build-packages
 

--- a/.github/workflows/fedora-41.yml
+++ b/.github/workflows/fedora-41.yml
@@ -49,8 +49,11 @@ jobs:
             bash ./.github/scripts/package/fedora.sh setup-secureboot
 
       - name: Build packages
+        env:
+          SB_DISABLED: ${{ vars.SB_DISABLED }}
         run: |
           bash ./.github/scripts/container/exec.sh \
+            -e SB_DISABLED \
             -- \
             bash ./.github/scripts/package/fedora.sh build-packages
 

--- a/pkg/fedora/kernel-surface/build-linux-surface.py
+++ b/pkg/fedora/kernel-surface/build-linux-surface.py
@@ -65,6 +65,12 @@ parser.add_argument(
     default="out",
 )
 
+parser.add_argument(
+    "--no-sb",
+    help="Do not use secureboot keys",
+    action="store_true",
+)
+
 args = parser.parse_args()
 
 # The directory where this script is saved.
@@ -92,13 +98,15 @@ if not patches.exists() or not config.exists():
 # Check if Secure Boot keys are available.
 sb_avail = sb_cert.exists() and sb_key.exists()
 
-# If we are building without secureboot, require user input to continue.
-if not sb_avail:
+# If we are building without secureboot, warn user.
+if not sb_avail or args.no_sb:
     print("")
     print("Secure Boot keys were not configured! Using Red Hat testkeys.")
     print("The compiled kernel will not boot with Secure Boot enabled!")
     print("")
 
+# If no keys and no flag, require user input to continue.
+if not sb_avail and not args.no_sb:
     input("Press enter to continue: ")
 
 # Expand globs
@@ -129,7 +137,7 @@ if len(local_configs) > 0:
 if len(local_files) > 0:
     cmd += ["--file"] + local_files
 
-if sb_avail:
+if sb_avail and not args.no_sb:
     sb_patches = sorted((script / "secureboot").glob("*.patch"))
     sb_configs = sorted((script / "secureboot").glob("*.config"))
 


### PR DESCRIPTION
While I was trying to build the new kernel on my fork, GitHub actions spit out an error. It turned out that the build without secureboot keys in the repo requires user input. GH actions handles this very poorly and terminates the action.

Since I don't think it's necessary to use secureboot for testing purposes, I added a configuration variable that allows the workflow to run without keys.

With this pull request it is possible to set the variable `SB_DISABLED` in the (forked) repo and thus run a GH actions build, whether keys are available or not.