### PR TITLE
patches/v6.18: Automatic update to v6.18.8

### DIFF
--- a/patches/6.18/0001-secureboot.patch
+++ b/patches/6.18/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From 65023019e757e470c4bd48765555ead3e5dcc187 Mon Sep 17 00:00:00 2001
+From 000648f4f90818dc20b4bebfcddc3a9f3803ff15 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -35,7 +35,7 @@ index 9bea5a1e2..25848f886 100644
 -- 
 2.52.0
 
-From a44c5b828a5940a8a00777fa7ea63ca31c1962de Mon Sep 17 00:00:00 2001
+From e041d8263d093f2d2d5123d246e220c53e6ca57b Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter

--- a/patches/6.18/0002-surface3.patch
+++ b/patches/6.18/0002-surface3.patch
@@ -1,4 +1,4 @@
-From 7540349a64515324758354f03f3ebbe69751dd44 Mon Sep 17 00:00:00 2001
+From e9e6b39423574dbf8c69dceb448a7d025c76a9d7 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI
@@ -99,7 +99,7 @@ index e4c3492a0..0b930c91b 100644
 -- 
 2.52.0
 
-From 0ab087c8315d63949bcca3bc962591357108c565 Mon Sep 17 00:00:00 2001
+From 4a07615e2ebf577c6e71b51b7badbbba4d633981 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
 Subject: [PATCH] surface3-spi: workaround: disable DMA mode to avoid crash by

--- a/patches/6.18/0003-mwifiex.patch
+++ b/patches/6.18/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From bb89bfa02608f36c7ed2b0274cd7238abd502f56 Mon Sep 17 00:00:00 2001
+From 7e1bb52229f6ce7a4a8b3feeee858c6ccf9eaa79 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -165,7 +165,7 @@ index d6ff964ae..5d30ae39d 100644
 -- 
 2.52.0
 
-From 28a6aba5caa6375b043c6911255153d6b3467f75 Mon Sep 17 00:00:00 2001
+From 9c0afb16977536994d235fa7a67344e79f9f56d5 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -320,7 +320,7 @@ index 5d30ae39d..c14eb56eb 100644
 -- 
 2.52.0
 
-From e9742fa6b209a09dfa2ca3a54d3b0fce4d753e49 Mon Sep 17 00:00:00 2001
+From 3767d1a91caf6f15f562b9d1742d0e4ac30ab18f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell

--- a/patches/6.18/0004-ath10k.patch
+++ b/patches/6.18/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From 0c29379773e77fabade4af9340a46ad70024611b Mon Sep 17 00:00:00 2001
+From c063b83e99378d0f2f2820291ac0d96f196e080c Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files

--- a/patches/6.18/0005-ipts.patch
+++ b/patches/6.18/0005-ipts.patch
@@ -1,4 +1,4 @@
-From cf7a77387b7ba7e212ece7b5eb49579667219942 Mon Sep 17 00:00:00 2001
+From 8b7cb164383dc09f88305bfbe2828edc5ca8456e Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -37,7 +37,7 @@ index 2a6e56955..c19dfba54 100644
 -- 
 2.52.0
 
-From fe3d622e306ca176f40588634022bea09fe7a9bf Mon Sep 17 00:00:00 2001
+From 7c3015468063bb7a0aa8b51c49290ed1542bd89c Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -144,7 +144,7 @@ index e236c7ec2..9e31a5fe1 100644
 -- 
 2.52.0
 
-From 8b3cf2142ffa659dab6041ede28dae1b923a4831 Mon Sep 17 00:00:00 2001
+From bdf9e4ac66246e18f06cae402728aef34e612c33 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus

--- a/patches/6.18/0006-ithc.patch
+++ b/patches/6.18/0006-ithc.patch
@@ -1,4 +1,4 @@
-From 7d653dd37c82eceddb940978a1d92bf64bbd99c7 Mon Sep 17 00:00:00 2001
+From 329dbd98a2f7dcab6ebce425af6c708319aa352d Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -39,7 +39,7 @@ index 8bcbfe3d9..c78806d35 100644
 -- 
 2.52.0
 
-From 6db881de95e570982525b040d5411aed42cf9fc2 Mon Sep 17 00:00:00 2001
+From b8585c954e2f495be9ed798528f348ab3fda65d2 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller

--- a/patches/6.18/0007-surface-sam.patch
+++ b/patches/6.18/0007-surface-sam.patch
@@ -1,4 +1,4 @@
-From 0e99b3cf2d60d2e62d35ace1cd7c6e8972f87a3a Mon Sep 17 00:00:00 2001
+From 878de2f4b354ad17071c51b43a4c9b873a5c52dd Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
 Subject: [PATCH] rtc: Add basic support for RTC via Surface System Aggregator
@@ -181,7 +181,7 @@ index 000000000..f6c17c4e9
 -- 
 2.52.0
 
