### PR TITLE
patches/v6.18: Automatic update to v6.18.11

### DIFF
--- a/patches/6.18/0001-secureboot.patch
+++ b/patches/6.18/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From bd4c46d5fcf52346c10baa2f93a8191b3666a7ca Mon Sep 17 00:00:00 2001
+From 22b998a09e9a1ae41b1e6fc8890f4890bf4b1e40 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -35,7 +35,7 @@ index 9bea5a1e2..25848f886 100644
 -- 
 2.52.0
 
-From 19cebf117e481f0227d7122812b03591199828d1 Mon Sep 17 00:00:00 2001
+From e83c6ff87e8c64d10888e21c406e7c5e41a1dfca Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter

--- a/patches/6.18/0002-surface3.patch
+++ b/patches/6.18/0002-surface3.patch
@@ -1,4 +1,4 @@
-From 69a85d6855669be7e986acef07ccbf8f8bf80448 Mon Sep 17 00:00:00 2001
+From bde75537b2df606a1f8da56b937094644c6992f5 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI
@@ -99,7 +99,7 @@ index e4c3492a0..0b930c91b 100644
 -- 
 2.52.0
 
-From 3d30bbd21b86edc7aee7f04d63f48274d2b18c91 Mon Sep 17 00:00:00 2001
+From 05efd61139fa6c6f6b929f075f5204e6bff98320 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
 Subject: [PATCH] surface3-spi: workaround: disable DMA mode to avoid crash by

--- a/patches/6.18/0003-mwifiex.patch
+++ b/patches/6.18/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From 9593c516ab9ffbaf6f3579fa9b4847334a06bedb Mon Sep 17 00:00:00 2001
+From c70486aa7bb7d03025fdbe3a09b57e6d72bd89a2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -165,7 +165,7 @@ index d6ff964ae..5d30ae39d 100644
 -- 
 2.52.0
 
-From 9cfa9e79bfab86b0dd006db23b8f4578d3793f79 Mon Sep 17 00:00:00 2001
+From 3ef61e3ac9b0c771f0530d449522442e9c92da66 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -320,7 +320,7 @@ index 5d30ae39d..c14eb56eb 100644
 -- 
 2.52.0
 
-From 8f1c63004d0669c9026ebf2c888a7aec4ee9956f Mon Sep 17 00:00:00 2001
+From 8cffe473197c53e403ced8188bd089e031127d50 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell
@@ -356,7 +356,7 @@ Patchset: mwifiex
  1 file changed, 15 insertions(+)
 
 diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
-index 3420f711f..50362656f 100644
+index a953fa9af..7e4670599 100644
 --- a/drivers/bluetooth/btusb.c
 +++ b/drivers/bluetooth/btusb.c
 @@ -67,6 +67,7 @@ static struct usb_driver btusb_driver;
@@ -375,7 +375,7 @@ index 3420f711f..50362656f 100644
  
  	/* Intel Bluetooth devices */
  	{ USB_DEVICE(0x8087, 0x0025), .driver_info = BTUSB_INTEL_COMBINED },
