### PR TITLE
Add camera support for Surface Pro 9

### DIFF
--- a/patches/experimental/surface-pro9-camera-support.patch
+++ b/patches/experimental/surface-pro9-camera-support.patch
@@ -1,0 +1,333 @@
+--- a/drivers/media/i2c/ov5693.c
++++ b/drivers/media/i2c/ov5693.c
+@@ -1403,6 +1403,7 @@
+ 
+ static const struct acpi_device_id ov5693_acpi_match[] = {
+ 	{"INT33BE"},
++	{"OVTI5693"},
+ 	{},
+ };
+ MODULE_DEVICE_TABLE(acpi, ov5693_acpi_match);
+
+--- a/drivers/media/pci/intel/ipu-bridge.c
++++ b/drivers/media/pci/intel/ipu-bridge.c
+@@ -58,6 +58,10 @@
+ 	IPU_SENSOR_CONFIG("INT0310", 0),
+ 	/* Omnivision OV5693 */
+ 	IPU_SENSOR_CONFIG("INT33BE", 1, 419200000),
++	/* Omnivision OV5693 - Surface Pro 9 */
++	IPU_SENSOR_CONFIG("OVTI5693", 1, 419200000),
++	/* Omnivision OV13858 - Surface Pro 9 */
++	IPU_SENSOR_CONFIG("OVTID858", 4, 540000000),
+ 	/* Omnivision OV2740 */
+ 	IPU_SENSOR_CONFIG("INT3474", 1, 180000000),
+ 	/* Omnivision OV5670 */
+
+--- a/drivers/media/i2c/ov13858.c
++++ b/drivers/media/i2c/ov13858.c
+@@ -2,6 +2,8 @@
+ // Copyright (c) 2017 Intel Corporation.
+ 
+ #include <linux/acpi.h>
++#include <linux/delay.h>
++#include <linux/clk.h>
+ #include <linux/i2c.h>
+ #include <linux/module.h>
+ #include <linux/pm_runtime.h>
+@@ -118,6 +120,14 @@
+ 	struct ov13858_reg_list reg_list;
+ };
+ 
++// Or use standard names that might be more correct:
++static const char * const ov13858_supply_names[] = {
++	"avdd",    // Analog voltage
++	"pwr1",    // Digital core voltage  
++};
++
++#define OV13858_NUM_SUPPLIES ARRAY_SIZE(ov13858_supply_names)
++
+ /* 4224x3136 needs 1080Mbps/lane, 4 lanes */
+ static const struct ov13858_reg mipi_data_rate_1080mbps[] = {
+ 	/* PLL1 registers */
+@@ -1041,13 +1051,131 @@
+ 
+ 	/* Current mode */
+ 	const struct ov13858_mode *cur_mode;
+-
++	struct regulator_bulk_data supplies[OV13858_NUM_SUPPLIES];
++	struct gpio_desc *reset;
++	struct clk *xvclk;
+ 	/* Mutex for serialized access */
+ 	struct mutex mutex;
+ };
+ 
+ #define to_ov13858(_sd)	container_of(_sd, struct ov13858, sd)
+ 
++
++static int ov13858_get_regulators(struct ov13858 *ov13858)
++{
++	struct i2c_client *client = v4l2_get_subdevdata(&ov13858->sd);
++	unsigned int i;
++
++	for (i = 0; i < OV13858_NUM_SUPPLIES; i++)
++		ov13858->supplies[i].supply = ov13858_supply_names[i];
++
++	return devm_regulator_bulk_get(&client->dev, OV13858_NUM_SUPPLIES,
++				       ov13858->supplies);
++}
++
++static int ov13858_sensor_powerup(struct ov13858 *ov13858)
++{
++	struct i2c_client *client = v4l2_get_subdevdata(&ov13858->sd);
++	int ret;
++
++	dev_info(&client->dev, "Powering up sensor\n");
++
++	/* Assert reset */
++	gpiod_set_value_cansleep(ov13858->reset, 1);
++
++	/* Enable clock FIRST - sensor needs clock to communicate */
++	ret = clk_prepare_enable(ov13858->xvclk);
++	if (ret) {
++		dev_err(&client->dev, "Failed to enable clock: %d\n", ret);
++		return ret;
++	}
++	dev_info(&client->dev, "Clock enabled\n");
++
++	/* Enable regulators */
++	ret = regulator_bulk_enable(OV13858_NUM_SUPPLIES, ov13858->supplies);
++	if (ret) {
++		dev_err(&client->dev, "Failed to enable regulators: %d\n", ret);
++		clk_disable_unprepare(ov13858->xvclk);
++		return ret;
++	}
++
++	dev_info(&client->dev, "Regulators enabled\n");
++
++	/* Wait for power to stabilize */
++	usleep_range(5000, 10000);
++	
++	/* De-assert reset */
++	gpiod_set_value_cansleep(ov13858->reset, 0);
++	
++	/* Wait for sensor to boot */
++	msleep(20);
++	
++	dev_info(&client->dev, "Reset de-asserted, sensor should be ready\n");
++
++	return 0;
++}
++
++static void ov13858_sensor_powerdown(struct ov13858 *ov13858)
++{
++	struct i2c_client *client = v4l2_get_subdevdata(&ov13858->sd);
++
++	dev_info(&client->dev, "Powering down sensor\n");
++
++	/* Assert reset to put sensor in reset state */
++	gpiod_set_value_cansleep(ov13858->reset, 1);
++
++	/* Disable regulators */
++	regulator_bulk_disable(OV13858_NUM_SUPPLIES, ov13858->supplies);
++	dev_info(&client->dev, "Regulators disabled\n");
++
++	/* Disable clock */
++	clk_disable_unprepare(ov13858->xvclk);
++	dev_info(&client->dev, "Clock disabled\n");
++}
++
++static int __maybe_unused ov13858_suspend(struct device *dev)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct v4l2_subdev *sd = i2c_get_clientdata(client);
++	struct ov13858 *ov13858 = to_ov13858(sd);
++
++	ov13858_sensor_powerdown(ov13858);
++
++	return 0;
++}
++
++static int __maybe_unused ov13858_resume(struct device *dev)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct v4l2_subdev *sd = i2c_get_clientdata(client);
++	struct ov13858 *ov13858 = to_ov13858(sd);
++	int ret;
++
++	ret = ov13858_sensor_powerup(ov13858);
++	if (ret)
++		return ret;
++
++	return 0;
++}
++
++static const struct dev_pm_ops ov13858_pm_ops = {
++	SET_RUNTIME_PM_OPS(ov13858_suspend, ov13858_resume, NULL)
++};
++
++static int ov13858_get_gpios(struct ov13858 *ov13858)
++{
++	struct i2c_client *client = v4l2_get_subdevdata(&ov13858->sd);
++	
++	ov13858->reset = devm_gpiod_get_optional(&client->dev, "reset",
++	                                         GPIOD_OUT_HIGH);
++	if (IS_ERR(ov13858->reset)) {
++		dev_err(&client->dev, "Error fetching reset GPIO\n");
++		return PTR_ERR(ov13858->reset);
++	}
++	
++	return 0;
++}
++
+ /* Read registers up to 4 at a time */
+ static int ov13858_read_reg(struct ov13858 *ov13858, u16 reg, u32 len,
+ 			    u32 *val)
+@@ -1499,8 +1627,11 @@
+ 	int ret;
+ 	u32 val;
+ 
++	dev_info(&client->dev, "Attempting to read chip ID from register 0x300a\n");
+ 	ret = ov13858_read_reg(ov13858, OV13858_REG_CHIP_ID,
+ 			       OV13858_REG_VALUE_24BIT, &val);
++	dev_info(&client->dev, "Chip ID read result: ret=%d, val=0x%06x (expected 0x%06x)\n", 
++	         ret, val, OV13858_CHIP_ID);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -1509,7 +1640,7 @@
+ 			OV13858_CHIP_ID, val);
+ 		return -EIO;
+ 	}
+-
++	dev_info(&client->dev, "Chip ID verified successfully!\n");
+ 	return 0;
+ }
+ 
+@@ -1664,6 +1795,7 @@
+ 	u32 val = 0;
+ 
+ 	device_property_read_u32(&client->dev, "clock-frequency", &val);
++	dev_info(&client->dev, "Clock frequency read: %u (expected 19200000)\n", val);
+ 	if (val != 19200000)
+ 		return -EINVAL;
+ 
+@@ -1671,14 +1803,33 @@
+ 	if (!ov13858)
+ 		return -ENOMEM;
+ 
++	/* Get the external clock */
++	ov13858->xvclk = devm_clk_get_optional(&client->dev, "xvclk");
++	if (IS_ERR(ov13858->xvclk))
++		return dev_err_probe(&client->dev, PTR_ERR(ov13858->xvclk),
++		       "failed to get xvclk\n");
++
+ 	/* Initialize subdev */
+ 	v4l2_i2c_subdev_init(&ov13858->sd, client, &ov13858_subdev_ops);
+ 
++	ret = ov13858_get_regulators(ov13858);
++	if (ret)
++		return dev_err_probe(&client->dev, ret,
++		       "Error fetching regulators\n");
++
++	ret = ov13858_get_gpios(ov13858);
++	if (ret)
++		return ret;
++
++	ret = ov13858_sensor_powerup(ov13858);
++	if (ret)
++		return ret;  // No cleanup needed yet, devm handles GPIOs/regulators
++
+ 	/* Check module identity */
+ 	ret = ov13858_identify_module(ov13858);
+ 	if (ret) {
+ 		dev_err(&client->dev, "failed to find sensor: %d\n", ret);
+-		return ret;
++		goto error_power_off;  // Now we need to power down
+ 	}
+ 
+ 	/* Set default mode to max resolution */
+@@ -1686,7 +1837,7 @@
+ 
+ 	ret = ov13858_init_controls(ov13858);
+ 	if (ret)
+-		return ret;
++		goto error_power_off;
+ 
+ 	/* Initialize subdev */
+ 	ov13858->sd.internal_ops = &ov13858_internal_ops;
+@@ -1722,6 +1873,9 @@
+ 
+ error_handler_free:
+ 	ov13858_free_controls(ov13858);
++
++error_power_off:
++	ov13858_sensor_powerdown(ov13858);
+ 	dev_err(&client->dev, "%s failed:%d\n", __func__, ret);
+ 
+ 	return ret;
+@@ -1737,6 +1891,9 @@
+ 	ov13858_free_controls(ov13858);
+ 
+ 	pm_runtime_disable(&client->dev);
++	if (!pm_runtime_status_suspended(&client->dev))
++		ov13858_sensor_powerdown(ov13858);
++	pm_runtime_set_suspended(&client->dev);
+ }
+ 
+ static const struct i2c_device_id ov13858_id_table[] = {
+@@ -1758,6 +1915,7 @@
+ static struct i2c_driver ov13858_i2c_driver = {
+ 	.driver = {
+ 		.name = "ov13858",
++		.pm = &ov13858_pm_ops,
+ 		.acpi_match_table = ACPI_PTR(ov13858_acpi_ids),
+ 	},
+ 	.probe = ov13858_probe,
+
+--- a/drivers/platform/x86/intel/int3472/discrete.c
++++ b/drivers/platform/x86/intel/int3472/discrete.c
+@@ -205,6 +205,14 @@
+ 		*con_id = "dvdd";
+ 		*gpio_flags = GPIO_ACTIVE_HIGH;
+ 		break;
++	case 0x08:  /* Surface Pro 9 - additional power rail */
++		*con_id = "pwr1";
++		*gpio_flags = GPIO_ACTIVE_HIGH;
++		break;
++	case 0x10:  /* Surface Pro 9 - secondary power rail */
++		*con_id = "pwr2";
++		*gpio_flags = GPIO_ACTIVE_HIGH;
++		break;
+ 	default:
+ 		*con_id = "unknown";
+ 		*gpio_flags = GPIO_ACTIVE_HIGH;
+@@ -307,6 +315,8 @@
+ 	case INT3472_GPIO_TYPE_PRIVACY_LED:
+ 	case INT3472_GPIO_TYPE_POWER_ENABLE:
+ 	case INT3472_GPIO_TYPE_HANDSHAKE:
++	case 0x08:  /* Surface Pro 9 power rails */
++	case 0x10:
+ 		gpio = skl_int3472_gpiod_get_from_temp_lookup(int3472, agpio, con_id, gpio_flags);
+ 		if (IS_ERR(gpio)) {
+ 			ret = PTR_ERR(gpio);
+@@ -345,6 +355,19 @@
+ 				err_msg = "Failed to map handshake to sensor\n";
+ 
+ 			break;
++		case 0x08:  /* Surface Pro 9 - treat as power*/
++		    dev_info(int3472->dev, "GPIO type 0x%02x detected on pin 0x%02x\n", type, agpio->pin_table[0]);
++		    dev_info(int3472->dev, "  con_id=%s, flags=0x%x\n", con_id, gpio_flags); 
++		    ret = skl_int3472_register_regulator(int3472, gpio,
++			 GPIO_REGULATOR_ENABLE_TIME,
++			 con_id, NULL); 
++		    dev_info(int3472->dev, "  register_regulator returned: %d\n", ret);		   
++		    if (ret) {
++			dev_err(int3472->dev, "Failed to register type 0x02x: %d\n", type, ret);
++		    }
++		    break;
++		case 0x10: 
++		    break;
+ 		default: /* Never reached */
+ 			ret = -EINVAL;
+ 			break;
+


### PR DESCRIPTION
I don't feel like the changes I've made are robust enough to be added to the kernel repo or even be merged in this repo for that matter. So this is just to start a thread with my patch so that the community can test and complete what I've done.

There are a ton of quirks that I cannot fully explain so here goes what I did:

1. `ov5693.c`: I just needed to add `OVTI5693` ACPI ID to make it bind properly!

2. `ov13858.c`: I have no idea why, but this code basically did none of the important things. I'm not experienced enough to know if this was intentional or just incomplete code. So I added regulators "avdd" and `pwr1`, which is my best guess for the type 0x08, as the only thing that worked was when that pin was treated as a regulator pin. The name, of course, is made up by me. By looking at other driver codes, I added callbacks for suspend and resume to hopefully not waste energy. I'm not sure if that goal was achieved, but it seems to work. I also added code for GPIO reset control and external clock (xvclk) management.

3. `discrete.c (INT3472)`: Oh this one was a weird one. For some reason, unrecognized GPIO types would make the entire thing fail. I have no idea what 0x10 is supposed to be, but I just ended up skipping it instead of failing. As for 0x08, as mentioned before, I named it "pwr1" and treated it just like a regulator.

4. `ipu-bridge.c`: I added OVTI5693 (front camera): 1 lane, 419.2 MHz link frequency and OVTID858 (rear camera): 4 lanes, 540 MHz link frequency. Honestly, the 4 x 540 MHz was a combination of guessing and looking at ov13858. Worked on my first try, so I didn't think twice about it. (I also skimmed through a weird 140-page document I found on the internet about the sensor)

And now it's time for the weird stuff!

At first, I added udev rules that would do the equivalent of these commands:
```
echo on | sudo tee /sys/bus/i2c/devices/i2c-OVTI5693:00/power/control
echo on | sudo tee /sys/bus/i2c/devices/i2c-OVTID858:00/power/control
```
When I did that, things would "work" but everything would look greenish! So I removed that rule and figured I'd run these commands manually, but surprise surprise, the privacy LED would turn on but nothing, just a black screen!! I had no idea what to do at that point, so I just echoed "auto" and a couple of "on"s back to back, and it started working. Once it started to work, it would just reliably work every time. I know, it's weird!

I would love to keep working on this until it's ready to use, but I'm a PhD candidate with very limited time. If someone's interested in picking up the rest of the work, I would happily provide all the information I have! I did mention this in an issue, but dumping ACPI tables and decompiling them proved to be invaluable.

Cheers everyone!

P.S.
These are a couple of notes about my machine and the commands I ran:
```
uname -r
6.16.9-1.surface.fc42.x86_64
```
```
gst-launch-1.0 libcamerasrc  ! videoflip method=rotate-180 ! videoconvert ! autovideosink
# Oh yeah, the feed is upside down, hence the flip!
```