### PR TITLE
patches/v6.12: Automatic update to v6.12.68

### DIFF
--- a/patches/6.12/0001-secureboot.patch
+++ b/patches/6.12/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From b8a82d2a626465f4cdf912f855fbcef247eedc10 Mon Sep 17 00:00:00 2001
+From 83fb412e5ce1df11aae62b316282cdf3cab99301 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -35,7 +35,7 @@ index b5c79f433..a1bbedd98 100644
 -- 
 2.52.0
 
-From 03705b5cfa7d87e162668f4cf47cb08a3aa002f1 Mon Sep 17 00:00:00 2001
+From fe63d5758097d8f030140b054ac6644107c956b9 Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter

--- a/patches/6.12/0002-surface3-oemb.patch
+++ b/patches/6.12/0002-surface3-oemb.patch
@@ -1,4 +1,4 @@
-From 4ee64efe2fcd913b93a12054df1cb2cb4a524e33 Mon Sep 17 00:00:00 2001
+From 8d20e56573c6b88f5e9d26c9b48194a69b1b263d Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI

--- a/patches/6.12/0003-mwifiex.patch
+++ b/patches/6.12/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From c3b97a265dd2e7a2bfa5d06ca4f5e7761b6e680d Mon Sep 17 00:00:00 2001
+From 455aa655eca2c1531e9e719dffe3b8a74b4cdcdd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -165,7 +165,7 @@ index d6ff964ae..5d30ae39d 100644
 -- 
 2.52.0
 
-From 3f90405b93b79a88952fbe674d084ec2c1d348a6 Mon Sep 17 00:00:00 2001
+From 4004203431ddaaee61dd98e07b6df4518e4c70f8 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -320,7 +320,7 @@ index 5d30ae39d..c14eb56eb 100644
 -- 
 2.52.0
 
-From 572b228bea431f8bcacf43abe99f22ddf5517d13 Mon Sep 17 00:00:00 2001
+From 8b32ce1c516120ff04578d2984c0a41b6b2eb32b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell

--- a/patches/6.12/0004-ath10k.patch
+++ b/patches/6.12/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From 79852758c6d277f11456f1675e28edd544e83151 Mon Sep 17 00:00:00 2001
+From 1272e0f2951f6d2deff64aaea6bcb9c1f1ec5fa5 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files

--- a/patches/6.12/0005-ipts.patch
+++ b/patches/6.12/0005-ipts.patch
@@ -1,4 +1,4 @@
-From 016b54e98cb0d9bcae3efdffa17e28cb6e9e9b71 Mon Sep 17 00:00:00 2001
+From 18382716c95dcbb8aef8394c695ed7302b237b52 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -37,7 +37,7 @@ index 1e4edf896..61d1a8816 100644
 -- 
 2.52.0
 
-From 812146c3632763ddfc8799683c181cf1a688fc9d Mon Sep 17 00:00:00 2001
+From 02c872988f7201479070a3f10b4518161556368a Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -144,7 +144,7 @@ index c799cc67d..65adfc813 100644
 -- 
 2.52.0
 
-From cd4b550350e259ac00d036e90b675108197077bb Mon Sep 17 00:00:00 2001
+From 1880d8e4133705698ca7aa18f5b65c7c92ba2de9 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus

--- a/patches/6.12/0006-ithc.patch
+++ b/patches/6.12/0006-ithc.patch
@@ -1,4 +1,4 @@
-From b4b53cb12fb1818201b29a9dca400e34f18f7494 Mon Sep 17 00:00:00 2001
+From 89f46673f771eb27289638133bd55c70dfc953d6 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -39,7 +39,7 @@ index 066e4cd6e..7b320d09d 100644
 -- 
 2.52.0
 
-From fac2cb111a39ed2d58dd4222b21d61c46d3d0d96 Mon Sep 17 00:00:00 2001
+From 3e42ef9a26315313a2dc7722645e45d3f2e86646 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller

--- a/patches/6.12/0007-surface-sam-over-hid.patch
+++ b/patches/6.12/0007-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From 438ff08b86c52d04b6d3335bd104aa6855bef8b9 Mon Sep 17 00:00:00 2001
+From 9a901fb49e8eeaaf6e32e33d2fb1595a5b68391d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -109,7 +109,7 @@ index f43067f67..1761ca30e 100644
 -- 
 2.52.0
 
-From 72729d60f3ea5601974e80e576c732ed8542f554 Mon Sep 17 00:00:00 2001
+From 910bd8dce5db8f99e7cc20f5a773ccc14092de00 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch

--- a/patches/6.12/0008-surface-button.patch
+++ b/patches/6.12/0008-surface-button.patch
@@ -1,4 +1,4 @@
-From fe02c79805a3d270bc2d8083d49a4968f1ac6d6b Mon Sep 17 00:00:00 2001
+From 833e3db5906a61edde1c514283c500873286192a Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -75,7 +75,7 @@ index 5c5d407fe..4e1bfe90e 100644
 -- 
 2.52.0
 
-From 6527332ea810dad56163535f4d4a7f7484aaca95 Mon Sep 17 00:00:00 2001
+From 8821ccb1052dbc6af294c56742662455cd7686ca Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd

--- a/patches/6.12/0009-surface-typecover.patch
+++ b/patches/6.12/0009-surface-typecover.patch
@@ -1,4 +1,4 @@
-From 4e994b026c3480eaf8663a017462d6e805cf9077 Mon Sep 17 00:00:00 2001
+From b672d83af9647f51ff73a8158d626898a46e8ec7 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -39,7 +39,7 @@ index 323a949bb..abc2cdecd 100644
 -- 
 2.52.0
 