-@@ -4192,6 +4194,19 @@ static int btusb_probe(struct usb_interface *intf,
+@@ -4194,6 +4196,19 @@ static int btusb_probe(struct usb_interface *intf,
  	if (id->driver_info & BTUSB_MARVELL)
  		hdev->set_bdaddr = btusb_set_bdaddr_marvell;
  

--- a/patches/6.18/0004-ath10k.patch
+++ b/patches/6.18/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From 6f78fa89621ae0d37150a56393c837610d4b64de Mon Sep 17 00:00:00 2001
+From 940d62775ebdb814133dece2f368fada929e0ce8 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files

--- a/patches/6.18/0005-ipts.patch
+++ b/patches/6.18/0005-ipts.patch
@@ -1,4 +1,4 @@
-From 52589066af6dc055659cc7c36fcafb8dd221d00e Mon Sep 17 00:00:00 2001
+From d27f6e6df0c326ce2b15c8cd7dc6775c17e92f5e Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -37,7 +37,7 @@ index 2a6e56955..c19dfba54 100644
 -- 
 2.52.0
 
-From 4d6c4cb07f0486c014733f8f1641cc4c4cb79c6b Mon Sep 17 00:00:00 2001
+From 9032ef950f6ae2260d52fa0fb02522e99672df33 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -144,7 +144,7 @@ index e236c7ec2..9e31a5fe1 100644
 -- 
 2.52.0
 
-From 947c00f6f25ef885ff9cfeee85f449311d822d1a Mon Sep 17 00:00:00 2001
+From 2fc506f9f27f3329a44918a1d1a0d1aa085cab4a Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus

--- a/patches/6.18/0006-ithc.patch
+++ b/patches/6.18/0006-ithc.patch
@@ -1,4 +1,4 @@
-From 35c9b0f076fc055736ab686e2e6b9f4ec73e1439 Mon Sep 17 00:00:00 2001
+From 7d8f787e1015952ee3dcb8a12e787ce0e8ad313e Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -39,7 +39,7 @@ index 8bcbfe3d9..c78806d35 100644
 -- 
 2.52.0
 
-From f1739d1bb079de11599ed4e58cba329c585c8bf5 Mon Sep 17 00:00:00 2001
+From d1d11261e5992cc71263ccc6af50f415ac6460e7 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller

--- a/patches/6.18/0007-surface-sam.patch
+++ b/patches/6.18/0007-surface-sam.patch
@@ -1,4 +1,4 @@
-From b5dca285f0fa20a64793c71c541a517a01a53ecf Mon Sep 17 00:00:00 2001
+From 25a5dd4d74e10fd90a9ab7af2fd9d54a80e980e4 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
 Subject: [PATCH] rtc: Add basic support for RTC via Surface System Aggregator
@@ -181,7 +181,7 @@ index 000000000..f6c17c4e9
 -- 
 2.52.0
 
-From a06532897c1ea9225e069d750bcdc2959a160f76 Mon Sep 17 00:00:00 2001
+From ce3c58d9193dd2d907d6986ee4277bb53d538aeb Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
 Subject: [PATCH] platform/surface: aggregator_registry: Add Surface Laptop 7

--- a/patches/6.18/0008-surface-sam-over-hid.patch
+++ b/patches/6.18/0008-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From 6579116fd37c78498cdd8ec2761dc0253a7cc85c Mon Sep 17 00:00:00 2001
+From 321d241b711de90393aae17dd7b950c07b5b9be6 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -109,7 +109,7 @@ index ed90858a2..070c36637 100644
 -- 
 2.52.0
 
-From d12c96869aab1623728e86b5d8f46e92ac2d0234 Mon Sep 17 00:00:00 2001
+From 6a0b6fb6fe385148787026bdd80d78d79d0b56de Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch

--- a/patches/6.18/0009-surface-button.patch
+++ b/patches/6.18/0009-surface-button.patch
@@ -1,4 +1,4 @@
-From 0e6feff1f9a8b53c04ec9e8d3efb90688b9c047f Mon Sep 17 00:00:00 2001
+From cbfece981a5aa82c4a6f6db09fb4cea076aec9b6 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -75,7 +75,7 @@ index b8cad415c..43b5d5638 100644
 -- 
 2.52.0
 
-From 06dfa01586a862d15cbb633c909cf03c8e6db0b9 Mon Sep 17 00:00:00 2001
+From 1873719245bb783ba7ade3523ce2803575927381 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd

--- a/patches/6.18/0010-surface-typecover.patch
+++ b/patches/6.18/0010-surface-typecover.patch
@@ -1,4 +1,4 @@
-From adbc1603b9afc63dcf78efc80a9ce74e54679f21 Mon Sep 17 00:00:00 2001
+From b1bbda8c1e793decc4f6700822252e2b1805fc29 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -39,7 +39,7 @@ index c4d85089d..3d0d35c72 100644
 -- 
 2.52.0
 
-From 2a2cd81bef4cf21419fc6bccb252b252ece03ac4 Mon Sep 17 00:00:00 2001
+From e14e8de9828103c096fcbd5917fe56719d4299ab Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -75,7 +75,7 @@ Patchset: surface-typecover
  1 file changed, 98 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 179dc316b..7d644e1c4 100644
+index a0c1ad5ac..2cd18fe61 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -35,7 +35,10 @@
@@ -130,7 +130,7 @@ index 179dc316b..7d644e1c4 100644
  #define MT_CLS_SIS				0x0457
  
  #define MT_DEFAULT_MAXCONTACT	10
-@@ -425,6 +435,16 @@ static const struct mt_class mt_classes[] = {
+@@ -426,6 +436,16 @@ static const struct mt_class mt_classes[] = {
  			MT_QUIRK_ALWAYS_VALID |
  			MT_QUIRK_CONTACT_CNT_ACCURATE,
  	},
@@ -147,7 +147,7 @@ index 179dc316b..7d644e1c4 100644
  	{ }
  };
  
-@@ -1842,6 +1862,69 @@ static void mt_expired_timeout(struct timer_list *t)
+@@ -1843,6 +1863,69 @@ static void mt_expired_timeout(struct timer_list *t)
  	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
  }
  
@@ -217,7 +217,7 @@ index 179dc316b..7d644e1c4 100644
  static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  {
  	int ret, i;
-@@ -1870,6 +1953,9 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1871,6 +1954,9 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  	td->inputmode_value = MT_INPUTMODE_TOUCHSCREEN;
  	hid_set_drvdata(hdev, td);
  
@@ -227,7 +227,7 @@ index 179dc316b..7d644e1c4 100644
  	INIT_LIST_HEAD(&td->applications);
  	INIT_LIST_HEAD(&td->reports);
  
-@@ -1908,8 +1994,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1909,8 +1995,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  	timer_setup(&td->release_timer, mt_expired_timeout, 0);
  
  	ret = hid_parse(hdev);
@@ -239,7 +239,7 @@ index 179dc316b..7d644e1c4 100644
  
  	if (mtclass->name == MT_CLS_APPLE_TOUCHBAR &&
  	    !hid_find_field(hdev, HID_INPUT_REPORT,
-@@ -1923,8 +2011,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1924,8 +2012,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  		hdev->quirks |= HID_QUIRK_NOGET;
  
  	ret = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
@@ -251,7 +251,7 @@ index 179dc316b..7d644e1c4 100644
  
  	ret = sysfs_create_group(&hdev->dev.kobj, &mt_attribute_group);
  	if (ret)
-@@ -1985,6 +2075,7 @@ static void mt_remove(struct hid_device *hdev)
+@@ -1986,6 +2076,7 @@ static void mt_remove(struct hid_device *hdev)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  
@@ -259,7 +259,7 @@ index 179dc316b..7d644e1c4 100644
  	timer_delete_sync(&td->release_timer);
  
  	sysfs_remove_group(&hdev->dev.kobj, &mt_attribute_group);
-@@ -2429,6 +2520,11 @@ static const struct hid_device_id mt_devices[] = {
+@@ -2430,6 +2521,11 @@ static const struct hid_device_id mt_devices[] = {
  		HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
  			USB_DEVICE_ID_APPLE_TOUCHBAR_DISPLAY) },
  
@@ -274,7 +274,7 @@ index 179dc316b..7d644e1c4 100644
 -- 
 2.52.0
 
-From 9431420d43fa3cc1e95e4f817b401ebb8da97793 Mon Sep 17 00:00:00 2001
+From c99a6cef28d73fea29881f05b1fb1dc6afff8ca6 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet
@@ -303,7 +303,7 @@ Patchset: surface-typecover
  1 file changed, 122 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 7d644e1c4..0eb4f7d12 100644
+index 2cd18fe61..c4179f6c3 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -81,6 +81,7 @@ MODULE_LICENSE("GPL");
@@ -323,7 +323,7 @@ index 7d644e1c4..0eb4f7d12 100644
  
  enum latency_mode {
  	HID_LATENCY_NORMAL = 0,
-@@ -437,6 +440,7 @@ static const struct mt_class mt_classes[] = {
+@@ -438,6 +441,7 @@ static const struct mt_class mt_classes[] = {
  	},
  	{ .name = MT_CLS_WIN_8_MS_SURFACE_TYPE_COVER,
  		.quirks = MT_QUIRK_HAS_TYPE_COVER_BACKLIGHT |
@@ -331,7 +331,7 @@ index 7d644e1c4..0eb4f7d12 100644
  			MT_QUIRK_ALWAYS_VALID |
  			MT_QUIRK_IGNORE_DUPLICATES |
  			MT_QUIRK_HOVERING |
-@@ -1463,6 +1467,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+@@ -1464,6 +1468,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
  	    field->application != HID_CP_CONSUMER_CONTROL &&
  	    field->application != HID_GD_WIRELESS_RADIO_CTLS &&
  	    field->application != HID_GD_SYSTEM_MULTIAXIS &&
@@ -341,7 +341,7 @@ index 7d644e1c4..0eb4f7d12 100644
  	    !(field->application == HID_VD_ASUS_CUSTOM_MEDIA_KEYS &&
  	      application->quirks & MT_QUIRK_ASUS_CUSTOM_UP))
  		return -1;
-@@ -1490,6 +1497,21 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+@@ -1491,6 +1498,21 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
  		return 1;
  	}
  
@@ -363,7 +363,7 @@ index 7d644e1c4..0eb4f7d12 100644
  	if (rdata->is_mt_collection)
  		return mt_touch_input_mapping(hdev, hi, field, usage, bit, max,
  					      application);
-@@ -1516,6 +1538,7 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+@@ -1517,6 +1539,7 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  	struct mt_report_data *rdata;
@@ -371,7 +371,7 @@ index 7d644e1c4..0eb4f7d12 100644
  
  	rdata = mt_find_report_data(td, field->report);
  	if (rdata && rdata->is_mt_collection) {
-@@ -1523,6 +1546,19 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+@@ -1524,6 +1547,19 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
  		return -1;
  	}
  
@@ -391,7 +391,7 @@ index 7d644e1c4..0eb4f7d12 100644
  	/* let hid-core decide for the others */
  	return 0;
  }
-@@ -1532,11 +1568,21 @@ static int mt_event(struct hid_device *hid, struct hid_field *field,
+@@ -1533,11 +1569,21 @@ static int mt_event(struct hid_device *hid, struct hid_field *field,
  {
  	struct mt_device *td = hid_get_drvdata(hid);
  	struct mt_report_data *rdata;
@@ -413,7 +413,7 @@ index 7d644e1c4..0eb4f7d12 100644
  	return 0;
  }
  
-@@ -1719,6 +1765,42 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app)
+@@ -1720,6 +1766,42 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app)
  		app->quirks &= ~MT_QUIRK_CONTACT_CNT_ACCURATE;
  }
  
@@ -456,7 +456,7 @@ index 7d644e1c4..0eb4f7d12 100644
  static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
-@@ -1776,6 +1858,13 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
+@@ -1777,6 +1859,13 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
  		/* force BTN_STYLUS to allow tablet matching in udev */
  		__set_bit(BTN_STYLUS, hi->input->keybit);
  		break;
@@ -470,7 +470,7 @@ index 7d644e1c4..0eb4f7d12 100644
  	default:
  		suffix = "UNKNOWN";
  		break;
-@@ -1862,30 +1951,6 @@ static void mt_expired_timeout(struct timer_list *t)
+@@ -1863,30 +1952,6 @@ static void mt_expired_timeout(struct timer_list *t)
  	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
  }
  
@@ -501,7 +501,7 @@ index 7d644e1c4..0eb4f7d12 100644
  static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
  {
  	struct usb_device *udev = hid_to_usb_dev(hdev);
-@@ -1894,8 +1959,9 @@ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
+@@ -1895,8 +1960,9 @@ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
  	/* Wake up the device in case it's already suspended */
  	pm_runtime_get_sync(&udev->dev);
  
@@ -513,7 +513,7 @@ index 7d644e1c4..0eb4f7d12 100644
  		hid_err(hdev, "couldn't find backlight field\n");
  		goto out;
  	}
-@@ -2053,13 +2119,24 @@ static int mt_suspend(struct hid_device *hdev, pm_message_t state)
+@@ -2054,13 +2120,24 @@ static int mt_suspend(struct hid_device *hdev, pm_message_t state)
  
  static int mt_reset_resume(struct hid_device *hdev)
  {
@@ -538,7 +538,7 @@ index 7d644e1c4..0eb4f7d12 100644
  	/* Some Elan legacy devices require SET_IDLE to be set on resume.
  	 * It should be safe to send it to other devices too.
  	 * Tested on 3M, Stantum, Cypress, Zytronic, eGalax, and Elan panels. */
-@@ -2068,12 +2145,31 @@ static int mt_resume(struct hid_device *hdev)
+@@ -2069,12 +2146,31 @@ static int mt_resume(struct hid_device *hdev)
  
  	mt_set_modes(hdev, HID_LATENCY_NORMAL, TOUCHPAD_REPORT_ALL);
  

--- a/patches/6.18/0011-surface-shutdown.patch
+++ b/patches/6.18/0011-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From 61db0e44597c45b85a384a87294bec26f52c35d9 Mon Sep 17 00:00:00 2001
+From fd14fb02df0deb1e037e2193319c2ebf425c79da Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
@@ -95,7 +95,7 @@ index bf97d49c2..90eead93d 100644
 -- 
 2.52.0
 
-From 13dd4da628d723d312830f7174e5dc8fa6f6385b Mon Sep 17 00:00:00 2001
+From bf0a09f4046c164ec5e6173beaa4a1c7443b5353 Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Wed, 7 Jan 2026 01:06:25 +0100
 Subject: [PATCH] PCI: Add Surface Laptop Studio 2 devices to shutdown ops

--- a/patches/6.18/0012-surface-gpe.patch
+++ b/patches/6.18/0012-surface-gpe.patch
@@ -1,4 +1,4 @@
-From 3f2c59f5654154a80b1fb978c8fa0b5a52c707b4 Mon Sep 17 00:00:00 2001
+From e19da6be6f513b0e2157d8af1948e6dbff2eac3e Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9

--- a/patches/6.18/0013-cameras.patch
+++ b/patches/6.18/0013-cameras.patch
@@ -1,4 +1,4 @@
-From 543b05525228ed555a763c4207e11f6c9355f32b Mon Sep 17 00:00:00 2001
+From 2a058a34f188ab3be922fe1200c086c13252db57 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -74,7 +74,7 @@ index ef16d58b2..a6bad2679 100644
 -- 
 2.52.0
 
-From a99581089b3d1df6d9982973b2d2c2fc30530024 Mon Sep 17 00:00:00 2001
+From 6bda96d594ca269da8926256cb086e59fc00cff4 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -184,7 +184,7 @@ index 9e31a5fe1..bdd32551c 100644
 -- 
 2.52.0
 
-From dca54560755ceecbed780d61e7935f4f9b73b01f Mon Sep 17 00:00:00 2001
+From 290c6c89be166c5543d305b22741d7a6c6f3d807 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -221,7 +221,7 @@ index 013340569..9e0763bdc 100644
 -- 
 2.52.0
 
-From df08cd915853c25601d57c3eba20de1fc66142fd Mon Sep 17 00:00:00 2001
+From 2cbe47df823def869c65420463eaa92cda15fa93 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -260,7 +260,7 @@ index 27afc3fc0..28b192c9a 100644
 -- 
 2.52.0
 
-From 388ea20ca3dc1d2341689908e685a892aa3ddc68 Mon Sep 17 00:00:00 2001
+From 6ec23248129504cacfb08f50ef80b899b7592970 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -311,7 +311,7 @@ index cb153ce42..f11b499e1 100644
 -- 
 2.52.0
 
-From 8b8cb7995f3524b791b99d73c0c07d7985db13e1 Mon Sep 17 00:00:00 2001
+From 708239c4ddcf7ebbdbde9306497c52726a6306b0 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -352,7 +352,7 @@ index 9e0763bdc..0976b2679 100644
 -- 
 2.52.0
 
-From e8b69207500fc57cd884611791e7bd902be0d6a3 Mon Sep 17 00:00:00 2001
+From 56ff2048b2c36c1b1f083468e48613d569c2edcd Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -393,7 +393,7 @@ index 7807fa329..2d2abb25b 100644
 -- 
 2.52.0
 
-From 78df6291c8680c90b325e3d3936614ed766b537a Mon Sep 17 00:00:00 2001
+From 46b0fe283977ad522ab99b482c9b970af7285027 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -644,7 +644,7 @@ index 000000000..35aeb5db8
 -- 
 2.52.0
 
-From 13f44051bfd17396abc876b53c732e15951160a2 Mon Sep 17 00:00:00 2001
+From cd773355136ca244f5e04390a46b3f2c3653b7c1 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2
@@ -676,7 +676,7 @@ index 032fbcb98..e03a1d8cd 100644
 -- 
 2.52.0
 
-From 228f2989668592d6fd7dbaf9afcb45a621f06489 Mon Sep 17 00:00:00 2001
+From a2a05ea7e835da551f645318ef14a50dcc524498 Mon Sep 17 00:00:00 2001
 From: Tooraj Taraz <tooraj.taraz@yahoo.com>
 Date: Wed, 31 Dec 2025 00:35:50 +0100
 Subject: [PATCH] Add camera support for Surface Pro 9

--- a/patches/6.18/0014-amd-gpio.patch
+++ b/patches/6.18/0014-amd-gpio.patch
@@ -1,4 +1,4 @@
-From 7de9c326ae3b13ac1c7d2fa69da742786e938acb Mon Sep 17 00:00:00 2001
+From 72e3b65e64b093ad572007bbb9f92b56124a42ff Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -65,7 +65,7 @@ index 9fa321a95..8914a922b 100644
 -- 
 2.52.0
 
-From c4785acab63b4f29bbbaf171d7bfd52aa21a2e40 Mon Sep 17 00:00:00 2001
+From bb776c1112b02d6fd8740fd165dd34897731c25d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override

--- a/patches/6.18/0015-rtc.patch
+++ b/patches/6.18/0015-rtc.patch
@@ -1,4 +1,4 @@
-From 4f883a2192301f67ce808158aba2af39522c00ae Mon Sep 17 00:00:00 2001
+From 7081c015deec8e2ea4e5ef8901c32dfb7a6d1202 Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms

--- a/patches/6.18/0016-hid-surface.patch
+++ b/patches/6.18/0016-hid-surface.patch
@@ -1,4 +1,4 @@
-From f201c243ea7f7a34d3c0743168b51b4cfa45d388 Mon Sep 17 00:00:00 2001
+From a3799500583c01fd98f47dab286b36671794d6e6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ciar=C3=A1n=20Coffey?= <github@ccoffey.ie>
 Date: Fri, 10 Oct 2025 19:04:03 +0100
 Subject: [PATCH] HID: Add hid-surface driver to filter BTN_0 (FN key)
@@ -156,7 +156,7 @@ index 000000000..a171ea656
 -- 
 2.52.0
 
-From ed2a9266036762ab98a801ee5bd0cb04442d4618 Mon Sep 17 00:00:00 2001
+From 64a421da7ba238bcdb942b87af797bd07bc3c205 Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Wed, 24 Dec 2025 00:54:44 -0800
 Subject: [PATCH] hid/multitouch: Prevent mode set on Surface Laptop Studio 2
@@ -168,7 +168,7 @@ Patchset: hid-surface
  1 file changed, 30 insertions(+)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 0eb4f7d12..8f2ed29b4 100644
+index c4179f6c3..d59fe2185 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -82,6 +82,7 @@ MODULE_LICENSE("GPL");
@@ -187,7 +187,7 @@ index 0eb4f7d12..8f2ed29b4 100644
  #define MT_CLS_SIS				0x0457
  
  #define MT_DEFAULT_MAXCONTACT	10
-@@ -449,6 +451,10 @@ static const struct mt_class mt_classes[] = {
+@@ -450,6 +452,10 @@ static const struct mt_class mt_classes[] = {
  			MT_QUIRK_WIN8_PTP_BUTTONS,
  		.export_all_inputs = true
  	},
@@ -198,7 +198,7 @@ index 0eb4f7d12..8f2ed29b4 100644
  	{ }
  };
  
-@@ -2180,11 +2186,30 @@ static void mt_remove(struct hid_device *hdev)
+@@ -2181,11 +2187,30 @@ static void mt_remove(struct hid_device *hdev)
  
  static void mt_on_hid_hw_open(struct hid_device *hdev)
  {
@@ -229,7 +229,7 @@ index 0eb4f7d12..8f2ed29b4 100644
  	mt_set_modes(hdev, HID_LATENCY_HIGH, TOUCHPAD_REPORT_NONE);
  }
  
-@@ -2621,6 +2646,11 @@ static const struct hid_device_id mt_devices[] = {
+@@ -2622,6 +2647,11 @@ static const struct hid_device_id mt_devices[] = {
  		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY,
  			USB_VENDOR_ID_MICROSOFT, 0x09c0) },
  

--- a/patches/6.18/0017-powercap.patch
+++ b/patches/6.18/0017-powercap.patch
@@ -1,4 +1,4 @@
-From 465b1c71a2c4bad54e9b84e02de93322df88d202 Mon Sep 17 00:00:00 2001
+From a01da84da9bc2b543438b0626c61ef2f3047c420 Mon Sep 17 00:00:00 2001
 From: Daniel Tang <danielzgtg.opensource@gmail.com>
 Date: Wed, 14 Jan 2026 20:31:38 -0500
 Subject: [PATCH] powercap: intel_rapl: Add PL4 support for Ice Lake


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.18** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.18-surface`
- **Base version**: `v6.18.11`
- **Patches generated**: 17
- **Patches directory**: `patches/6.18/`

### Changes
This PR updates kernel patches to the latest version from the `v6.18-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.18-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.