### PR TITLE
Update patches for 6.12 LTS kernel

### DIFF
--- a/patches/6.12/0012-cameras.patch
+++ b/patches/6.12/0012-cameras.patch
@@ -247,7 +247,7 @@ index 3de463c3d13b..0a012eeed30a 100644
 --- a/drivers/platform/x86/intel/int3472/discrete.c
 +++ b/drivers/platform/x86/intel/int3472/discrete.c
 @@ -80,12 +80,27 @@ static int skl_int3472_map_gpio_to_sensor(struct int3472_discrete_device *int347
- 					  const char *func, u32 polarity)
+ 					  const char *func, unsigned long gpio_flags)
  {
  	int ret;
 +	const struct acpi_device_id ov7251_ids[] = {
@@ -268,7 +268,7 @@ index 3de463c3d13b..0a012eeed30a 100644
 +	 */
 +	if (!strcmp(func, "reset") && !acpi_match_device_ids(int3472->sensor, ov7251_ids)) {
 +		func = "enable";
-+		polarity ^= GPIO_ACTIVE_LOW;
++		gpio_flags ^= GPIO_ACTIVE_LOW;
 +	}
 +
  	ret = skl_int3472_fill_gpiod_lookup(&int3472->gpios.table[int3472->n_sensor_gpios],


### PR DESCRIPTION
I successfully compiled and booted 6.12.57 with surface patches, but it needed a tweak to the cameras patch.