-From d69cc1c7e46d9e9aea52ee64500e43fa823f183e Mon Sep 17 00:00:00 2001
+From f91864077f6380de6d73fea2b935cfe8d0ec0c1d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -274,7 +274,7 @@ index 0e4cb0e66..26b551523 100644
 -- 
 2.52.0
 
-From 52a3c2f1c8cd4521161c419daec8739612297a8a Mon Sep 17 00:00:00 2001
+From 9a1db7e264b5484d7281b8b8f352222e77017acb Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet

--- a/patches/6.12/0010-surface-shutdown.patch
+++ b/patches/6.12/0010-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From c09a82503e99e9879188f0e459a22717fef6ecce Mon Sep 17 00:00:00 2001
+From 50751f30b80fdf8da3931ea45bff613e9fff20e1 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod

--- a/patches/6.12/0011-surface-gpe.patch
+++ b/patches/6.12/0011-surface-gpe.patch
@@ -1,4 +1,4 @@
-From d3fd9b8e861c4e05f50c3062d93ab84ed8198a49 Mon Sep 17 00:00:00 2001
+From 0d638821f83be823bc8345da67dc575b4f63a8a4 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9

--- a/patches/6.12/0012-cameras.patch
+++ b/patches/6.12/0012-cameras.patch
@@ -1,4 +1,4 @@
-From b77dfed1149b9dfbfb112d4e6aa29a6eb6007840 Mon Sep 17 00:00:00 2001
+From 7425a395008ba82583190496b0d5b931650273de Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -74,7 +74,7 @@ index ba98763ce..6021907ec 100644
 -- 
 2.52.0
 
-From 5d9d56716cc3f34562d11286cdbca59adfe20fd0 Mon Sep 17 00:00:00 2001
+From da323c3272093ad7d5d24ec67ff5e255389ea829 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -184,7 +184,7 @@ index 65adfc813..3dcabd6c5 100644
 -- 
 2.52.0
 
-From 2bde38758603b21b0b7f3eaf023f2778c2d50a68 Mon Sep 17 00:00:00 2001
+From b30bb045b4d67722312ba305f9303b8cf2dcbf74 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -221,7 +221,7 @@ index 81ac4c691..f453c9043 100644
 -- 
 2.52.0
 
-From 3d030f709639be08ac364a455cc46bdee615ffa8 Mon Sep 17 00:00:00 2001
+From e1cef1af2572cb49bc479c781ea313e63a5f1dc6 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Thu, 2 Mar 2023 12:59:39 +0000
 Subject: [PATCH] platform/x86: int3472: Remap reset GPIO for INT347E
@@ -277,7 +277,7 @@ index 9e69ac9cf..d6003198a 100644
 -- 
 2.52.0
 
-From 70f4fc9c7be17384d365cca714e3f6cd1f487ac1 Mon Sep 17 00:00:00 2001
+From 299c771ba77c2eddf8704a86e7bab43d83d58d13 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -316,7 +316,7 @@ index 3226888d7..3bfe45b76 100644
 -- 
 2.52.0
 
-From da4e91f43bcbc995ca528ae1480f26dedcbc7e60 Mon Sep 17 00:00:00 2001
+From 30c528c9306fc89ccc0b9494de692ee2eb547f8e Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -367,7 +367,7 @@ index f19c8adf2..923ed1b5a 100644
 -- 
 2.52.0
 
-From 24a0c28ce10e49979d41712c68a6698043fd22ad Mon Sep 17 00:00:00 2001
+From 5d50a766308660d2ae03100f2d63689825cc39d2 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -408,7 +408,7 @@ index f453c9043..b8ad6b413 100644
 -- 
 2.52.0
 
-From b62f4ea198626e8272626caa013e7b6baa3e1f4f Mon Sep 17 00:00:00 2001
+From 7591d1c40fb71d4b8a7246d9fcc035f6339b82d5 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -449,7 +449,7 @@ index 7807fa329..2d2abb25b 100644
 -- 
 2.52.0
 
-From 549dace780d55486e60f5350b568b53d186ac122 Mon Sep 17 00:00:00 2001
+From 1f4c6b08455a323956c12a9c69fb809e0c1e4a92 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -700,7 +700,7 @@ index 000000000..35aeb5db8
 -- 
 2.52.0
 
-From 495d725951025e883e494ef1c1731e042a545363 Mon Sep 17 00:00:00 2001
+From c44aa32a7a57e44fb992dcdfa30dd2d5723e15ec Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2

--- a/patches/6.12/0013-amd-gpio.patch
+++ b/patches/6.12/0013-amd-gpio.patch
@@ -1,4 +1,4 @@
-From 31e8f1a75ddb7c0de5c1b63523f356bea7c6beed Mon Sep 17 00:00:00 2001
+From 949bb8d4c19b6f83e581980373f0cc6d17a1985f Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -65,7 +65,7 @@ index 63adda8a1..00914222a 100644
 -- 
 2.52.0
 
-From 29a7f6dbf6340689752fb699c060a8fe7b11231e Mon Sep 17 00:00:00 2001
+From 07eb4f50c84102985c37e930e6596bffe93ece1d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override

--- a/patches/6.12/0014-rtc.patch
+++ b/patches/6.12/0014-rtc.patch
@@ -1,4 +1,4 @@
-From 3a3721568ebb2ede3a4822a6e7f81b98db06946a Mon Sep 17 00:00:00 2001
+From d7276bb3fd747ae88c0638c294e9f3e8ab60d6cd Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.12** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.12-surface`
- **Base version**: `v6.12.68`
- **Patches generated**: 14
- **Patches directory**: `patches/6.12/`

### Changes
This PR updates kernel patches to the latest version from the `v6.12-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.12-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.