### PR TITLE
Update v6.16 patches

### DIFF
--- a/patches/6.10/0011-surface-shutdown.patch
+++ b/patches/6.10/0011-surface-shutdown.patch
@@ -1,7 +1,7 @@
 From fe6c6b6e8d581aeca114902ec5f962a44a0ee3ff Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod
+Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices
 (Surface Pro 9 and Surface Laptop 5) the EFI ResetSystem call with

--- a/patches/6.11/0011-surface-shutdown.patch
+++ b/patches/6.11/0011-surface-shutdown.patch
@@ -1,7 +1,7 @@
 From 44765b95447983e3e02aa26937c6b04266f09461 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod
+Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices
 (Surface Pro 9 and Surface Laptop 5) the EFI ResetSystem call with

--- a/patches/6.12/0010-surface-shutdown.patch
+++ b/patches/6.12/0010-surface-shutdown.patch
@@ -1,7 +1,7 @@
 From e88946a0b6535c5a7e31d30f345551df35ac1ef5 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod
+Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices
 (Surface Pro 9 and Surface Laptop 5) the EFI ResetSystem call with

--- a/patches/6.13/0011-surface-shutdown.patch
+++ b/patches/6.13/0011-surface-shutdown.patch
@@ -1,7 +1,7 @@
 From a8fd28a346634ae41963cabaa22c249c66289cf6 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod
+Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices
 (Surface Pro 9 and Surface Laptop 5) the EFI ResetSystem call with

--- a/patches/6.14/0011-surface-shutdown.patch
+++ b/patches/6.14/0011-surface-shutdown.patch
@@ -1,7 +1,7 @@
 From b19ebe86f0efac469f91581fe6ee53bce4586bc2 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod
+Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices
 (Surface Pro 9 and Surface Laptop 5) the EFI ResetSystem call with

--- a/patches/6.15/0011-surface-shutdown.patch
+++ b/patches/6.15/0011-surface-shutdown.patch
@@ -1,7 +1,7 @@
 From 46248cbac7ca6e688ebe5be29344239c78a884a7 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod
+Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices
 (Surface Pro 9 and Surface Laptop 5) the EFI ResetSystem call with

--- a/patches/6.16/0001-secureboot.patch
+++ b/patches/6.16/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From e87eeb0fa251c56d9966ad1e59b261ee0b14a566 Mon Sep 17 00:00:00 2001
+From ef381b568568d83624a9f527b394528bbf9f9cc4 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -35,7 +35,7 @@ index e1f4fd5bc8ee..64f8dc548045 100644
 -- 
 2.51.0
 
-From d697f8d42f404ba2615c63a36f3ce73931dcf2ea Mon Sep 17 00:00:00 2001
+From 2a3d0ca06b2a6f7c9f206b06886095f1d7658c94 Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter

--- a/patches/6.16/0002-surface3.patch
+++ b/patches/6.16/0002-surface3.patch
@@ -1,4 +1,4 @@
-From 594f39a9ca0f976ec3ab30fa6852ad4c2b4831a0 Mon Sep 17 00:00:00 2001
+From 0d1d229f54a68e14ee69bececce8fd06dbb1287e Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI
@@ -99,7 +99,7 @@ index e4c3492a0c28..0b930c91bccb 100644
 -- 
 2.51.0
 
-From 48541ded57baafc01b4a738a056c3ccec25c8df1 Mon Sep 17 00:00:00 2001
+From a5550b1de4700806a951fa58da2c7db0cb3a51c6 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
 Subject: [PATCH] surface3-spi: workaround: disable DMA mode to avoid crash by

--- a/patches/6.16/0003-mwifiex.patch
+++ b/patches/6.16/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From ac77045658a4d9764b9a6395e7b193ed14414ff5 Mon Sep 17 00:00:00 2001
+From 5ebd733c7a2faf6442fdbb64620664c6c74a3c6d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -165,7 +165,7 @@ index d6ff964aec5b..5d30ae39d65e 100644
 -- 
 2.51.0
 
