### PR TITLE
patches/v6.18: Automatic update to v6.18.9

### DIFF
--- a/patches/6.18/0001-secureboot.patch
+++ b/patches/6.18/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From 000648f4f90818dc20b4bebfcddc3a9f3803ff15 Mon Sep 17 00:00:00 2001
+From bd4c46d5fcf52346c10baa2f93a8191b3666a7ca Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -35,7 +35,7 @@ index 9bea5a1e2..25848f886 100644
 -- 
 2.52.0
 
-From e041d8263d093f2d2d5123d246e220c53e6ca57b Mon Sep 17 00:00:00 2001
+From 19cebf117e481f0227d7122812b03591199828d1 Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter

--- a/patches/6.18/0002-surface3.patch
+++ b/patches/6.18/0002-surface3.patch
@@ -1,4 +1,4 @@
-From e9e6b39423574dbf8c69dceb448a7d025c76a9d7 Mon Sep 17 00:00:00 2001
+From 69a85d6855669be7e986acef07ccbf8f8bf80448 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI
@@ -99,7 +99,7 @@ index e4c3492a0..0b930c91b 100644
 -- 
 2.52.0
 
-From 4a07615e2ebf577c6e71b51b7badbbba4d633981 Mon Sep 17 00:00:00 2001
+From 3d30bbd21b86edc7aee7f04d63f48274d2b18c91 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
 Subject: [PATCH] surface3-spi: workaround: disable DMA mode to avoid crash by

--- a/patches/6.18/0003-mwifiex.patch
+++ b/patches/6.18/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From 7e1bb52229f6ce7a4a8b3feeee858c6ccf9eaa79 Mon Sep 17 00:00:00 2001
+From 9593c516ab9ffbaf6f3579fa9b4847334a06bedb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -165,7 +165,7 @@ index d6ff964ae..5d30ae39d 100644
 -- 
 2.52.0
 
-From 9c0afb16977536994d235fa7a67344e79f9f56d5 Mon Sep 17 00:00:00 2001
+From 9cfa9e79bfab86b0dd006db23b8f4578d3793f79 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -320,7 +320,7 @@ index 5d30ae39d..c14eb56eb 100644
 -- 
 2.52.0
 
-From 3767d1a91caf6f15f562b9d1742d0e4ac30ab18f Mon Sep 17 00:00:00 2001
+From 8f1c63004d0669c9026ebf2c888a7aec4ee9956f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell

--- a/patches/6.18/0004-ath10k.patch
+++ b/patches/6.18/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From c063b83e99378d0f2f2820291ac0d96f196e080c Mon Sep 17 00:00:00 2001
+From 6f78fa89621ae0d37150a56393c837610d4b64de Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files

--- a/patches/6.18/0005-ipts.patch
+++ b/patches/6.18/0005-ipts.patch
@@ -1,4 +1,4 @@
-From 8b7cb164383dc09f88305bfbe2828edc5ca8456e Mon Sep 17 00:00:00 2001
+From 52589066af6dc055659cc7c36fcafb8dd221d00e Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -37,7 +37,7 @@ index 2a6e56955..c19dfba54 100644
 -- 
 2.52.0
 
-From 7c3015468063bb7a0aa8b51c49290ed1542bd89c Mon Sep 17 00:00:00 2001
+From 4d6c4cb07f0486c014733f8f1641cc4c4cb79c6b Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -144,7 +144,7 @@ index e236c7ec2..9e31a5fe1 100644
 -- 
 2.52.0
 
-From bdf9e4ac66246e18f06cae402728aef34e612c33 Mon Sep 17 00:00:00 2001
+From 947c00f6f25ef885ff9cfeee85f449311d822d1a Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus

--- a/patches/6.18/0006-ithc.patch
+++ b/patches/6.18/0006-ithc.patch
@@ -1,4 +1,4 @@
-From 329dbd98a2f7dcab6ebce425af6c708319aa352d Mon Sep 17 00:00:00 2001
+From 35c9b0f076fc055736ab686e2e6b9f4ec73e1439 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -39,7 +39,7 @@ index 8bcbfe3d9..c78806d35 100644
 -- 
 2.52.0
 
-From b8585c954e2f495be9ed798528f348ab3fda65d2 Mon Sep 17 00:00:00 2001
+From f1739d1bb079de11599ed4e58cba329c585c8bf5 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller

--- a/patches/6.18/0007-surface-sam.patch
+++ b/patches/6.18/0007-surface-sam.patch
@@ -1,4 +1,4 @@
-From 878de2f4b354ad17071c51b43a4c9b873a5c52dd Mon Sep 17 00:00:00 2001
+From b5dca285f0fa20a64793c71c541a517a01a53ecf Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
 Subject: [PATCH] rtc: Add basic support for RTC via Surface System Aggregator
@@ -181,7 +181,7 @@ index 000000000..f6c17c4e9
 -- 
 2.52.0
 
