### PR TITLE
patches/v6.12: Automatic update to v6.12.70

### DIFF
--- a/patches/6.12/0001-secureboot.patch
+++ b/patches/6.12/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From 6877febf6457275aa81ef3b912bc3393698ce3f3 Mon Sep 17 00:00:00 2001
+From ad46b63a9b906897d183049819d08cf739ac3531 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -35,7 +35,7 @@ index b5c79f433..a1bbedd98 100644
 -- 
 2.52.0
 
-From b3b97c7e967ba187f7e19ba2dc601f6adf7bb7ce Mon Sep 17 00:00:00 2001
+From 1969042d58d3a1e2aa57fe4123f8fa6f7439c273 Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter

--- a/patches/6.12/0002-surface3-oemb.patch
+++ b/patches/6.12/0002-surface3-oemb.patch
@@ -1,4 +1,4 @@
-From 432544da5814c6ef03cea6fd19e304a732c638f9 Mon Sep 17 00:00:00 2001
+From d4fc77d0b547daf43478cd87bf3e25e2d8ffdbf6 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI

--- a/patches/6.12/0003-mwifiex.patch
+++ b/patches/6.12/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From 92c40c9dc2adc649202903a880a4376ba421a865 Mon Sep 17 00:00:00 2001
+From e22f904b7491dd5608cabe95596f2305337a9cec Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -165,7 +165,7 @@ index d6ff964ae..5d30ae39d 100644
 -- 
 2.52.0
 
-From 426a0dace73b66616780d6cabe2fd4d3e097f0d2 Mon Sep 17 00:00:00 2001
+From 2758abf8aa951559a954c0efbe531904d556daf2 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -320,7 +320,7 @@ index 5d30ae39d..c14eb56eb 100644
 -- 
 2.52.0
 
-From 51e1c076bba9fcbff159ca77ba1a82fbf7033ecb Mon Sep 17 00:00:00 2001
+From ead51b919f58f3c21c6bcf3f50943ae1bd80d543 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell

--- a/patches/6.12/0004-ath10k.patch
+++ b/patches/6.12/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From 8c3eb2772c31f18f4d3b9df993fc2984604f9035 Mon Sep 17 00:00:00 2001
+From 50919ec9529991de2f72d7c935692ffe9148ee09 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files

--- a/patches/6.12/0005-ipts.patch
+++ b/patches/6.12/0005-ipts.patch
@@ -1,4 +1,4 @@
-From 1890f0507b799548781b7a28886b8625399691c0 Mon Sep 17 00:00:00 2001
+From 1a6b41faf24ff19fb855a0196c24db6e6af42c97 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -37,7 +37,7 @@ index 1e4edf896..61d1a8816 100644
 -- 
 2.52.0
 
-From 7f8a88610707324d4109f07afe9279a79c651158 Mon Sep 17 00:00:00 2001
+From 35cb9b0b1b3a8ebea42dfdd0e62109d6d2824596 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -144,7 +144,7 @@ index c799cc67d..65adfc813 100644
 -- 
 2.52.0
 
-From 4fc39217748aa357920ef5c82932541bb24f7a6a Mon Sep 17 00:00:00 2001
+From 1f86b9f0bfe410917faaf4b75a7e9c196fa77d97 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus

--- a/patches/6.12/0006-ithc.patch
+++ b/patches/6.12/0006-ithc.patch
@@ -1,4 +1,4 @@
-From bc6959f413d60e79c333fb8b24dd3d35558316e0 Mon Sep 17 00:00:00 2001
+From 8a17efd9d6600f29fcaf65ed0012540c61ebcbb3 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -39,7 +39,7 @@ index 066e4cd6e..7b320d09d 100644
 -- 
 2.52.0
 
-From 9e031dc46bd980b02718fd00b1a0a5b9af18f173 Mon Sep 17 00:00:00 2001
+From 5855e5f9eb2fc73ecb6290bb90023c1b02e0a90e Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller

