### PR TITLE
patches/v6.12: Automatic update to v6.12.66

### DIFF
--- a/patches/6.12/0001-secureboot.patch
+++ b/patches/6.12/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From 63f1542405be6514cdb9504112379c22b748231c Mon Sep 17 00:00:00 2001
+From a2423a437bfdf0ed5dbfefb5027c6e540bc3468d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -35,7 +35,7 @@ index b5c79f433..a1bbedd98 100644
 -- 
 2.52.0
 
-From f8e1a06586181686a9ff1df26ac291134759d9cb Mon Sep 17 00:00:00 2001
+From 7d5bbf942248ee27275160eb50d7e4e08a61b8f9 Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter

--- a/patches/6.12/0002-surface3-oemb.patch
+++ b/patches/6.12/0002-surface3-oemb.patch
@@ -1,4 +1,4 @@
-From 5977a8fea25fd09161c5904e33ff90c9f0c36100 Mon Sep 17 00:00:00 2001
+From e99a1260bbafbbcddeff9b777bab48ff3e7e76cf Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI

--- a/patches/6.12/0003-mwifiex.patch
+++ b/patches/6.12/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From 1106cc5afb2f7db4ca9dc6359952766226a2fe67 Mon Sep 17 00:00:00 2001
+From b55306ce435ea996e721221e07643ac8d3f3d0ec Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -165,7 +165,7 @@ index d6ff964ae..5d30ae39d 100644
 -- 
 2.52.0
 
-From edf9836d0f1d0eea5c98fd1e6de91da2c22472ad Mon Sep 17 00:00:00 2001
+From e2ec0841f3e94259534b0de6b4ac39d3d81653de Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -320,7 +320,7 @@ index 5d30ae39d..c14eb56eb 100644
 -- 
 2.52.0
 
-From 8f4b822de3c6817607f9c893d541fff7328ea1e4 Mon Sep 17 00:00:00 2001
+From 0a1ec5d7d9cd96cdb37402925d0b4e6610e66fc9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell

--- a/patches/6.12/0004-ath10k.patch
+++ b/patches/6.12/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From 23f0f61a46dc4a43f753a9ed38b27181e6d90510 Mon Sep 17 00:00:00 2001
+From 94abd2f89ef12048add8754aa23ab20ebc441687 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files

--- a/patches/6.12/0005-ipts.patch
+++ b/patches/6.12/0005-ipts.patch
@@ -1,4 +1,4 @@
-From fef08eee7169b1c1d65252985b201c83c07df382 Mon Sep 17 00:00:00 2001
+From 5a3a551bb17fe87de8d726adf5a299c862852ca8 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -11,7 +11,7 @@ Patchset: ipts
  2 files changed, 2 insertions(+)
 
 diff --git a/drivers/misc/mei/hw-me-regs.h b/drivers/misc/mei/hw-me-regs.h
-index a4f75dc36..e4a561b25 100644
+index fa30899a5..a1864dcb7 100644
 --- a/drivers/misc/mei/hw-me-regs.h
 +++ b/drivers/misc/mei/hw-me-regs.h
 @@ -92,6 +92,7 @@
@@ -23,7 +23,7 @@ index a4f75dc36..e4a561b25 100644
  
  #define MEI_DEV_ID_JSP_N      0x4DE0  /* Jasper Lake Point N */
 diff --git a/drivers/misc/mei/pci-me.c b/drivers/misc/mei/pci-me.c
