### PR TITLE
Update build for v6.18.3-arch1 and update checksums

### DIFF
--- a/pkg/arch/kernel/PKGBUILD
+++ b/pkg/arch/kernel/PKGBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Jan Alexander Steffens (heftig) <jan.steffens@gmail.com>
 
 pkgbase=linux-surface
-pkgver=6.18.2.arch2
+pkgver=6.18.3.arch1
 pkgrel=1
 pkgdesc='Linux'
 _shortver=${pkgver%.*}
@@ -64,7 +64,7 @@ validpgpkeys=(
   '647F28654894E3BD457199BE38DBBDC86092693E'  # Greg Kroah-Hartman
   'A2FF3A36AAA56654109064AB19802F8B0D70FC30'  # Jan Alexander Steffens (heftig)
 )
-sha256sums=('63794d6bd1c8f2ca7a023ce333e3a26c423637dd0fdefe612e2950e6604190b6'
+sha256sums=('b5af77758935f761ee42b9aa407809bb1dc5fd15ee379a73f66e14c7dca75300'
             'd0ce1ee11ca0bc6a817c3c17a2651076409bd9fd6c0ab9e744aae2131ab654ce'
             '233a1c4d898b7720dd623421b694cc030075317b01cba6444b53faefc7b2ca55'
             '008e37de7e6cf8b9479ef0f0f425a25092646e85d741aedd056e5ff3e1096361'


### PR DESCRIPTION
Updated the build package to build arch v6.18.3-arch1. I'm not sure how adamant we are about minor kernel releases, but I have it built and have been using it with no issues on my Surface Laptop Studio 2. No merge conflicts on patches to resolve.