--- a/patches/6.12/0007-surface-sam-over-hid.patch
+++ b/patches/6.12/0007-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From 2706f5bc42ccf89b99e29d9e6ccce296d577b20b Mon Sep 17 00:00:00 2001
+From ca043de4816f44083660858387957370350f63ba Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -109,7 +109,7 @@ index f43067f67..1761ca30e 100644
 -- 
 2.52.0
 
-From 014f329f675c21a32cf6f9639eed27230380422a Mon Sep 17 00:00:00 2001
+From 6b4c9249091575217ea704589ade4e94a5d83441 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch

--- a/patches/6.12/0008-surface-button.patch
+++ b/patches/6.12/0008-surface-button.patch
@@ -1,4 +1,4 @@
-From a34c0a35f3e02e016a0f9025f0074b5073ed7acd Mon Sep 17 00:00:00 2001
+From a3b72a686a08904e55d8f4e416b3addab7dedec9 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -75,7 +75,7 @@ index 5c5d407fe..4e1bfe90e 100644
 -- 
 2.52.0
 
-From f5ceefaf29e53be0086ecf4820e2a1719b77275a Mon Sep 17 00:00:00 2001
+From c3d6cd2dc3f074a2d0e43da1a207368690e7dc36 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd

--- a/patches/6.12/0009-surface-typecover.patch
+++ b/patches/6.12/0009-surface-typecover.patch
@@ -1,4 +1,4 @@
-From 42a180489bac8661318ad604eea360b786cebae3 Mon Sep 17 00:00:00 2001
+From 3479226a150afdd0f935e4328c9f5d9f7b3eb002 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -39,7 +39,7 @@ index 323a949bb..abc2cdecd 100644
 -- 
 2.52.0
 
-From 107614f6918d76f712db23504912511c441f517d Mon Sep 17 00:00:00 2001
+From 7d7504ee8ad07aecd777e58cbd229bc78a5a37a6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -75,7 +75,7 @@ Patchset: surface-typecover
  1 file changed, 98 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 0e4cb0e66..26b551523 100644
+index fcfc508d1..be4e0ebbc 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -34,7 +34,10 @@
@@ -130,7 +130,7 @@ index 0e4cb0e66..26b551523 100644
  #define MT_CLS_SIS				0x0457
  
  #define MT_DEFAULT_MAXCONTACT	10
-@@ -405,6 +415,16 @@ static const struct mt_class mt_classes[] = {
+@@ -406,6 +416,16 @@ static const struct mt_class mt_classes[] = {
  			MT_QUIRK_ALWAYS_VALID |
  			MT_QUIRK_CONTACT_CNT_ACCURATE,
  	},
@@ -147,7 +147,7 @@ index 0e4cb0e66..26b551523 100644
  	{ }
  };
  
-@@ -1763,6 +1783,69 @@ static void mt_expired_timeout(struct timer_list *t)
+@@ -1764,6 +1784,69 @@ static void mt_expired_timeout(struct timer_list *t)
  	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
  }
  