-From d517dea0845c01308edb3b219867886470e363db Mon Sep 17 00:00:00 2001
+From 6e8dc33ef616c446653e9b362e3d73b130729190 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
 Subject: [PATCH] platform/surface: aggregator_registry: Add Surface Laptop 7

--- a/patches/6.18/0008-surface-sam-over-hid.patch
+++ b/patches/6.18/0008-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From 7ed908f77f3703a80af9163376a0d257688fe63d Mon Sep 17 00:00:00 2001
+From a2b8be244e3bca9055d360ebc90471d7418c52ab Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -109,7 +109,7 @@ index ed90858a2..070c36637 100644
 -- 
 2.52.0
 
-From 990d8e44668a9a8fa90c998cca066877f0e094e8 Mon Sep 17 00:00:00 2001
+From 96d18f6989c750179269ae199f4a1f32aa3c3059 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch

--- a/patches/6.18/0009-surface-button.patch
+++ b/patches/6.18/0009-surface-button.patch
@@ -1,4 +1,4 @@
-From 5435570ea3009568161af7bdfd7720b664d1140c Mon Sep 17 00:00:00 2001
+From 9bea2a09219c5b3acf4c7ba8b328b1675e964bb7 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -75,7 +75,7 @@ index b8cad415c..43b5d5638 100644
 -- 
 2.52.0
 
-From a84a014b4bdf583f23acd8056ce23464a4d4ca47 Mon Sep 17 00:00:00 2001
+From 37a68e90e88ad5f17b65dd6e74b91907b9f3d658 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd

--- a/patches/6.18/0010-surface-typecover.patch
+++ b/patches/6.18/0010-surface-typecover.patch
@@ -1,4 +1,4 @@
-From 0a8c670d0a5e2db12cea9e192e48e2cfb1a86973 Mon Sep 17 00:00:00 2001
+From 5f0114d0663f471a37224f81d9decbb4671e5664 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -39,7 +39,7 @@ index c4d85089d..3d0d35c72 100644
 -- 
 2.52.0
 
-From ff53718ae3c358eb6da5dcd77b426fc7543d0dc1 Mon Sep 17 00:00:00 2001
+From e69f8b3a80a4684de31ea21f23211ed2acaeed35 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -274,7 +274,7 @@ index 179dc316b..7d644e1c4 100644
 -- 
 2.52.0
 
-From 1a6aa250e57410a9f013a2d46cd74a6e327a4046 Mon Sep 17 00:00:00 2001
+From e01885e989e3f0f4d8ccef483ae6f7b0896d1cbb Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet

--- a/patches/6.18/0011-surface-shutdown.patch
+++ b/patches/6.18/0011-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From 67b13eaca5b31245a5217682083642ad5d1515fc Mon Sep 17 00:00:00 2001
+From 22ea5007c2f6c4a45778e5719fe68f98f6a128b5 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
@@ -95,7 +95,7 @@ index bf97d49c2..90eead93d 100644
 -- 
 2.52.0
 
-From a78e463c5d6d9b007d8d45719df365c9f9d84be3 Mon Sep 17 00:00:00 2001
+From 5f5fe5c30fed707408e995b5f9b4fd70850502ed Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Wed, 7 Jan 2026 01:06:25 +0100
 Subject: [PATCH] PCI: Add Surface Laptop Studio 2 devices to shutdown ops

--- a/patches/6.18/0012-surface-gpe.patch
+++ b/patches/6.18/0012-surface-gpe.patch
@@ -1,4 +1,4 @@
-From c8d2a9c279cb950a3c8d0793386592c6fa48de0e Mon Sep 17 00:00:00 2001
+From 544ebf521bb51bc76bbb53be59dd343553238299 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9

--- a/patches/6.18/0013-cameras.patch
+++ b/patches/6.18/0013-cameras.patch
@@ -1,4 +1,4 @@
-From e286569044ab46525518d0e6b6c9060ffaef2ab6 Mon Sep 17 00:00:00 2001
+From 4efcc8606f380b191a190c0dea444783a76b8e80 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -74,7 +74,7 @@ index ef16d58b2..a6bad2679 100644
 -- 
 2.52.0
 
-From f21f1ebd6e35d221201e1cdd8366d52d116dd93b Mon Sep 17 00:00:00 2001
+From 9c8c596646650ffc4e2aec66b64bfc53bd1064d6 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -184,7 +184,7 @@ index 9e31a5fe1..bdd32551c 100644
 -- 
 2.52.0
 
-From 7dabd26ac8d9da4268d0c0e2c86e6c25aff1d3f8 Mon Sep 17 00:00:00 2001
+From fdf85e34e0cd9707edead5c6629af8297bfe799e Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -221,7 +221,7 @@ index 013340569..9e0763bdc 100644
 -- 
 2.52.0
 
-From e2d439ead544873d9408d8eb5670b00cf3f4dd41 Mon Sep 17 00:00:00 2001
+From f504b621cd3f73e83fa62117d4bef7c623d16859 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -260,7 +260,7 @@ index 27afc3fc0..28b192c9a 100644
 -- 
 2.52.0
 
