### PR TITLE
patches/v6.18: Automatic update to v6.18.5

### DIFF
--- a/patches/6.18/0001-secureboot.patch
+++ b/patches/6.18/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From b0e0398f4f468ece3c20371fe1c7d12d5b168140 Mon Sep 17 00:00:00 2001
+From 1bbb1f037b8827971c5a6ef902e0b46a560bb49f Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -35,7 +35,7 @@ index 9bea5a1e2..25848f886 100644
 -- 
 2.52.0
 
-From 9b9d346c25feaab026a21b9e430d42c9dbc70215 Mon Sep 17 00:00:00 2001
+From d12ba6f313df27a23dfbedd33eb27a66e54433d3 Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter

--- a/patches/6.18/0002-surface3.patch
+++ b/patches/6.18/0002-surface3.patch
@@ -1,4 +1,4 @@
-From 87c2e72e7547137bd0a22818208c26640526c59f Mon Sep 17 00:00:00 2001
+From 41fd825cc8e72c3aeb75477c51113e7e6922a47b Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI
@@ -99,7 +99,7 @@ index e4c3492a0..0b930c91b 100644
 -- 
 2.52.0
 
-From 2b85458ab9beb7f81618c5a71e4446be86850d89 Mon Sep 17 00:00:00 2001
+From 5377c5f58271e97b209e0e0cbdc5130fae0181c4 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
 Subject: [PATCH] surface3-spi: workaround: disable DMA mode to avoid crash by

--- a/patches/6.18/0003-mwifiex.patch
+++ b/patches/6.18/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From a10a3d9a31c5fdd5748f796dd02787bbdcc219ac Mon Sep 17 00:00:00 2001
+From 30529332e1f6cc038e52456946a4d8b20864bc7d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -165,7 +165,7 @@ index d6ff964ae..5d30ae39d 100644
 -- 
 2.52.0
 
-From 3f5365b05fcaa1e9a01ddbd1b4fbfb3cf13ed6b8 Mon Sep 17 00:00:00 2001
+From 87a78acab5967185d744bc20b50b817347ace0c4 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -320,7 +320,7 @@ index 5d30ae39d..c14eb56eb 100644
 -- 
 2.52.0
 
-From ac70d7580b1d368d2a2174ad7c9165fdd2cf37de Mon Sep 17 00:00:00 2001
+From 5688a8233080b57b7d7f2fe5ce8d9abc04f4c9da Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell

--- a/patches/6.18/0004-ath10k.patch
+++ b/patches/6.18/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From b7fa0d87576307a4525d8f047e8efacab66df2ca Mon Sep 17 00:00:00 2001
+From 7f620f005272c98c82d2e1ea77a5442e99977b97 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files

--- a/patches/6.18/0005-ipts.patch
+++ b/patches/6.18/0005-ipts.patch
@@ -1,4 +1,4 @@
-From 22c4f1b753aa6f381bc367bf16f4bed0b8187386 Mon Sep 17 00:00:00 2001
+From 3a23613571db186f35b71c30798c57cb41bd592d Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -37,7 +37,7 @@ index 73cad914b..807e352af 100644
 -- 
 2.52.0
 
-From 34ac5358779ab71f9ee1c0d831842473a0579231 Mon Sep 17 00:00:00 2001
+From 9ea1d8c6cb18eb013c94a91eb10984693a0e5d23 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -144,7 +144,7 @@ index e236c7ec2..9e31a5fe1 100644
 -- 
 2.52.0
 
-From 7a787a4d3d3173955c241673f365333a71748949 Mon Sep 17 00:00:00 2001
+From af0f6a541e284ab2f46077facc08fbb8bfb40fd2 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus

--- a/patches/6.18/0006-ithc.patch
+++ b/patches/6.18/0006-ithc.patch
@@ -1,4 +1,4 @@
-From ccbd80a1526b82e7f76cc1808775ed952fce90f1 Mon Sep 17 00:00:00 2001
+From 7c8c6138ea744eb959eeea1f698b0742696a1a57 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -39,7 +39,7 @@ index 8bcbfe3d9..c78806d35 100644
 -- 
 2.52.0
 
-From 3e9189b92d72fc0859c39687794f55b36e270c6c Mon Sep 17 00:00:00 2001
+From 1cf2aa6e51cc654c0fb29b8ce3619ae55d1a0d99 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller

--- a/patches/6.18/0007-surface-sam.patch
+++ b/patches/6.18/0007-surface-sam.patch
@@ -1,4 +1,4 @@
-From 341b34d9fbf0bf7351f2dc481a2acf5e5076829b Mon Sep 17 00:00:00 2001
+From c31d2f6813605ca6957ece3a190ff8c5e6a38949 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
 Subject: [PATCH] rtc: Add basic support for RTC via Surface System Aggregator
