### PR TITLE
patches/v6.18: Automatic update to v6.18.7

### DIFF
--- a/patches/6.18/0017-powercap.patch
+++ b/patches/6.18/0017-powercap.patch
@@ -1,4 +1,4 @@
-From a1c886a619ddf7245f2a5cc51404baacb92c29c6 Mon Sep 17 00:00:00 2001
+From 6186a782293d3eaa335d0e32048d2b1dd32d4369 Mon Sep 17 00:00:00 2001
 From: Daniel Tang <danielzgtg.opensource@gmail.com>
 Date: Wed, 14 Jan 2026 20:31:38 -0500
 Subject: [PATCH] powercap: intel_rapl: Add PL4 support for Ice Lake
@@ -8,15 +8,16 @@ boot/resume. Userspace needs to be able to restore the correct value.
 
 Link: https://github.com/linux-surface/linux-surface/issues/706
 Signed-off-by: Daniel Tang <danielzgtg.opensource@gmail.com>
+Patchset: powercap
 ---
  drivers/powercap/intel_rapl_msr.c | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/powercap/intel_rapl_msr.c b/drivers/powercap/intel_rapl_msr.c
-index 9a7e150b3536..a2bc0a9c1e10 100644
+index c6b9a7deb..e82724768 100644
 --- a/drivers/powercap/intel_rapl_msr.c
 +++ b/drivers/powercap/intel_rapl_msr.c
-@@ -162,6 +162,7 @@ static int rapl_msr_write_raw(int cpu, struct reg_action *ra)
+@@ -140,6 +140,7 @@ static int rapl_msr_write_raw(int cpu, struct reg_action *ra)
  
  /* List of verified CPUs. */
  static const struct x86_cpu_id pl4_support_ids[] = {
@@ -25,5 +26,5 @@ index 9a7e150b3536..a2bc0a9c1e10 100644
  	X86_MATCH_VFM(INTEL_ALDERLAKE, NULL),
  	X86_MATCH_VFM(INTEL_ALDERLAKE_L, NULL),
 -- 
-2.51.0
+2.52.0
 


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.18** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.18-surface`
- **Base version**: `v6.18.7`
- **Patches generated**: 17
- **Patches directory**: `patches/6.18/`

### Changes
This PR updates kernel patches to the latest version from the `v6.18-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.18-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.