-From ad42c93969536b0baa79e3645fb40f8843b99e99 Mon Sep 17 00:00:00 2001
+From 9389eecd77c1bd3c64a65e53d51bd872bd08b48a Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -311,7 +311,7 @@ index cb153ce42..f11b499e1 100644
 -- 
 2.52.0
 
-From 7a237ebefcf137537da3747fa057a9755449f79b Mon Sep 17 00:00:00 2001
+From b2ba431af4ef8243a28baef5f221a94343b8ea01 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -352,7 +352,7 @@ index 9e0763bdc..0976b2679 100644
 -- 
 2.52.0
 
-From 2b4b5979e609ff1a8585e04cb7409b8130bb1a50 Mon Sep 17 00:00:00 2001
+From 3a7716a4105e214a32ea0f1d2b41bbdecedc6f7f Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -393,7 +393,7 @@ index 7807fa329..2d2abb25b 100644
 -- 
 2.52.0
 
-From 261989a64ab1c651f2c79e300d1ed83c5f9a24c2 Mon Sep 17 00:00:00 2001
+From 9a52132b23e671cc90c43857e933395f8bec3387 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -644,7 +644,7 @@ index 000000000..35aeb5db8
 -- 
 2.52.0
 
-From 6b054d0f9cc77fbce385ffdddb0ada60823e2d21 Mon Sep 17 00:00:00 2001
+From f34913af5afdc387e79d79d3f10ae65c4c0fde1f Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2
@@ -676,7 +676,7 @@ index 032fbcb98..e03a1d8cd 100644
 -- 
 2.52.0
 
-From e39fb77521f13219b27d0e39e2a77a84b17ded58 Mon Sep 17 00:00:00 2001
+From 5e74b93b87352d1fc8ba38f76aca030f32a3ead1 Mon Sep 17 00:00:00 2001
 From: Tooraj Taraz <tooraj.taraz@yahoo.com>
 Date: Wed, 31 Dec 2025 00:35:50 +0100
 Subject: [PATCH] Add camera support for Surface Pro 9

--- a/patches/6.18/0014-amd-gpio.patch
+++ b/patches/6.18/0014-amd-gpio.patch
@@ -1,4 +1,4 @@
-From d3d85f0c39e70ea972456bad4c7447b5eb207db3 Mon Sep 17 00:00:00 2001
+From db7f975d923852f9d93d032b52a588925504c5d0 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -65,7 +65,7 @@ index 9fa321a95..8914a922b 100644
 -- 
 2.52.0
 
-From 78dd2102bdfd831dd957e3f4c8710eb6ded17f2b Mon Sep 17 00:00:00 2001
+From 6d51695d00d982bae907489634463512df354442 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override

--- a/patches/6.18/0015-rtc.patch
+++ b/patches/6.18/0015-rtc.patch
@@ -1,4 +1,4 @@
-From 6767aeecda4156c7d5e82f3910ff7b23ec59b318 Mon Sep 17 00:00:00 2001
+From c2d11cf6dde6a9bef309a899c1749026106a7918 Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms

--- a/patches/6.18/0016-hid-surface.patch
+++ b/patches/6.18/0016-hid-surface.patch
@@ -1,4 +1,4 @@
-From 56bdbcbcabe6116da57bcd583a2101f68815fabd Mon Sep 17 00:00:00 2001
+From c55655d0f695e5d55b239299ab8fc9d4f759393b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ciar=C3=A1n=20Coffey?= <github@ccoffey.ie>
 Date: Fri, 10 Oct 2025 19:04:03 +0100
 Subject: [PATCH] HID: Add hid-surface driver to filter BTN_0 (FN key)
@@ -156,7 +156,7 @@ index 000000000..a171ea656
 -- 
 2.52.0
 
-From 5d71ba3d69436b26d4940d73f9a55eda46394b15 Mon Sep 17 00:00:00 2001
+From 63ec93c9a203b844e2ede74e74abb181c7c3dbe6 Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Wed, 24 Dec 2025 00:54:44 -0800
 Subject: [PATCH] hid/multitouch: Prevent mode set on Surface Laptop Studio 2

--- a/patches/6.18/0017-powercap.patch
+++ b/patches/6.18/0017-powercap.patch
@@ -1,4 +1,4 @@
-From 6186a782293d3eaa335d0e32048d2b1dd32d4369 Mon Sep 17 00:00:00 2001
+From cf0ba7bf5d6a7feb9851facf1808985a2ed5b89b Mon Sep 17 00:00:00 2001
 From: Daniel Tang <danielzgtg.opensource@gmail.com>
 Date: Wed, 14 Jan 2026 20:31:38 -0500
 Subject: [PATCH] powercap: intel_rapl: Add PL4 support for Ice Lake


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.18** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.18-surface`
- **Base version**: `v6.18.8`
- **Patches generated**: 17
- **Patches directory**: `patches/6.18/`

### Changes
This PR updates kernel patches to the latest version from the `v6.18-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.18-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.