@@ -181,7 +181,7 @@ index 000000000..f6c17c4e9
 -- 
 2.52.0
 
-From 2971c838857dcd170848a1f655b06a26f2b3541f Mon Sep 17 00:00:00 2001
+From e6a3cef76cf1b9bfbf517d38fbb4078d9594cfe7 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
 Subject: [PATCH] platform/surface: aggregator_registry: Add Surface Laptop 7

--- a/patches/6.18/0008-surface-sam-over-hid.patch
+++ b/patches/6.18/0008-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From 7ecd3735e92ad10f072ea5755e30aa70f1de04fb Mon Sep 17 00:00:00 2001
+From d3664722e4011fff0ad8c6587c57295bd05643f8 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -109,7 +109,7 @@ index ed90858a2..070c36637 100644
 -- 
 2.52.0
 
-From 497dd96a69fac182bc2f1dc110ec32789839deee Mon Sep 17 00:00:00 2001
+From 543bca549766be688af3e8cd8739059e4b7d66d1 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch

--- a/patches/6.18/0009-surface-button.patch
+++ b/patches/6.18/0009-surface-button.patch
@@ -1,4 +1,4 @@
-From 66db0bcac62218421b6ed1662f2688933dab48f4 Mon Sep 17 00:00:00 2001
+From 4a861d096e575cb4276772501b4ba31b1be2c068 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -75,7 +75,7 @@ index b8cad415c..43b5d5638 100644
 -- 
 2.52.0
 
-From b051f52f5fe5748b4877f73b81f91d38a5033c1c Mon Sep 17 00:00:00 2001
+From 06f3f9d53e6776f02c4d32d739ae89c82b24431c Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd

--- a/patches/6.18/0010-surface-typecover.patch
+++ b/patches/6.18/0010-surface-typecover.patch
@@ -1,4 +1,4 @@
-From 8e7a306e02f3631bb15804dcacc372dc4ee28406 Mon Sep 17 00:00:00 2001
+From 259aa8c7eb475ec80810a57f052226a33cb5141d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -39,7 +39,7 @@ index 47f589c41..6b00aec67 100644
 -- 
 2.52.0
 
-From 8b8670b3421cb324331011f714df157ec658844a Mon Sep 17 00:00:00 2001
+From afd6c78a0e6bca37e5df34c630b7b26665da1d87 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -274,7 +274,7 @@ index 179dc316b..7d644e1c4 100644
 -- 
 2.52.0
 
-From 3bb9c674792795fe54da7901bfc638daffdf9446 Mon Sep 17 00:00:00 2001
+From a76c1b739d57247de62b3cfd28f0524dac280292 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet

--- a/patches/6.18/0011-surface-shutdown.patch
+++ b/patches/6.18/0011-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From bab8498e8af2474d85f8a6c3f8396dbf9dbf8d2e Mon Sep 17 00:00:00 2001
+From 7a544468a6af1e5660f7ab6151e3ad676ebfec74 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
@@ -95,7 +95,7 @@ index bf97d49c2..90eead93d 100644
 -- 
 2.52.0
 
-From 1afc88118fa7014d5d6ef99c48d14468393ad422 Mon Sep 17 00:00:00 2001
+From d432ea18a56ef2f8ddcc29bbe8b9c91014138e9c Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Wed, 7 Jan 2026 01:06:25 +0100
 Subject: [PATCH] PCI: Add Surface Laptop Studio 2 devices to shutdown ops

--- a/patches/6.18/0012-surface-gpe.patch
+++ b/patches/6.18/0012-surface-gpe.patch
@@ -1,4 +1,4 @@
-From cec5167e48fe6afb38dd75cf6f0f700566313267 Mon Sep 17 00:00:00 2001
+From dba267593ba95bf9c1597a856e7b4444857597ab Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9

--- a/patches/6.18/0013-cameras.patch
+++ b/patches/6.18/0013-cameras.patch
@@ -1,4 +1,4 @@
-From 1b27298c89877c41dbcc314443d75fe910e22853 Mon Sep 17 00:00:00 2001
+From e75f2d73aa53f48967aab634634395a2a2613a62 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -74,7 +74,7 @@ index ef16d58b2..a6bad2679 100644
 -- 
 2.52.0
 
-From 877aeb2d25ada1c118875cfdb3729693f35c5ff4 Mon Sep 17 00:00:00 2001
+From 495a72e2b98c75b52ba61d37b59bfa9831a5022b Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -184,7 +184,7 @@ index 9e31a5fe1..bdd32551c 100644
 -- 
 2.52.0
 
-From 3234b69803a65f71309184b4c041e35f3d23eaf9 Mon Sep 17 00:00:00 2001
+From cd0bb895ba436a10646eb72ed15f981e693ef09a Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -221,7 +221,7 @@ index 013340569..9e0763bdc 100644
 -- 
 2.52.0
 