-From f57cfe5a93d9d0bd3024367ffa9c99812feab8e0 Mon Sep 17 00:00:00 2001
+From 7fc537753e00ffba79cd3b93cff948569d0f85a0 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -320,7 +320,7 @@ index 5d30ae39d65e..c14eb56eb911 100644
 -- 
 2.51.0
 
-From 4c7809f1af22d2502869a90f8958f89ef7bc0a0c Mon Sep 17 00:00:00 2001
+From b13ce3956e2c84e8e0f9ede608419981c47238ce Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell

--- a/patches/6.16/0004-ath10k.patch
+++ b/patches/6.16/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From 61461ed065cb724b5fc971cb0c5272ef3313a42f Mon Sep 17 00:00:00 2001
+From 509e9d1b4d4803b7b3061cae155b92b5129b8569 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files

--- a/patches/6.16/0005-ipts.patch
+++ b/patches/6.16/0005-ipts.patch
@@ -1,4 +1,4 @@
-From 0ada79877cefaf982ffd379465e225042a283208 Mon Sep 17 00:00:00 2001
+From 766b671b7b337d44a2d543e038af19705b65dc32 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -37,7 +37,7 @@ index 3f9c60b579ae..853a67753333 100644
 -- 
 2.51.0
 
-From 3153c571ead4689a56c8b6cf35a3030e6cff7683 Mon Sep 17 00:00:00 2001
+From 52ab7cdaafa370cdaca812debc559a4c4f28afc5 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -144,7 +144,7 @@ index 3dd4d73fcb5d..98def863f736 100644
 -- 
 2.51.0
 
-From 7929eb6116ecdfacbf0bd288ae8f57a03f00b81a Mon Sep 17 00:00:00 2001
+From a94045db4fab0ee662697cdc70473e7162702b0a Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus

--- a/patches/6.16/0006-ithc.patch
+++ b/patches/6.16/0006-ithc.patch
@@ -1,4 +1,4 @@
-From 020ac25e7bf02edab684906a300a8624e2353b0d Mon Sep 17 00:00:00 2001
+From 1e8740a68d6ca59e6814a7470d04f139240c0c30 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -39,7 +39,7 @@ index cf7b6882ec75..55ab16865774 100644
 -- 
 2.51.0
 
-From f698eb55ef20a37e5724d7e8f5cb609d12fcabcc Mon Sep 17 00:00:00 2001
+From 6253e4bc033038c1e682057b7992692b517c7231 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller

--- a/patches/6.16/0007-surface-sam.patch
+++ b/patches/6.16/0007-surface-sam.patch
@@ -1,4 +1,4 @@
-From b83775761995a645f0c958d518ae0e9dc2c40cb7 Mon Sep 17 00:00:00 2001
+From 1578f4db9e0da5dc08d1169cc6694474b9ab9ab7 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
 Subject: [PATCH] rtc: Add basic support for RTC via Surface System Aggregator
@@ -181,7 +181,7 @@ index 000000000000..f6c17c4e98d5
 -- 
 2.51.0
 
-From d8f161cde861f572e191a8f7baa59d8e55051799 Mon Sep 17 00:00:00 2001
+From 6871f7ece4ce979923ea83e19c3cd2830188b4c5 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
 Subject: [PATCH] platform/surface: aggregator_registry: Add Surface Laptop 7

--- a/patches/6.16/0008-surface-sam-over-hid.patch
+++ b/patches/6.16/0008-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From e65ba8e7b543f1a0af66062d05d9d98c4602a8ad Mon Sep 17 00:00:00 2001
+From f5015fb9b2720652748f6bbc7ed8eb0adea07854 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -109,7 +109,7 @@ index f43067f6797e..1761ca30e17a 100644
 -- 
 2.51.0
 
-From c9c5d92d081d485de80aad30f535768848263247 Mon Sep 17 00:00:00 2001
+From 4972b5ba149ead25f9b3300674225788043b40d2 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch

--- a/patches/6.16/0009-surface-button.patch
+++ b/patches/6.16/0009-surface-button.patch
@@ -1,4 +1,4 @@
-From 13a6e5683a378d75df86470a039bb41d9d98e7eb Mon Sep 17 00:00:00 2001
+From 55168a263afd9a033c00ff9625b6324345d9405c Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -75,7 +75,7 @@ index b8cad415c62c..43b5d56383e3 100644
 -- 
 2.51.0
 