-index bc0fc584a..51a91ef66 100644
+index 1e4edf896..61d1a8816 100644
 --- a/drivers/misc/mei/pci-me.c
 +++ b/drivers/misc/mei/pci-me.c
 @@ -97,6 +97,7 @@ static const struct pci_device_id mei_me_pci_tbl[] = {
@@ -37,7 +37,7 @@ index bc0fc584a..51a91ef66 100644
 -- 
 2.52.0
 
-From c0f4c7831822a7c7376dd159758420b1dd99f7a8 Mon Sep 17 00:00:00 2001
+From b5509f0f29c6d2965cf87b2817e0ea1b3770153d Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -144,7 +144,7 @@ index c799cc67d..65adfc813 100644
 -- 
 2.52.0
 
-From d924a0bfa4e787757f42c2011c7c8beaae1ee359 Mon Sep 17 00:00:00 2001
+From ffc2c79b83a3ef1aa12a12023d82f01369f98e35 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus

--- a/patches/6.12/0006-ithc.patch
+++ b/patches/6.12/0006-ithc.patch
@@ -1,4 +1,4 @@
-From fc5fa3bf68958afa207d59d442b42623173fe711 Mon Sep 17 00:00:00 2001
+From 2dec3490991faec7329071fb1da84fbb66ea6c33 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -39,7 +39,7 @@ index 066e4cd6e..7b320d09d 100644
 -- 
 2.52.0
 
-From 3bd90d4e30ceeec7281e1781b35b783109736019 Mon Sep 17 00:00:00 2001
+From e391a07dc54b637bb96565766da220263b620411 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller

--- a/patches/6.12/0007-surface-sam-over-hid.patch
+++ b/patches/6.12/0007-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From 9426284cef0fca02f23a75b33dc8ed39e116e3d1 Mon Sep 17 00:00:00 2001
+From aba6ab6b04bec689fd73f2bea505b58238d46f3d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -109,7 +109,7 @@ index f43067f67..1761ca30e 100644
 -- 
 2.52.0
 
-From 1eb7e55a8b1cca487474bc5b6efabfd20f1ff2ae Mon Sep 17 00:00:00 2001
+From a4dbbeb93034e310ddb73c4d1a8f5281eb3cb415 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch

--- a/patches/6.12/0008-surface-button.patch
+++ b/patches/6.12/0008-surface-button.patch
@@ -1,4 +1,4 @@
-From 72ac1d1bb27f99dca1df5b73062e02178e6c132a Mon Sep 17 00:00:00 2001
+From aafcec22ad9776d4448f09223fd26c826ab4406c Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -75,7 +75,7 @@ index 5c5d407fe..4e1bfe90e 100644
 -- 
 2.52.0
 
-From 5c8a82f4b432a636005e19f1991185ed9eb1a8df Mon Sep 17 00:00:00 2001
+From 99238a763d217e20c12894ecd13b453151e6eb07 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd

--- a/patches/6.12/0009-surface-typecover.patch
+++ b/patches/6.12/0009-surface-typecover.patch
@@ -1,4 +1,4 @@
-From ecb1c88302dacba1813b7e6b482920bd3ba9bbc3 Mon Sep 17 00:00:00 2001
+From fab95626dba115cb07de7d7fa797bffbb5f80c64 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -39,7 +39,7 @@ index c322d0c1d..52ae06afd 100644
 -- 
 2.52.0
 
-From 2b744e2b904c695736bde325efe573af78077088 Mon Sep 17 00:00:00 2001
+From 1fda0cc37076dac0a11ce1a6c460f203b19e1a91 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -274,7 +274,7 @@ index 0e4cb0e66..26b551523 100644
 -- 
 2.52.0
 
-From 05afdfa6c585bdffd6f35c470da129373fee45fb Mon Sep 17 00:00:00 2001
+From 12804521a6c821c27ab2bd8ac889ec68cda7a726 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet

--- a/patches/6.12/0010-surface-shutdown.patch
+++ b/patches/6.12/0010-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From e8e8f9dcf8a6d2981c196c3fdbe193a69b130d56 Mon Sep 17 00:00:00 2001
+From d765ff7ceea05518a0efa2339d996bbd40ba1560 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod

--- a/patches/6.12/0011-surface-gpe.patch
+++ b/patches/6.12/0011-surface-gpe.patch
@@ -1,4 +1,4 @@
-From e321c203143de27d3bf7b4feb60ffa8f5db0d3bf Mon Sep 17 00:00:00 2001
+From 88132a4c037665666f6d9e0f4cb04692e173f1ac Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9

--- a/patches/6.12/0012-cameras.patch
+++ b/patches/6.12/0012-cameras.patch
@@ -1,4 +1,4 @@
-From 908376ffdfb35e8a7fc0b0741168f6981306b7e3 Mon Sep 17 00:00:00 2001
+From 025283349ce42174ae2991d156fd187c84bcc821 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -74,7 +74,7 @@ index ba98763ce..6021907ec 100644
 -- 
 2.52.0
 
-From b50fa0e9a3d0a92ebe1845f4ae92798a9b602f27 Mon Sep 17 00:00:00 2001
+From 1cb705d86eab6e25171d9f934d4fc559a6fc1e9c Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -184,7 +184,7 @@ index 65adfc813..3dcabd6c5 100644
 -- 
 2.52.0
 
-From 04808bcd8b873245f8878c5cb6a243f6a54a1c9b Mon Sep 17 00:00:00 2001
+From 7465075410aafe1c2e056837b892d6088fd7a23c Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -221,7 +221,7 @@ index 81ac4c691..f453c9043 100644
 -- 
 2.52.0
 
-From 04d6cc0a730b23707e9eccc4a1e269ba027dc74b Mon Sep 17 00:00:00 2001
+From fed9d310d3c03130ed6db3a7785a3c1a9da7b109 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Thu, 2 Mar 2023 12:59:39 +0000
 Subject: [PATCH] platform/x86: int3472: Remap reset GPIO for INT347E
@@ -277,7 +277,7 @@ index 9e69ac9cf..d6003198a 100644
 -- 
 2.52.0
 
-From c561d9d986e0ec9972c93505d07754e700d83a62 Mon Sep 17 00:00:00 2001
+From 6b156036bf2fa490510465025d3368997eda6d6d Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -316,7 +316,7 @@ index 3226888d7..3bfe45b76 100644
 -- 
 2.52.0
 
-From 239cb784959f9c6751edcb8e30246f6e6947a3ac Mon Sep 17 00:00:00 2001
+From b46667943978af7b971a927b1b9bef2302a4d231 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -367,7 +367,7 @@ index f19c8adf2..923ed1b5a 100644
 -- 
 2.52.0
 
-From c39a94ea4950d143cae4d8b8683017a89fc3377f Mon Sep 17 00:00:00 2001
+From 9dbe43576efe56749b172fb001f0ba09394a58d4 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -408,7 +408,7 @@ index f453c9043..b8ad6b413 100644
 -- 
 2.52.0
 
-From 738ebac2df91aa10961af97aac1a9f0c339a5a19 Mon Sep 17 00:00:00 2001
+From 4e92c03760b866eeea7d13af3f8964c15682f468 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -449,7 +449,7 @@ index 7807fa329..2d2abb25b 100644
 -- 
 2.52.0
 
-From cd994d28d4edebc119ba0832c0e03995e53a1c95 Mon Sep 17 00:00:00 2001
+From 957b635554899ebc3c9777b205ca1dea8fd11799 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -700,7 +700,7 @@ index 000000000..35aeb5db8
 -- 
 2.52.0
 
-From 1c3470f95886ee86781fa164a70ecc5f0b51dfa2 Mon Sep 17 00:00:00 2001
+From 40ce1bffe21b3945e0db8c93fe0420370e011c2d Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2

--- a/patches/6.12/0013-amd-gpio.patch
+++ b/patches/6.12/0013-amd-gpio.patch
@@ -1,4 +1,4 @@
-From 4f72a8fba6496c49f0205e21772c7781f5f2e6d0 Mon Sep 17 00:00:00 2001
+From cb5c9d5aef5db7e1bda4a5f1b8d5b09263a0bd48 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -65,7 +65,7 @@ index 63adda8a1..00914222a 100644
 -- 
 2.52.0
 
-From 796bdd93f2c2a1026d70100f304caef38662f361 Mon Sep 17 00:00:00 2001
+From d3762de8c84471626b6619138fa6eff0e04bdbe5 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override

--- a/patches/6.12/0014-rtc.patch
+++ b/patches/6.12/0014-rtc.patch
@@ -1,4 +1,4 @@
-From e2c9f4a3dfa5587ce98a77222db6b960c427d3fe Mon Sep 17 00:00:00 2001
+From d499d81c907450682259040cb23f4334c5291d34 Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.12** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.12-surface`
- **Base version**: `v6.12.66`
- **Patches generated**: 14
- **Patches directory**: `patches/6.12/`

### Changes
This PR updates kernel patches to the latest version from the `v6.12-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.12-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.