-From a3471b5fa576339b79789e4894511d8577034ae8 Mon Sep 17 00:00:00 2001
+From 75a3d5630b9a965cb48ecf09d0b0d9be9c3e2100 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -260,7 +260,7 @@ index 27afc3fc0..28b192c9a 100644
 -- 
 2.52.0
 
-From f1cd3e354b93cf64d376d05bbd8eaf6dc5ba599c Mon Sep 17 00:00:00 2001
+From a2e0668c55f529d0abe95cf822bd4b86222f81bb Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -311,7 +311,7 @@ index cb153ce42..f11b499e1 100644
 -- 
 2.52.0
 
-From 88ec91cbb62af9a1f6e832513e7bd0ed3a58f8b1 Mon Sep 17 00:00:00 2001
+From 98bb0310011338a2ab70d7536952ab1caf35e6a4 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -352,7 +352,7 @@ index 9e0763bdc..0976b2679 100644
 -- 
 2.52.0
 
-From d43b113bcfde39b2f34cafc35cee360990264e0f Mon Sep 17 00:00:00 2001
+From 534f5cb94af7f067f24c0a204e98b7d9a513cd45 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -393,7 +393,7 @@ index 7807fa329..2d2abb25b 100644
 -- 
 2.52.0
 
-From 15375784ea12d3765570207775b8f1a937d34cdb Mon Sep 17 00:00:00 2001
+From 2094bfb94b193ec8f975f0d602aeef444d8880da Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -644,7 +644,7 @@ index 000000000..35aeb5db8
 -- 
 2.52.0
 
-From 1353085e2af88492f9cd453d0550845e0b90fee3 Mon Sep 17 00:00:00 2001
+From eba864a5f58712f7a6ce3555484092485637938a Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2
@@ -676,7 +676,7 @@ index 032fbcb98..e03a1d8cd 100644
 -- 
 2.52.0
 
-From ef9a9b266336018293d7ab8e38bdaf9508ef0140 Mon Sep 17 00:00:00 2001
+From f25ebe5b31578d2a4d4e66c3817ce4e0c9f412b8 Mon Sep 17 00:00:00 2001
 From: Tooraj Taraz <tooraj.taraz@yahoo.com>
 Date: Wed, 31 Dec 2025 00:35:50 +0100
 Subject: [PATCH] Add camera support for Surface Pro 9

--- a/patches/6.18/0014-amd-gpio.patch
+++ b/patches/6.18/0014-amd-gpio.patch
@@ -1,4 +1,4 @@
-From 363fb65941b1a0be6e96ea2c99bcf867591ee636 Mon Sep 17 00:00:00 2001
+From db3ec9540d493a473491fca1391969ad00212db8 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -65,7 +65,7 @@ index 9fa321a95..8914a922b 100644
 -- 
 2.52.0
 
-From ce356231516a26fcd77d47d9ee5582eeb70dc580 Mon Sep 17 00:00:00 2001
+From f2dcd89f3807295c28eb8248140735dca8b4a9d5 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override

--- a/patches/6.18/0015-rtc.patch
+++ b/patches/6.18/0015-rtc.patch
@@ -1,4 +1,4 @@
-From 912222e4789bae13a9bb59ebc0da8dd22b8f9aa4 Mon Sep 17 00:00:00 2001
+From 0dfdb22b626f288d56d9a41530ccdfb84a8baa47 Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms

--- a/patches/6.18/0016-hid-surface.patch
+++ b/patches/6.18/0016-hid-surface.patch
@@ -1,4 +1,4 @@
-From de8b880277239e1670a9206a62b8460254f78ef5 Mon Sep 17 00:00:00 2001
+From ddec4ff683bbbb1e92e4fa30adcefe93b38c2cb0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ciar=C3=A1n=20Coffey?= <github@ccoffey.ie>
 Date: Fri, 10 Oct 2025 19:04:03 +0100
 Subject: [PATCH] HID: Add hid-surface driver to filter BTN_0 (FN key)
@@ -156,7 +156,7 @@ index 000000000..a171ea656
 -- 
 2.52.0
 
-From 659b9c8cfffb64b9cbea819cb82ce221b8c18ec2 Mon Sep 17 00:00:00 2001
+From 16174508fdd5cdfaebb39bc5c1747c09679b7a70 Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Wed, 24 Dec 2025 00:54:44 -0800
 Subject: [PATCH] hid/multitouch: Prevent mode set on Surface Laptop Studio 2


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.18** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.18-surface`
- **Base version**: `v6.18.5`
- **Patches generated**: 16
- **Patches directory**: `patches/6.18/`

### Changes
This PR updates kernel patches to the latest version from the `v6.18-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.18-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.