-From de2da3530b7fda779b5b5eb86b1f2d35087828fd Mon Sep 17 00:00:00 2001
+From bb174e7f9377b9f0afce68e2e52ceaf3584950a5 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd

--- a/patches/6.16/0010-surface-typecover.patch
+++ b/patches/6.16/0010-surface-typecover.patch
@@ -1,4 +1,4 @@
-From 0c9d7910c676745bcbac6439f0fd0697ec0dd327 Mon Sep 17 00:00:00 2001
+From 84deac886f50cf811673ad70953d5ab79b89617f Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -23,7 +23,7 @@ Patchset: surface-typecover
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
-index d6daad39491b..2e50dd89b800 100644
+index f5bc53875330..31fa895d73c4 100644
 --- a/drivers/usb/core/quirks.c
 +++ b/drivers/usb/core/quirks.c
 @@ -223,6 +223,9 @@ static const struct usb_device_id usb_quirk_list[] = {
@@ -39,7 +39,7 @@ index d6daad39491b..2e50dd89b800 100644
 -- 
 2.51.0
 
-From 096340b6ad9ccc772d7f1be6ea455f48ee5f72a4 Mon Sep 17 00:00:00 2001
+From 8c85bf8003cf8dcbe8f04a100474513a10e3f207 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -75,7 +75,7 @@ Patchset: surface-typecover
  1 file changed, 98 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 4c22bd2ba170..e231393da178 100644
+index edb8da49d916..650df45e9f13 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -35,7 +35,10 @@
@@ -97,11 +97,11 @@ index 4c22bd2ba170..e231393da178 100644
  
  /* quirks to control the device */
  #define MT_QUIRK_NOT_SEEN_MEANS_UP	BIT(0)
-@@ -73,12 +77,15 @@ MODULE_LICENSE("GPL");
- #define MT_QUIRK_FORCE_MULTI_INPUT	BIT(20)
+@@ -74,12 +78,15 @@ MODULE_LICENSE("GPL");
  #define MT_QUIRK_DISABLE_WAKEUP		BIT(21)
  #define MT_QUIRK_ORIENTATION_INVERT	BIT(22)
-+#define MT_QUIRK_HAS_TYPE_COVER_BACKLIGHT	BIT(23)
+ #define MT_QUIRK_APPLE_TOUCHBAR		BIT(23)
++#define MT_QUIRK_HAS_TYPE_COVER_BACKLIGHT	BIT(24)
  
  #define MT_INPUTMODE_TOUCHSCREEN	0x02
  #define MT_INPUTMODE_TOUCHPAD		0x03
@@ -113,7 +113,7 @@ index 4c22bd2ba170..e231393da178 100644
  enum latency_mode {
  	HID_LATENCY_NORMAL = 0,
  	HID_LATENCY_HIGH = 1,
-@@ -176,6 +183,8 @@ struct mt_device {
+@@ -177,6 +184,8 @@ struct mt_device {
  
  	struct list_head applications;
  	struct list_head reports;
@@ -122,7 +122,7 @@ index 4c22bd2ba170..e231393da178 100644
  };
  
  static void mt_post_parse_default_settings(struct mt_device *td,
-@@ -220,6 +229,7 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app);
+@@ -221,6 +230,7 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app);
  #define MT_CLS_GOOGLE				0x0111
  #define MT_CLS_RAZER_BLADE_STEALTH		0x0112
  #define MT_CLS_SMART_TECH			0x0113
@@ -130,7 +130,7 @@ index 4c22bd2ba170..e231393da178 100644
  #define MT_CLS_SIS				0x0457
  
  #define MT_DEFAULT_MAXCONTACT	10
-@@ -410,6 +420,16 @@ static const struct mt_class mt_classes[] = {
+@@ -411,6 +421,16 @@ static const struct mt_class mt_classes[] = {
  			MT_QUIRK_ALWAYS_VALID |
  			MT_QUIRK_CONTACT_CNT_ACCURATE,
  	},
@@ -147,7 +147,7 @@ index 4c22bd2ba170..e231393da178 100644
  	{ }
  };
  
-@@ -1767,6 +1787,69 @@ static void mt_expired_timeout(struct timer_list *t)
+@@ -1802,6 +1822,69 @@ static void mt_expired_timeout(struct timer_list *t)
  	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
  }
  
@@ -217,7 +217,7 @@ index 4c22bd2ba170..e231393da178 100644
  static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  {
  	int ret, i;
-@@ -1790,6 +1873,9 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1825,6 +1908,9 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  	td->inputmode_value = MT_INPUTMODE_TOUCHSCREEN;
  	hid_set_drvdata(hdev, td);
  
@@ -227,7 +227,7 @@ index 4c22bd2ba170..e231393da178 100644
  	INIT_LIST_HEAD(&td->applications);
  	INIT_LIST_HEAD(&td->reports);
  
-@@ -1828,8 +1914,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1863,8 +1949,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  	timer_setup(&td->release_timer, mt_expired_timeout, 0);
  
  	ret = hid_parse(hdev);
@@ -239,7 +239,7 @@ index 4c22bd2ba170..e231393da178 100644
  
  	if (mtclass->quirks & MT_QUIRK_FIX_CONST_CONTACT_ID)
  		mt_fix_const_fields(hdev, HID_DG_CONTACTID);
-@@ -1838,8 +1926,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1873,8 +1961,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  		hdev->quirks |= HID_QUIRK_NOGET;
  
  	ret = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
@@ -251,7 +251,7 @@ index 4c22bd2ba170..e231393da178 100644
  
  	ret = sysfs_create_group(&hdev->dev.kobj, &mt_attribute_group);
  	if (ret)
-@@ -1889,6 +1979,7 @@ static void mt_remove(struct hid_device *hdev)
+@@ -1924,6 +2014,7 @@ static void mt_remove(struct hid_device *hdev)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  
@@ -259,7 +259,7 @@ index 4c22bd2ba170..e231393da178 100644
  	timer_delete_sync(&td->release_timer);
  
  	sysfs_remove_group(&hdev->dev.kobj, &mt_attribute_group);
-@@ -2328,6 +2419,11 @@ static const struct hid_device_id mt_devices[] = {
+@@ -2363,6 +2454,11 @@ static const struct hid_device_id mt_devices[] = {
  		MT_USB_DEVICE(USB_VENDOR_ID_XIROKU,
  			USB_DEVICE_ID_XIROKU_CSR2) },
  
@@ -274,7 +274,7 @@ index 4c22bd2ba170..e231393da178 100644
 -- 
 2.51.0
 
-From dd133146d7777b2793f31952b45dbcc9fd89e900 Mon Sep 17 00:00:00 2001
+From b4e3dfa79f33a0e59e7054ae764f2026f93a0113 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet
@@ -303,18 +303,18 @@ Patchset: surface-typecover
  1 file changed, 122 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index e231393da178..d9b80e1dd3c6 100644
+index 650df45e9f13..bb63fe858d87 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
-@@ -78,6 +78,7 @@ MODULE_LICENSE("GPL");
- #define MT_QUIRK_DISABLE_WAKEUP		BIT(21)
+@@ -79,6 +79,7 @@ MODULE_LICENSE("GPL");
  #define MT_QUIRK_ORIENTATION_INVERT	BIT(22)
- #define MT_QUIRK_HAS_TYPE_COVER_BACKLIGHT	BIT(23)
-+#define MT_QUIRK_HAS_TYPE_COVER_TABLET_MODE_SWITCH	BIT(24)
+ #define MT_QUIRK_APPLE_TOUCHBAR		BIT(23)
+ #define MT_QUIRK_HAS_TYPE_COVER_BACKLIGHT	BIT(24)
++#define MT_QUIRK_HAS_TYPE_COVER_TABLET_MODE_SWITCH	BIT(25)
  
  #define MT_INPUTMODE_TOUCHSCREEN	0x02
  #define MT_INPUTMODE_TOUCHPAD		0x03
-@@ -85,6 +86,8 @@ MODULE_LICENSE("GPL");
+@@ -86,6 +87,8 @@ MODULE_LICENSE("GPL");
  #define MT_BUTTONTYPE_CLICKPAD		0
  
  #define MS_TYPE_COVER_FEATURE_REPORT_USAGE	0xff050086
@@ -323,7 +323,7 @@ index e231393da178..d9b80e1dd3c6 100644
  
  enum latency_mode {
  	HID_LATENCY_NORMAL = 0,
-@@ -422,6 +425,7 @@ static const struct mt_class mt_classes[] = {
+@@ -423,6 +426,7 @@ static const struct mt_class mt_classes[] = {
  	},
  	{ .name = MT_CLS_WIN_8_MS_SURFACE_TYPE_COVER,
  		.quirks = MT_QUIRK_HAS_TYPE_COVER_BACKLIGHT |
@@ -331,7 +331,7 @@ index e231393da178..d9b80e1dd3c6 100644
  			MT_QUIRK_ALWAYS_VALID |
  			MT_QUIRK_IGNORE_DUPLICATES |
  			MT_QUIRK_HOVERING |
-@@ -1403,6 +1407,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+@@ -1438,6 +1442,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
  	    field->application != HID_CP_CONSUMER_CONTROL &&
  	    field->application != HID_GD_WIRELESS_RADIO_CTLS &&
  	    field->application != HID_GD_SYSTEM_MULTIAXIS &&
@@ -341,7 +341,7 @@ index e231393da178..d9b80e1dd3c6 100644
  	    !(field->application == HID_VD_ASUS_CUSTOM_MEDIA_KEYS &&
  	      application->quirks & MT_QUIRK_ASUS_CUSTOM_UP))
  		return -1;
-@@ -1430,6 +1437,21 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+@@ -1465,6 +1472,21 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
  		return 1;
  	}
  
@@ -363,7 +363,7 @@ index e231393da178..d9b80e1dd3c6 100644
  	if (rdata->is_mt_collection)
  		return mt_touch_input_mapping(hdev, hi, field, usage, bit, max,
  					      application);
-@@ -1451,6 +1473,7 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+@@ -1486,6 +1508,7 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  	struct mt_report_data *rdata;
@@ -371,7 +371,7 @@ index e231393da178..d9b80e1dd3c6 100644
  
  	rdata = mt_find_report_data(td, field->report);
  	if (rdata && rdata->is_mt_collection) {
-@@ -1458,6 +1481,19 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+@@ -1493,6 +1516,19 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
  		return -1;
  	}
  
@@ -391,7 +391,7 @@ index e231393da178..d9b80e1dd3c6 100644
  	/* let hid-core decide for the others */
  	return 0;
  }
-@@ -1467,11 +1503,21 @@ static int mt_event(struct hid_device *hid, struct hid_field *field,
+@@ -1502,11 +1538,21 @@ static int mt_event(struct hid_device *hid, struct hid_field *field,
  {
  	struct mt_device *td = hid_get_drvdata(hid);
  	struct mt_report_data *rdata;
@@ -413,7 +413,7 @@ index e231393da178..d9b80e1dd3c6 100644
  	return 0;
  }
  
-@@ -1654,6 +1700,42 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app)
+@@ -1689,6 +1735,42 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app)
  		app->quirks &= ~MT_QUIRK_CONTACT_CNT_ACCURATE;
  }
  
@@ -456,7 +456,7 @@ index e231393da178..d9b80e1dd3c6 100644
  static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
-@@ -1702,6 +1784,13 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
+@@ -1737,6 +1819,13 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
  		/* force BTN_STYLUS to allow tablet matching in udev */
  		__set_bit(BTN_STYLUS, hi->input->keybit);
  		break;
@@ -470,7 +470,7 @@ index e231393da178..d9b80e1dd3c6 100644
  	default:
  		suffix = "UNKNOWN";
  		break;
-@@ -1787,30 +1876,6 @@ static void mt_expired_timeout(struct timer_list *t)
+@@ -1822,30 +1911,6 @@ static void mt_expired_timeout(struct timer_list *t)
  	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
  }
  
@@ -501,7 +501,7 @@ index e231393da178..d9b80e1dd3c6 100644
  static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
  {
  	struct usb_device *udev = hid_to_usb_dev(hdev);
-@@ -1819,8 +1884,9 @@ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
+@@ -1854,8 +1919,9 @@ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
  	/* Wake up the device in case it's already suspended */
  	pm_runtime_get_sync(&udev->dev);
  
@@ -513,7 +513,7 @@ index e231393da178..d9b80e1dd3c6 100644
  		hid_err(hdev, "couldn't find backlight field\n");
  		goto out;
  	}
-@@ -1957,13 +2023,24 @@ static int mt_suspend(struct hid_device *hdev, pm_message_t state)
+@@ -1992,13 +2058,24 @@ static int mt_suspend(struct hid_device *hdev, pm_message_t state)
  
  static int mt_reset_resume(struct hid_device *hdev)
  {
@@ -538,7 +538,7 @@ index e231393da178..d9b80e1dd3c6 100644
  	/* Some Elan legacy devices require SET_IDLE to be set on resume.
  	 * It should be safe to send it to other devices too.
  	 * Tested on 3M, Stantum, Cypress, Zytronic, eGalax, and Elan panels. */
-@@ -1972,12 +2049,31 @@ static int mt_resume(struct hid_device *hdev)
+@@ -2007,12 +2084,31 @@ static int mt_resume(struct hid_device *hdev)
  
  	mt_set_modes(hdev, HID_LATENCY_NORMAL, TOUCHPAD_REPORT_ALL);
  

--- a/patches/6.16/0011-surface-shutdown.patch
+++ b/patches/6.16/0011-surface-shutdown.patch
@@ -1,7 +1,7 @@
 From 29accd39e3da7cc94b35a062853509f1de3d9e1d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod
+Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices
 (Surface Pro 9 and Surface Laptop 5) the EFI ResetSystem call with

--- a/patches/6.16/0011-surface-shutdown.patch
+++ b/patches/6.16/0011-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From 9653abf64529b1ac674213c039d3d1be04dd853d Mon Sep 17 00:00:00 2001
+From 29accd39e3da7cc94b35a062853509f1de3d9e1d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod

--- a/patches/6.16/0012-surface-gpe.patch
+++ b/patches/6.16/0012-surface-gpe.patch
@@ -1,4 +1,4 @@
-From 81c20c9fb321319c93fa3d89de5842c9916309df Mon Sep 17 00:00:00 2001
+From f0ec37bb5b3ce1f5d651c6c422b3a1451b73d158 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9

--- a/patches/6.16/0013-cameras.patch
+++ b/patches/6.16/0013-cameras.patch
@@ -1,4 +1,4 @@
-From 6d3b7898c2d4ca1e93bca6467377087e59b4fe6e Mon Sep 17 00:00:00 2001
+From cfe2852b5ec7fb20b7f0308a075680cbfeaf7705 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -74,7 +74,7 @@ index fb1fe9f3b1a3..5be8893b3912 100644
 -- 
 2.51.0
 
-From 963e4c165afc61c5faba46f8ca20c1d0b2932db7 Mon Sep 17 00:00:00 2001
+From cf577fc4e338d0c1d1fcae2fe865f2d918576da9 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -184,7 +184,7 @@ index 98def863f736..15af4773df7e 100644
 -- 
 2.51.0
 
-From a61ad0677bd36ec052487ab4cef6101d8138d6f1 Mon Sep 17 00:00:00 2001
+From 0c5ca0dd30fa269db29ec608313418e87de3740a Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -221,7 +221,7 @@ index 0133405697dc..9e0763bdc758 100644
 -- 
 2.51.0
 
-From 39e4ca443f7436678999b2e4c63fe6c7c79b821a Mon Sep 17 00:00:00 2001
+From 2f2889ce527f770d01a15fbbe60af475898d673b Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -260,7 +260,7 @@ index 3226888d77e9..3bfe45b764f7 100644
 -- 
 2.51.0
 
-From 67898bb4c736f5846c66fd7737154cdc0ba5e1cd Mon Sep 17 00:00:00 2001
+From 13b8a5bf77dba2eb32fba569c1c619d6a484dbbb Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -311,7 +311,7 @@ index cb153ce42c45..f11b499e14bb 100644
 -- 
 2.51.0
 
-From be89734907a8d9bc31e1ecb96680d7d1bb94150d Mon Sep 17 00:00:00 2001
+From 6a9f73420a018f4ee807b06a7aedaa5a3abdeecd Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -352,7 +352,7 @@ index 9e0763bdc758..0976b267972b 100644
 -- 
 2.51.0
 
-From acf6a36fee44848bea5ef5ab5394a42f37c5b9bf Mon Sep 17 00:00:00 2001
+From 0b974c7f54cf8e827bda14dc9b4e8830ab7e7b21 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -393,7 +393,7 @@ index 7807fa329db0..2d2abb25b944 100644
 -- 
 2.51.0
 
-From 51508796651e42174d2a1105159d66fa4e3ad809 Mon Sep 17 00:00:00 2001
+From 2b99d15b534e9c291557225dfc87b710cf97e026 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -644,7 +644,7 @@ index 000000000000..35aeb5db89c8
 -- 
 2.51.0
 
-From dae5c7687ff0f6becfb72b4144e54f7022e54c11 Mon Sep 17 00:00:00 2001
+From 7890a9f304c08fd53a218520e9f89a64c1c65c15 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2

--- a/patches/6.16/0014-amd-gpio.patch
+++ b/patches/6.16/0014-amd-gpio.patch
@@ -1,4 +1,4 @@
-From 05505e5575eb38c3dff121869c72c8c224063f9c Mon Sep 17 00:00:00 2001
+From 48d639e6d267d1c87265b284bb2a511d46d8b776 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -65,7 +65,7 @@ index 9fa321a95eb3..8914a922be2b 100644
 -- 
 2.51.0
 
-From 6df4d2ebe1e08d1907af8c90bb152843c465b3d9 Mon Sep 17 00:00:00 2001
+From 15fee80b2eed64de9f8a4bba533520476d7c9276 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override

--- a/patches/6.16/0015-rtc.patch
+++ b/patches/6.16/0015-rtc.patch
@@ -1,4 +1,4 @@
-From bc0020cb77950499ba8166abe4e0b08ebd1aeb21 Mon Sep 17 00:00:00 2001
+From 160e5f8ff4b9b34fea0cf2575939470cd5d8a63b Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms

--- a/patches/6.17/0011-surface-shutdown.patch
+++ b/patches/6.17/0011-surface-shutdown.patch
@@ -1,7 +1,7 @@
 From 269ce75e30d184b81b8b40bb0c1bee28abe95082 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod
+Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices
 (Surface Pro 9 and Surface Laptop 5) the EFI ResetSystem call with

--- a/patches/6.6/0010-surface-shutdown.patch
+++ b/patches/6.6/0010-surface-shutdown.patch
@@ -1,7 +1,7 @@
 From b57c1784927f0ef467efdee4cb2a026d7eea3c1c Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod
+Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices
 (Surface Pro 9 and Surface Laptop 5) the EFI ResetSystem call with

--- a/patches/6.9/0011-surface-shutdown.patch
+++ b/patches/6.9/0011-surface-shutdown.patch
@@ -1,7 +1,7 @@
 From 6ab472fbfe2677b038998f6482da35a7daf3c14d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
-Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod
+Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
 
 Work around buggy EFI firmware: On some Microsoft Surface devices
 (Surface Pro 9 and Surface Laptop 5) the EFI ResetSystem call with


### PR DESCRIPTION
Rebased onto v6.16.10 and resolved upstream conflict like done in the v6.17 `0010-surface-typecover.patch`:

https://github.com/linux-surface/linux-surface/blob/94217c2dc8818afd2296c3776223fc1c093f78fb/patches/6.17/0010-surface-typecover.patch#L103-L104

https://github.com/linux-surface/linux-surface/blob/94217c2dc8818afd2296c3776223fc1c093f78fb/patches/6.17/0010-surface-typecover.patch#L311-L313

Also fixed a typo in the surface-shutdown patch.