-From 6e8dc33ef616c446653e9b362e3d73b130729190 Mon Sep 17 00:00:00 2001
+From a06532897c1ea9225e069d750bcdc2959a160f76 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
 Subject: [PATCH] platform/surface: aggregator_registry: Add Surface Laptop 7

--- a/patches/6.18/0008-surface-sam-over-hid.patch
+++ b/patches/6.18/0008-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From a2b8be244e3bca9055d360ebc90471d7418c52ab Mon Sep 17 00:00:00 2001
+From 6579116fd37c78498cdd8ec2761dc0253a7cc85c Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -109,7 +109,7 @@ index ed90858a2..070c36637 100644
 -- 
 2.52.0
 
-From 96d18f6989c750179269ae199f4a1f32aa3c3059 Mon Sep 17 00:00:00 2001
+From d12c96869aab1623728e86b5d8f46e92ac2d0234 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch

--- a/patches/6.18/0009-surface-button.patch
+++ b/patches/6.18/0009-surface-button.patch
@@ -1,4 +1,4 @@
-From 9bea2a09219c5b3acf4c7ba8b328b1675e964bb7 Mon Sep 17 00:00:00 2001
+From 0e6feff1f9a8b53c04ec9e8d3efb90688b9c047f Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -75,7 +75,7 @@ index b8cad415c..43b5d5638 100644
 -- 
 2.52.0
 
-From 37a68e90e88ad5f17b65dd6e74b91907b9f3d658 Mon Sep 17 00:00:00 2001
+From 06dfa01586a862d15cbb633c909cf03c8e6db0b9 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd

--- a/patches/6.18/0010-surface-typecover.patch
+++ b/patches/6.18/0010-surface-typecover.patch
@@ -1,4 +1,4 @@
-From 5f0114d0663f471a37224f81d9decbb4671e5664 Mon Sep 17 00:00:00 2001
+From adbc1603b9afc63dcf78efc80a9ce74e54679f21 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -39,7 +39,7 @@ index c4d85089d..3d0d35c72 100644
 -- 
 2.52.0
 
-From e69f8b3a80a4684de31ea21f23211ed2acaeed35 Mon Sep 17 00:00:00 2001
+From 2a2cd81bef4cf21419fc6bccb252b252ece03ac4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -274,7 +274,7 @@ index 179dc316b..7d644e1c4 100644
 -- 
 2.52.0
 
-From e01885e989e3f0f4d8ccef483ae6f7b0896d1cbb Mon Sep 17 00:00:00 2001
+From 9431420d43fa3cc1e95e4f817b401ebb8da97793 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet

--- a/patches/6.18/0011-surface-shutdown.patch
+++ b/patches/6.18/0011-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From 22ea5007c2f6c4a45778e5719fe68f98f6a128b5 Mon Sep 17 00:00:00 2001
+From 61db0e44597c45b85a384a87294bec26f52c35d9 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
@@ -95,7 +95,7 @@ index bf97d49c2..90eead93d 100644
 -- 
 2.52.0
 
-From 5f5fe5c30fed707408e995b5f9b4fd70850502ed Mon Sep 17 00:00:00 2001
+From 13dd4da628d723d312830f7174e5dc8fa6f6385b Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Wed, 7 Jan 2026 01:06:25 +0100
 Subject: [PATCH] PCI: Add Surface Laptop Studio 2 devices to shutdown ops

--- a/patches/6.18/0012-surface-gpe.patch
+++ b/patches/6.18/0012-surface-gpe.patch
@@ -1,4 +1,4 @@
-From 544ebf521bb51bc76bbb53be59dd343553238299 Mon Sep 17 00:00:00 2001
+From 3f2c59f5654154a80b1fb978c8fa0b5a52c707b4 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9

--- a/patches/6.18/0013-cameras.patch
+++ b/patches/6.18/0013-cameras.patch
@@ -1,4 +1,4 @@
-From 4efcc8606f380b191a190c0dea444783a76b8e80 Mon Sep 17 00:00:00 2001
+From 543b05525228ed555a763c4207e11f6c9355f32b Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -74,7 +74,7 @@ index ef16d58b2..a6bad2679 100644
 -- 
 2.52.0
 
-From 9c8c596646650ffc4e2aec66b64bfc53bd1064d6 Mon Sep 17 00:00:00 2001
+From a99581089b3d1df6d9982973b2d2c2fc30530024 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -184,7 +184,7 @@ index 9e31a5fe1..bdd32551c 100644
 -- 
 2.52.0
 
-From fdf85e34e0cd9707edead5c6629af8297bfe799e Mon Sep 17 00:00:00 2001
+From dca54560755ceecbed780d61e7935f4f9b73b01f Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -221,7 +221,7 @@ index 013340569..9e0763bdc 100644
 -- 
 2.52.0
 
-From f504b621cd3f73e83fa62117d4bef7c623d16859 Mon Sep 17 00:00:00 2001
+From df08cd915853c25601d57c3eba20de1fc66142fd Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -260,7 +260,7 @@ index 27afc3fc0..28b192c9a 100644
 -- 
 2.52.0
 