@@ -217,7 +217,7 @@ index 0e4cb0e66..26b551523 100644
  static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  {
  	int ret, i;
-@@ -1786,6 +1869,9 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1787,6 +1870,9 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  	td->inputmode_value = MT_INPUTMODE_TOUCHSCREEN;
  	hid_set_drvdata(hdev, td);
  
@@ -227,7 +227,7 @@ index 0e4cb0e66..26b551523 100644
  	INIT_LIST_HEAD(&td->applications);
  	INIT_LIST_HEAD(&td->reports);
  
-@@ -1824,8 +1910,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1825,8 +1911,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  	timer_setup(&td->release_timer, mt_expired_timeout, 0);
  
  	ret = hid_parse(hdev);
@@ -239,7 +239,7 @@ index 0e4cb0e66..26b551523 100644
  
  	if (mtclass->quirks & MT_QUIRK_FIX_CONST_CONTACT_ID)
  		mt_fix_const_fields(hdev, HID_DG_CONTACTID);
-@@ -1834,8 +1922,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1835,8 +1923,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  		hdev->quirks |= HID_QUIRK_NOGET;
  
  	ret = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
@@ -251,7 +251,7 @@ index 0e4cb0e66..26b551523 100644
  
  	ret = sysfs_create_group(&hdev->dev.kobj, &mt_attribute_group);
  	if (ret)
-@@ -1885,6 +1975,7 @@ static void mt_remove(struct hid_device *hdev)
+@@ -1886,6 +1976,7 @@ static void mt_remove(struct hid_device *hdev)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  
@@ -259,7 +259,7 @@ index 0e4cb0e66..26b551523 100644
  	del_timer_sync(&td->release_timer);
  
  	sysfs_remove_group(&hdev->dev.kobj, &mt_attribute_group);
-@@ -2314,6 +2405,11 @@ static const struct hid_device_id mt_devices[] = {
+@@ -2315,6 +2406,11 @@ static const struct hid_device_id mt_devices[] = {
  		MT_USB_DEVICE(USB_VENDOR_ID_XIROKU,
  			USB_DEVICE_ID_XIROKU_CSR2) },
  
@@ -274,7 +274,7 @@ index 0e4cb0e66..26b551523 100644
 -- 
 2.52.0
 
-From 41bb83b6c2ce88d10aa76f6e233e30beca605db0 Mon Sep 17 00:00:00 2001
+From e5149dc37f91cbf994d14bf230eee68f17277871 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet
@@ -303,7 +303,7 @@ Patchset: surface-typecover
  1 file changed, 122 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 26b551523..37a3e6489 100644
+index be4e0ebbc..a1df34afc 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -77,6 +77,7 @@ MODULE_LICENSE("GPL");
@@ -323,7 +323,7 @@ index 26b551523..37a3e6489 100644
  
  enum latency_mode {
  	HID_LATENCY_NORMAL = 0,
-@@ -417,6 +420,7 @@ static const struct mt_class mt_classes[] = {
+@@ -418,6 +421,7 @@ static const struct mt_class mt_classes[] = {
  	},
  	{ .name = MT_CLS_WIN_8_MS_SURFACE_TYPE_COVER,
  		.quirks = MT_QUIRK_HAS_TYPE_COVER_BACKLIGHT |
@@ -331,7 +331,7 @@ index 26b551523..37a3e6489 100644
  			MT_QUIRK_ALWAYS_VALID |
  			MT_QUIRK_IGNORE_DUPLICATES |
  			MT_QUIRK_HOVERING |
-@@ -1395,6 +1399,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+@@ -1396,6 +1400,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
  	    field->application != HID_CP_CONSUMER_CONTROL &&
  	    field->application != HID_GD_WIRELESS_RADIO_CTLS &&
  	    field->application != HID_GD_SYSTEM_MULTIAXIS &&
@@ -341,7 +341,7 @@ index 26b551523..37a3e6489 100644
  	    !(field->application == HID_VD_ASUS_CUSTOM_MEDIA_KEYS &&
  	      application->quirks & MT_QUIRK_ASUS_CUSTOM_UP))
  		return -1;
-@@ -1422,6 +1429,21 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+@@ -1423,6 +1430,21 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
  		return 1;
  	}
  
@@ -363,7 +363,7 @@ index 26b551523..37a3e6489 100644
  	if (rdata->is_mt_collection)
  		return mt_touch_input_mapping(hdev, hi, field, usage, bit, max,
  					      application);
-@@ -1443,6 +1465,7 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+@@ -1444,6 +1466,7 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  	struct mt_report_data *rdata;
@@ -371,7 +371,7 @@ index 26b551523..37a3e6489 100644
  
  	rdata = mt_find_report_data(td, field->report);
  	if (rdata && rdata->is_mt_collection) {
-@@ -1450,6 +1473,19 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+@@ -1451,6 +1474,19 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
  		return -1;
  	}
  
@@ -391,7 +391,7 @@ index 26b551523..37a3e6489 100644
  	/* let hid-core decide for the others */
  	return 0;
  }
-@@ -1459,11 +1495,21 @@ static int mt_event(struct hid_device *hid, struct hid_field *field,
+@@ -1460,11 +1496,21 @@ static int mt_event(struct hid_device *hid, struct hid_field *field,
  {
  	struct mt_device *td = hid_get_drvdata(hid);
  	struct mt_report_data *rdata;
@@ -413,7 +413,7 @@ index 26b551523..37a3e6489 100644
  	return 0;
  }
  
-@@ -1648,6 +1694,42 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app)
+@@ -1649,6 +1695,42 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app)
  		app->quirks &= ~MT_QUIRK_CONTACT_CNT_ACCURATE;
  }
  
@@ -456,7 +456,7 @@ index 26b551523..37a3e6489 100644
  static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
-@@ -1697,6 +1779,13 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
+@@ -1698,6 +1780,13 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
  		/* force BTN_STYLUS to allow tablet matching in udev */
  		__set_bit(BTN_STYLUS, hi->input->keybit);
  		break;
@@ -470,7 +470,7 @@ index 26b551523..37a3e6489 100644
  	default:
  		suffix = "UNKNOWN";
  		break;
-@@ -1783,30 +1872,6 @@ static void mt_expired_timeout(struct timer_list *t)
+@@ -1784,30 +1873,6 @@ static void mt_expired_timeout(struct timer_list *t)
  	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
  }
  