-From 9389eecd77c1bd3c64a65e53d51bd872bd08b48a Mon Sep 17 00:00:00 2001
+From 388ea20ca3dc1d2341689908e685a892aa3ddc68 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -311,7 +311,7 @@ index cb153ce42..f11b499e1 100644
 -- 
 2.52.0
 
-From b2ba431af4ef8243a28baef5f221a94343b8ea01 Mon Sep 17 00:00:00 2001
+From 8b8cb7995f3524b791b99d73c0c07d7985db13e1 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -352,7 +352,7 @@ index 9e0763bdc..0976b2679 100644
 -- 
 2.52.0
 
-From 3a7716a4105e214a32ea0f1d2b41bbdecedc6f7f Mon Sep 17 00:00:00 2001
+From e8b69207500fc57cd884611791e7bd902be0d6a3 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -393,7 +393,7 @@ index 7807fa329..2d2abb25b 100644
 -- 
 2.52.0
 
-From 9a52132b23e671cc90c43857e933395f8bec3387 Mon Sep 17 00:00:00 2001
+From 78df6291c8680c90b325e3d3936614ed766b537a Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -644,7 +644,7 @@ index 000000000..35aeb5db8
 -- 
 2.52.0
 
-From f34913af5afdc387e79d79d3f10ae65c4c0fde1f Mon Sep 17 00:00:00 2001
+From 13f44051bfd17396abc876b53c732e15951160a2 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2
@@ -676,7 +676,7 @@ index 032fbcb98..e03a1d8cd 100644
 -- 
 2.52.0
 
-From 5e74b93b87352d1fc8ba38f76aca030f32a3ead1 Mon Sep 17 00:00:00 2001
+From 228f2989668592d6fd7dbaf9afcb45a621f06489 Mon Sep 17 00:00:00 2001
 From: Tooraj Taraz <tooraj.taraz@yahoo.com>
 Date: Wed, 31 Dec 2025 00:35:50 +0100
 Subject: [PATCH] Add camera support for Surface Pro 9

--- a/patches/6.18/0014-amd-gpio.patch
+++ b/patches/6.18/0014-amd-gpio.patch
@@ -1,4 +1,4 @@
-From db7f975d923852f9d93d032b52a588925504c5d0 Mon Sep 17 00:00:00 2001
+From 7de9c326ae3b13ac1c7d2fa69da742786e938acb Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -65,7 +65,7 @@ index 9fa321a95..8914a922b 100644
 -- 
 2.52.0
 
-From 6d51695d00d982bae907489634463512df354442 Mon Sep 17 00:00:00 2001
+From c4785acab63b4f29bbbaf171d7bfd52aa21a2e40 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override

--- a/patches/6.18/0015-rtc.patch
+++ b/patches/6.18/0015-rtc.patch
@@ -1,4 +1,4 @@
-From c2d11cf6dde6a9bef309a899c1749026106a7918 Mon Sep 17 00:00:00 2001
+From 4f883a2192301f67ce808158aba2af39522c00ae Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms

--- a/patches/6.18/0016-hid-surface.patch
+++ b/patches/6.18/0016-hid-surface.patch
@@ -1,4 +1,4 @@
-From c55655d0f695e5d55b239299ab8fc9d4f759393b Mon Sep 17 00:00:00 2001
+From f201c243ea7f7a34d3c0743168b51b4cfa45d388 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ciar=C3=A1n=20Coffey?= <github@ccoffey.ie>
 Date: Fri, 10 Oct 2025 19:04:03 +0100
 Subject: [PATCH] HID: Add hid-surface driver to filter BTN_0 (FN key)
@@ -156,7 +156,7 @@ index 000000000..a171ea656
 -- 
 2.52.0
 
-From 63ec93c9a203b844e2ede74e74abb181c7c3dbe6 Mon Sep 17 00:00:00 2001
+From ed2a9266036762ab98a801ee5bd0cb04442d4618 Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Wed, 24 Dec 2025 00:54:44 -0800
 Subject: [PATCH] hid/multitouch: Prevent mode set on Surface Laptop Studio 2

--- a/patches/6.18/0017-powercap.patch
+++ b/patches/6.18/0017-powercap.patch
@@ -1,4 +1,4 @@
-From cf0ba7bf5d6a7feb9851facf1808985a2ed5b89b Mon Sep 17 00:00:00 2001
+From 465b1c71a2c4bad54e9b84e02de93322df88d202 Mon Sep 17 00:00:00 2001
 From: Daniel Tang <danielzgtg.opensource@gmail.com>
 Date: Wed, 14 Jan 2026 20:31:38 -0500
 Subject: [PATCH] powercap: intel_rapl: Add PL4 support for Ice Lake


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.18** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.18-surface`
- **Base version**: `v6.18.9`
- **Patches generated**: 17
- **Patches directory**: `patches/6.18/`

### Changes
This PR updates kernel patches to the latest version from the `v6.18-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.18-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.