@@ -501,7 +501,7 @@ index 26b551523..37a3e6489 100644
  static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
  {
  	struct usb_device *udev = hid_to_usb_dev(hdev);
-@@ -1815,8 +1880,9 @@ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
+@@ -1816,8 +1881,9 @@ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
  	/* Wake up the device in case it's already suspended */
  	pm_runtime_get_sync(&udev->dev);
  
@@ -513,7 +513,7 @@ index 26b551523..37a3e6489 100644
  		hid_err(hdev, "couldn't find backlight field\n");
  		goto out;
  	}
-@@ -1953,13 +2019,24 @@ static int mt_suspend(struct hid_device *hdev, pm_message_t state)
+@@ -1954,13 +2020,24 @@ static int mt_suspend(struct hid_device *hdev, pm_message_t state)
  
  static int mt_reset_resume(struct hid_device *hdev)
  {
@@ -538,7 +538,7 @@ index 26b551523..37a3e6489 100644
  	/* Some Elan legacy devices require SET_IDLE to be set on resume.
  	 * It should be safe to send it to other devices too.
  	 * Tested on 3M, Stantum, Cypress, Zytronic, eGalax, and Elan panels. */
-@@ -1968,12 +2045,31 @@ static int mt_resume(struct hid_device *hdev)
+@@ -1969,12 +2046,31 @@ static int mt_resume(struct hid_device *hdev)
  
  	mt_set_modes(hdev, HID_LATENCY_NORMAL, true, true);
  

--- a/patches/6.12/0010-surface-shutdown.patch
+++ b/patches/6.12/0010-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From 6f15b3e9b2948b4e5c8fd3a22915d813432c1378 Mon Sep 17 00:00:00 2001
+From d77b3707ae9c527fd5f117e1bbb5fc0b80245a27 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod

--- a/patches/6.12/0011-surface-gpe.patch
+++ b/patches/6.12/0011-surface-gpe.patch
@@ -1,4 +1,4 @@
-From 790fb8b5cf76dc803866536a02da951aed484c52 Mon Sep 17 00:00:00 2001
+From f5c276e92652ba140ef7d3a840f5f4508dfe2bc4 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9

--- a/patches/6.12/0012-cameras.patch
+++ b/patches/6.12/0012-cameras.patch
@@ -1,4 +1,4 @@
-From ee0d663e7b026f0d55bbaec01a5396dc854564b9 Mon Sep 17 00:00:00 2001
+From 7d6f44d3883476d43c69516942bb99da676756b6 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -74,7 +74,7 @@ index ba98763ce..6021907ec 100644
 -- 
 2.52.0
 
-From 2447fb5d79ac300dbb8a9d77c7345b4d480783fc Mon Sep 17 00:00:00 2001
+From c25094a62a4b09803392a0a22644d03577d55f15 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -184,7 +184,7 @@ index 65adfc813..3dcabd6c5 100644
 -- 
 2.52.0
 
-From df89ea0106e2dc9612841d751af1790dc7590f95 Mon Sep 17 00:00:00 2001
+From 2d61eed3282cd712d6f9d3635ef8756643af6ecb Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -221,7 +221,7 @@ index 81ac4c691..f453c9043 100644
 -- 
 2.52.0
 
-From 5d26b73e9c4fafc85e10fa0f6cff5b521439daf9 Mon Sep 17 00:00:00 2001
+From 92e169a7834c8e3519727539e53e980cbd40a541 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Thu, 2 Mar 2023 12:59:39 +0000
 Subject: [PATCH] platform/x86: int3472: Remap reset GPIO for INT347E
@@ -277,7 +277,7 @@ index 9e69ac9cf..d6003198a 100644
 -- 
 2.52.0
 
-From 382fa1814a74f86e6fdb7cf1958819a47db75e55 Mon Sep 17 00:00:00 2001
+From 4f5b71aafdc8af7755e976c21c116c1db22c069e Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -316,7 +316,7 @@ index 3226888d7..3bfe45b76 100644
 -- 
 2.52.0
 
-From 3766a8f87d398ee3963d43faca14f695c1736171 Mon Sep 17 00:00:00 2001
+From 7559e28435a0e090be30517ea283c5543bcc0cc9 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -367,7 +367,7 @@ index f19c8adf2..923ed1b5a 100644
 -- 
 2.52.0
 
-From bbdda831930f5248735ac63df2696f2caf286e2a Mon Sep 17 00:00:00 2001
+From e51850211f90539e0bb6a4b808fb7e5282ff2cee Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -408,7 +408,7 @@ index f453c9043..b8ad6b413 100644
 -- 
 2.52.0
 
-From 6e50522329564b39a2a263aae50eb61a279d299c Mon Sep 17 00:00:00 2001
+From 6bba5c1d53fe180905d6cb502748e7aae6b8dd4e Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -449,7 +449,7 @@ index 7807fa329..2d2abb25b 100644
 -- 
 2.52.0
 
-From bd12a50a8fa84acc18af0cf1dfa0aa465947b855 Mon Sep 17 00:00:00 2001
+From 41b34370ba5d532e82dc5c8120c171eaf1b0c563 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -700,7 +700,7 @@ index 000000000..35aeb5db8
 -- 
 2.52.0
 
-From 483a9864ec356caec47b62251a5289962cbc189b Mon Sep 17 00:00:00 2001
+From 15dfc7d626f50055c56e4926170fe0349c2a6cc4 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2

--- a/patches/6.12/0013-amd-gpio.patch
+++ b/patches/6.12/0013-amd-gpio.patch
@@ -1,4 +1,4 @@
-From 9993bf7a1efe55b66f8c8109e65e0ac355f1ba25 Mon Sep 17 00:00:00 2001
+From 3440cfbe1b9c3c111e6e283715f2d893913f50a0 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -65,7 +65,7 @@ index 63adda8a1..00914222a 100644
 -- 
 2.52.0
 
-From 1494323ffcfaadbb7c19554d347dd0cf270134de Mon Sep 17 00:00:00 2001
+From bd69aaff1fa154536284b83ae5e85fec331bc3e2 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override

--- a/patches/6.12/0014-rtc.patch
+++ b/patches/6.12/0014-rtc.patch
@@ -1,4 +1,4 @@
-From e99383a91ae6cd8861bfdc564ed1d02d23263bec Mon Sep 17 00:00:00 2001
+From 6fc7a238ff1adf6903ad1e2923c4a608b135eb0a Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.12** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.12-surface`
- **Base version**: `v6.12.70`
- **Patches generated**: 14
- **Patches directory**: `patches/6.12/`

### Changes
This PR updates kernel patches to the latest version from the `v6.12-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.12-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.