### PR TITLE
patches/v6.18: Automatic update to v6.18.15

### DIFF
--- a/patches/6.18/0001-secureboot.patch
+++ b/patches/6.18/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From 4b4ce7116b7c0ad7d1e51ad619b9eb81d66af13b Mon Sep 17 00:00:00 2001
+From 9412ec0a4367dba3d49b08c5be2c7897909ad170 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -33,9 +33,9 @@ index 9bea5a1e2..25848f886 100644
  	.long	0				# SizeOfStackReserve
  	.long	0				# SizeOfStackCommit
 -- 
-2.52.0
+2.53.0
 
-From a60e892a264dac56d17c0eef4af8b6248c271444 Mon Sep 17 00:00:00 2001
+From 7543fc3ab11366b07683c09426539550ee448a07 Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter
@@ -108,5 +108,5 @@ index 26e45f86b..8ec46d456 100644
  __setup("nohibernate", nohibernate_setup);
 +__setup("lockdown_hibernate", lockdown_hibernate_setup);
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0002-surface3.patch
+++ b/patches/6.18/0002-surface3.patch
@@ -1,4 +1,4 @@
-From 5e759ec36f6a4329bda2f6fc1d13390a1b6b7074 Mon Sep 17 00:00:00 2001
+From 78a1aba1d17b4d21cf4b5bd6a1c198ef221fce98 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI
@@ -97,9 +97,9 @@ index e4c3492a0..0b930c91b 100644
  };
  
 -- 
-2.52.0
+2.53.0
 
-From 4a41660055f580887775fda819a09aae4e7fa4bb Mon Sep 17 00:00:00 2001
+From 85706f7075943ffe39f327721c898d9d1fef43c7 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
 Subject: [PATCH] surface3-spi: workaround: disable DMA mode to avoid crash by
@@ -230,5 +230,5 @@ index 6074b7730..6aa3e1d6f 100644
  }
  
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0003-mwifiex.patch
+++ b/patches/6.18/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From b6b1c95e100682c8674b3db7155f8bc60a453171 Mon Sep 17 00:00:00 2001
+From 45d35540c439d252607aa190ca0dc1a622f18a40 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -163,9 +163,9 @@ index d6ff964ae..5d30ae39d 100644
  void mwifiex_initialize_quirks(struct pcie_service_card *card);
  int mwifiex_pcie_reset_d3cold_quirk(struct pci_dev *pdev);
 -- 
-2.52.0
+2.53.0
 
-From 6c0913443c9ba701b349a05f4f1672b1278b8f8b Mon Sep 17 00:00:00 2001
+From bcee2861f1aa74e4e6709a918b6679e75a068d1f Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -318,9 +318,9 @@ index 5d30ae39d..c14eb56eb 100644
  void mwifiex_initialize_quirks(struct pcie_service_card *card);
  int mwifiex_pcie_reset_d3cold_quirk(struct pci_dev *pdev);
 -- 
-2.52.0
+2.53.0
 
-From 72d0eb8d4a676652ec58e7e707e5f4cd6d51b30d Mon Sep 17 00:00:00 2001
+From c81db79b0ec5a97fbebb990a7214a061971676ca Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell
@@ -396,5 +396,5 @@ index a953fa9af..7e4670599 100644
  	    (id->driver_info & BTUSB_MEDIATEK)) {
  		hdev->setup = btusb_mtk_setup;
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0004-ath10k.patch
+++ b/patches/6.18/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From 7d52f30be7f191a3f4206e6cb43b43c66b3b30df Mon Sep 17 00:00:00 2001
+From 808098a1de903d77e33549c9af585f4490fe922e Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files
@@ -116,5 +116,5 @@ index 9ae3595fb..b26a39c97 100644
  		snprintf(filename, sizeof(filename), "%s/%s/%s",
  			 dir, ar->board_name, file);
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0005-ipts.patch
+++ b/patches/6.18/0005-ipts.patch
@@ -1,4 +1,4 @@
-From 0c42d3ef5be780bec2767ad0910ab96200ad50f8 Mon Sep 17 00:00:00 2001
+From 8d7b230709a5e6d1de3c02e104c05cb7ea629f96 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -35,9 +35,9 @@ index 2a6e56955..c19dfba54 100644
  
  	{MEI_PCI_DEVICE(MEI_DEV_ID_TGP_LP, MEI_ME_PCH15_CFG)},
 -- 
-2.52.0
+2.53.0
 
-From 0dddf0a24b18680fa269a0d3a7b4c87597fc2535 Mon Sep 17 00:00:00 2001
+From 1dbcc354b741d9e76cb7bc9f6a75dd9bf3399e7c Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -61,7 +61,7 @@ Patchset: ipts
  1 file changed, 29 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index e236c7ec2..9e31a5fe1 100644
+index 49e83c856..a3e35c77d 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -39,6 +39,11 @@
@@ -91,7 +91,7 @@ index e236c7ec2..9e31a5fe1 100644
  
  const struct iommu_ops intel_iommu_ops;
  static const struct iommu_dirty_ops intel_dirty_ops;
-@@ -1879,6 +1886,9 @@ static int device_def_domain_type(struct device *dev)
+@@ -1881,6 +1888,9 @@ static int device_def_domain_type(struct device *dev)
  
  		if ((iommu_identity_mapping & IDENTMAP_AZALIA) && IS_AZALIA(pdev))
  			return IOMMU_DOMAIN_IDENTITY;
@@ -101,7 +101,7 @@ index e236c7ec2..9e31a5fe1 100644
  	}
  
  	return 0;
-@@ -2169,6 +2179,9 @@ static int __init init_dmars(void)
+@@ -2171,6 +2181,9 @@ static int __init init_dmars(void)
  		iommu_set_root_entry(iommu);
  	}
  
@@ -111,7 +111,7 @@ index e236c7ec2..9e31a5fe1 100644
  	check_tylersburg_isoch();
  
  	/*
-@@ -4515,6 +4528,18 @@ static void quirk_iommu_igfx(struct pci_dev *dev)
+@@ -4517,6 +4530,18 @@ static void quirk_iommu_igfx(struct pci_dev *dev)
  	disable_igfx_iommu = 1;
  }
  
@@ -130,7 +130,7 @@ index e236c7ec2..9e31a5fe1 100644
  /* G4x/GM45 integrated gfx dmar support is totally busted. */
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x2a40, quirk_iommu_igfx);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x2e00, quirk_iommu_igfx);
-@@ -4553,6 +4578,10 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x1632, quirk_iommu_igfx);
+@@ -4555,6 +4580,10 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x1632, quirk_iommu_igfx);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x163A, quirk_iommu_igfx);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x163D, quirk_iommu_igfx);
  
@@ -142,9 +142,9 @@ index e236c7ec2..9e31a5fe1 100644
  {
  	if (risky_device(dev))
 -- 
-2.52.0
+2.53.0
 
-From 2d3ebe8da80b712d62f6556bd35bfec0cbd8855b Mon Sep 17 00:00:00 2001
+From 8563cac2ccd2b4f0d03a4b5aa2c1beac5454acc6 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus
@@ -3239,5 +3239,5 @@ index 000000000..1f966b8b3
 +
 +#endif /* IPTS_THREAD_H */
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0006-ithc.patch
+++ b/patches/6.18/0006-ithc.patch
@@ -1,4 +1,4 @@
-From d52e2510add1b174d32ac5476fbee0138f642261 Mon Sep 17 00:00:00 2001
+From bc0df8a2c5d563e483417e7787502fff448ccc55 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -37,9 +37,9 @@ index 8bcbfe3d9..c78806d35 100644
  	 * DMA alias provides us with a PCI device and alias.  The only case
  	 * where the it will return an alias on a different bus than the
 -- 
-2.52.0
+2.53.0
 
-From bcae5998d9e659722f1c1912690efbe11afc13f9 Mon Sep 17 00:00:00 2001
+From 575e1388156a64c57bbd8a8215c69dde8660b997 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller
@@ -2776,5 +2776,5 @@ index 000000000..aec320d4e
 +int ithc_reset(struct ithc *ithc);
 +
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0007-surface-sam.patch
+++ b/patches/6.18/0007-surface-sam.patch
@@ -1,4 +1,4 @@
-From d64b237185aec90aab4278469a5a826348065b3f Mon Sep 17 00:00:00 2001
+From 36f54d6d5e37c0e414302dac292c53cc1d1462f4 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
 Subject: [PATCH] rtc: Add basic support for RTC via Surface System Aggregator
@@ -179,9 +179,9 @@ index 000000000..f6c17c4e9
 +MODULE_DESCRIPTION("RTC driver for Surface System Aggregator Module");
 +MODULE_LICENSE("GPL");
 -- 
-2.52.0
+2.53.0
 
-From 9a5f80d5b74c3ff8d31f2b22e37bcc4792d91a23 Mon Sep 17 00:00:00 2001
+From 02583690b1e0bde30845676bb7ee107ce3ae3c03 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
 Subject: [PATCH] platform/surface: aggregator_registry: Add Surface Laptop 7
@@ -207,5 +207,5 @@ index a594d5fcf..07b03aa4f 100644
  	{ "MSHW0118", (unsigned long)ssam_node_group_slg1 },
  
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0008-surface-sam-over-hid.patch
+++ b/patches/6.18/0008-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From aea01d05f5e71da926fbac44c158ce1d7fe98562 Mon Sep 17 00:00:00 2001
+From 05db25c3bbe01a872263d5f7c9ee6c99563d166c Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -107,9 +107,9 @@ index ed90858a2..070c36637 100644
  		dev_warn(&adapter->dev, "protocol 0x%02x not supported for client 0x%02x\n",
  			 accessor_type, client->addr);
 -- 
-2.52.0
+2.53.0
 
-From 08a08c034bbc0f8d4c11ff60c7d078c6de5542af Mon Sep 17 00:00:00 2001
+From f1699f8ab47b35b6da492a4f3d39b23a180ea01c Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch
@@ -304,5 +304,5 @@ index 000000000..68db23773
 +MODULE_DESCRIPTION("Discrete GPU Power-Switch for Surface Book 1");
 +MODULE_LICENSE("GPL");
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0009-surface-button.patch
+++ b/patches/6.18/0009-surface-button.patch
@@ -1,4 +1,4 @@
-From cad7c632ef22427f26dceb4e1a3b0d5d143991d8 Mon Sep 17 00:00:00 2001
+From d1df0bae120e18b13d8feffc95c393709fe6ecbf Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -73,9 +73,9 @@ index b8cad415c..43b5d5638 100644
  
  /*
 -- 
-2.52.0
+2.53.0
 
-From f1c04affde903b94f8cd1e37c48a6a92dc280443 Mon Sep 17 00:00:00 2001
+From 88923f576fe1a9422035bc83de218d6d70f630a9 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd
@@ -145,5 +145,5 @@ index 2755601f9..4240c98ca 100644
  
  
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0010-surface-typecover.patch
+++ b/patches/6.18/0010-surface-typecover.patch
@@ -1,4 +1,4 @@
-From 7480aa8ac22d073ca9e6d56305bcf7eb578955e9 Mon Sep 17 00:00:00 2001
+From a701eba4fc75763e6b1bb027a9ff968d0a542e38 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -37,9 +37,9 @@ index c4d85089d..3d0d35c72 100644
  	{ USB_DEVICE(0x046a, 0x0023), .driver_info = USB_QUIRK_RESET_RESUME },
  
 -- 
-2.52.0
+2.53.0
 
-From 09d6209e5e3de8e20d764975e783a155ede483ce Mon Sep 17 00:00:00 2001
+From c209067470c24c9573d3eb860bca1919b53bc09e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -272,9 +272,9 @@ index a0c1ad5ac..2cd18fe61 100644
  	{ .driver_data = MT_CLS_GOOGLE,
  		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY, USB_VENDOR_ID_GOOGLE,
 -- 
-2.52.0
+2.53.0
 
-From 9a451e7c0c26329ad8e334238c601cc2e1c4cf0a Mon Sep 17 00:00:00 2001
+From 1419b33d01f6c5918f953453e2ae804fb12b521f Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet
@@ -571,5 +571,5 @@ index 2cd18fe61..c4179f6c3 100644
  	unregister_pm_notifier(&td->pm_notifier);
  	timer_delete_sync(&td->release_timer);
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0011-surface-shutdown.patch
+++ b/patches/6.18/0011-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From f6f5d63846d4b868464b914ec63baf2ef000d95a Mon Sep 17 00:00:00 2001
+From 8fec826a4428dbca54ebfeefed7fa310fc37bdc7 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
@@ -37,10 +37,10 @@ index 327b21c48..51dd5e10f 100644
  
  	if (drv && drv->shutdown)
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index b9c252aa6..ce4c0da99 100644
+index 9e073321b..db17ae875 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -6341,3 +6341,39 @@ static void pci_mask_replay_timer_timeout(struct pci_dev *pdev)
+@@ -6346,3 +6346,39 @@ static void pci_mask_replay_timer_timeout(struct pci_dev *pdev)
  DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_GLI, 0x9750, pci_mask_replay_timer_timeout);
  DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_GLI, 0x9755, pci_mask_replay_timer_timeout);
  #endif
@@ -93,9 +93,9 @@ index bf97d49c2..90eead93d 100644
  	atomic_t	enable_cnt;	/* pci_enable_device has been called */
  
 -- 
-2.52.0
+2.53.0
 
-From e37ed31e23703d9f2f210e26677d41ef3dde634b Mon Sep 17 00:00:00 2001
+From f3d545071c4055b5495c45ee13572126599e0984 Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Wed, 7 Jan 2026 01:06:25 +0100
 Subject: [PATCH] PCI: Add Surface Laptop Studio 2 devices to shutdown ops
@@ -108,10 +108,10 @@ Patchset: surface-shutdown
  1 file changed, 13 insertions(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index ce4c0da99..fdc410bf7 100644
+index db17ae875..142b70c4e 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -6360,6 +6360,13 @@ static const struct dmi_system_id no_shutdown_dmi_table[] = {
+@@ -6365,6 +6365,13 @@ static const struct dmi_system_id no_shutdown_dmi_table[] = {
  			DMI_MATCH(DMI_PRODUCT_NAME, "Surface Laptop 5"),
  		},
  	},
@@ -125,7 +125,7 @@ index ce4c0da99..fdc410bf7 100644
  	{}
  };
  
-@@ -6377,3 +6384,9 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x461f, quirk_no_shutdown);  // Thu
+@@ -6382,3 +6389,9 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x461f, quirk_no_shutdown);  // Thu
  DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x462f, quirk_no_shutdown);  // Thunderbolt 4 PCI Express Root Port
  DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x466d, quirk_no_shutdown);  // Thunderbolt 4 NHI
  DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x46a8, quirk_no_shutdown);  // GPU
@@ -136,5 +136,5 @@ index ce4c0da99..fdc410bf7 100644
 +DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa73e, quirk_no_shutdown);  // Thunderbolt 4 NHI
 +DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa7a0, quirk_no_shutdown);  // GPU
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0012-surface-gpe.patch
+++ b/patches/6.18/0012-surface-gpe.patch
@@ -1,4 +1,4 @@
-From fe14472400b7156fb3fdb8fc9108018da180da32 Mon Sep 17 00:00:00 2001
+From 864ceb0e76cf9e161d1b887e02dc86419a2fe5f8 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9
@@ -47,5 +47,5 @@ index b35941390..b4496db79 100644
  		.ident = "Surface Book 1",
  		.matches = {
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0013-cameras.patch
+++ b/patches/6.18/0013-cameras.patch
@@ -1,4 +1,4 @@
-From 79d2acffafb8f9dfd0615feaf3681ad6f544654b Mon Sep 17 00:00:00 2001
+From f62ef5c6c2bb1ca38cfcc0a7f915bd06b619c6b2 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -72,9 +72,9 @@ index ef16d58b2..a6bad2679 100644
  	 * Do not enumerate devices with enumeration_by_parent flag set as
  	 * they will be enumerated by their respective parents.
 -- 
-2.52.0
+2.53.0
 
-From 8d0914e088c9a8303ff59fd76b0efb63fcb66fcb Mon Sep 17 00:00:00 2001
+From e2485f6846c281b00ca7b3a20540889689b67d93 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -100,7 +100,7 @@ Patchset: cameras
  1 file changed, 30 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index 9e31a5fe1..bdd32551c 100644
+index a3e35c77d..28567ba59 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -44,6 +44,13 @@
@@ -132,7 +132,7 @@ index 9e31a5fe1..bdd32551c 100644
  #define IDENTMAP_IPTS		16
  
  const struct iommu_ops intel_iommu_ops;
-@@ -1887,6 +1896,9 @@ static int device_def_domain_type(struct device *dev)
+@@ -1889,6 +1898,9 @@ static int device_def_domain_type(struct device *dev)
  		if ((iommu_identity_mapping & IDENTMAP_AZALIA) && IS_AZALIA(pdev))
  			return IOMMU_DOMAIN_IDENTITY;
  
@@ -142,7 +142,7 @@ index 9e31a5fe1..bdd32551c 100644
  		if ((iommu_identity_mapping & IDENTMAP_IPTS) && IS_IPTS(pdev))
  			return IOMMU_DOMAIN_IDENTITY;
  	}
-@@ -2179,6 +2191,9 @@ static int __init init_dmars(void)
+@@ -2181,6 +2193,9 @@ static int __init init_dmars(void)
  		iommu_set_root_entry(iommu);
  	}
  
@@ -152,7 +152,7 @@ index 9e31a5fe1..bdd32551c 100644
  	if (!dmar_map_ipts)
  		iommu_identity_mapping |= IDENTMAP_IPTS;
  
-@@ -4528,6 +4543,18 @@ static void quirk_iommu_igfx(struct pci_dev *dev)
+@@ -4530,6 +4545,18 @@ static void quirk_iommu_igfx(struct pci_dev *dev)
  	disable_igfx_iommu = 1;
  }
  
@@ -171,7 +171,7 @@ index 9e31a5fe1..bdd32551c 100644
  static void quirk_iommu_ipts(struct pci_dev *dev)
  {
  	if (!IS_IPTS(dev))
-@@ -4578,6 +4605,9 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x1632, quirk_iommu_igfx);
+@@ -4580,6 +4607,9 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x1632, quirk_iommu_igfx);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x163A, quirk_iommu_igfx);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x163D, quirk_iommu_igfx);
  
@@ -182,9 +182,9 @@ index 9e31a5fe1..bdd32551c 100644
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x9D3E, quirk_iommu_ipts);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x34E4, quirk_iommu_ipts);
 -- 
-2.52.0
+2.53.0
 
-From d5b1ddd3cc136ba7710e4781a4bcd08fea0ed6fa Mon Sep 17 00:00:00 2001
+From 0fca5d63d59c1814035fc9f3266e80247469f02e Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -219,9 +219,9 @@ index 013340569..9e0763bdc 100644
  
  	return 0;
 -- 
-2.52.0
+2.53.0
 
-From 4d89428772cec0f47fba2a04dd663f21df1d20d6 Mon Sep 17 00:00:00 2001
+From 3bf17b5bb08e34876378c1ea8712721259ccb1f7 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -258,9 +258,9 @@ index 27afc3fc0..28b192c9a 100644
  				     V4L2_CID_TEST_PATTERN,
  				     ARRAY_SIZE(ov7251_test_pattern_menu) - 1,
 -- 
-2.52.0
+2.53.0
 
-From 12273c1327ac6f6249dc771f125dfb4a93583593 Mon Sep 17 00:00:00 2001
+From 93fa7e20d12a117b9576bf922b2675f71646ed86 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -309,9 +309,9 @@ index cb153ce42..f11b499e1 100644
  	if (ret < 0)
  		goto out_cleanup;
 -- 
-2.52.0
+2.53.0
 
-From a1d8907d34da038a7caeeae5258de037db32b48d Mon Sep 17 00:00:00 2001
+From 1b58827f602d48de182fa325ec43bb840c886f78 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -350,9 +350,9 @@ index 9e0763bdc..0976b2679 100644
  		for (i = 0; i < board_data->n_gpiod_lookups; i++)
  			gpiod_add_lookup_table(board_data->tps68470_gpio_lookup_tables[i]);
 -- 
-2.52.0
+2.53.0
 
-From 16d8bb8adce156323c6c2d698fbbfc3846a5a760 Mon Sep 17 00:00:00 2001
+From bf12c640346fa42ffcde7b3844c14296fd068b80 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -391,9 +391,9 @@ index 7807fa329..2d2abb25b 100644
 +
  #endif /* __LINUX_MFD_TPS68470_H */
 -- 
-2.52.0
+2.53.0
 
-From 93b8ec92a713fbe3846eee21d24f4b1a53dea456 Mon Sep 17 00:00:00 2001
+From 6605ebaea2328e2a8fc56e0e8931d026d798f653 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -642,9 +642,9 @@ index 000000000..35aeb5db8
 +MODULE_DESCRIPTION("LED driver for TPS68470 PMIC");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.52.0
+2.53.0
 
-From f8485df32505cd4f3ab155c0723dac20fc4c6cc4 Mon Sep 17 00:00:00 2001
+From 1a04f4d35f23bee257eca09006bf4ba45090486c Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2
@@ -674,9 +674,9 @@ index 032fbcb98..e03a1d8cd 100644
  	cci_write(dw9719->regmap, DW9719_CONTROL, DW9719_SHUTDOWN, &ret);
  	fsleep(100);
 -- 
-2.52.0
+2.53.0
 
-From ce276ac4c6169e6194f4af489a6aaa9d91b022fd Mon Sep 17 00:00:00 2001
+From d85232a2a24f17ea9c0019c6c392de019d89abe8 Mon Sep 17 00:00:00 2001
 From: Tooraj Taraz <tooraj.taraz@yahoo.com>
 Date: Wed, 31 Dec 2025 00:35:50 +0100
 Subject: [PATCH] Add camera support for Surface Pro 9
@@ -1015,5 +1015,5 @@ index 1505fc3ef..20962e8ac 100644
  			ret = -EINVAL;
  			break;
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0014-amd-gpio.patch
+++ b/patches/6.18/0014-amd-gpio.patch
@@ -1,4 +1,4 @@
-From 69c528d432300afb2d6f516bbeb5387f604f7c1a Mon Sep 17 00:00:00 2001
+From 9fe3d86d129d4f65c41052dc59b296168404e1a2 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -63,9 +63,9 @@ index 9fa321a95..8914a922b 100644
  	mp_config_acpi_legacy_irqs();
  
 -- 
-2.52.0
+2.53.0
 
-From ed986760aea58b450fd5d68a7680e5e89b13b956 Mon Sep 17 00:00:00 2001
+From 3c209d211e352bfc582014b49aa7cd22716bcc65 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override
@@ -105,5 +105,5 @@ index 8914a922b..c43d0a553 100644
  };
  
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0015-rtc.patch
+++ b/patches/6.18/0015-rtc.patch
@@ -1,4 +1,4 @@
-From 572c4db540d3260d10f88fe175faa8b095e81d47 Mon Sep 17 00:00:00 2001
+From 0bb7ff260d1a718576a47ed4f1bb004381cfe5a7 Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms
@@ -106,5 +106,5 @@ index 33418dd67..f94bbdc1d 100644
  		ret = sysfs_create_group(&dev->kobj, &acpi_tad_dc_attr_group);
  		if (ret)
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0016-hid-surface.patch
+++ b/patches/6.18/0016-hid-surface.patch
@@ -1,4 +1,4 @@
-From fcc0ca5789466264c908c7a793ee86f7848d3460 Mon Sep 17 00:00:00 2001
+From 660cf58c0f52affe196e79cdd2460394b461ed4a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ciar=C3=A1n=20Coffey?= <github@ccoffey.ie>
 Date: Fri, 10 Oct 2025 19:04:03 +0100
 Subject: [PATCH] HID: Add hid-surface driver to filter BTN_0 (FN key)
@@ -154,9 +154,9 @@ index 000000000..a171ea656
 +MODULE_DESCRIPTION("Microsoft Surface HID driver");
 +MODULE_LICENSE("GPL");
 -- 
-2.52.0
+2.53.0
 
-From 49aefa6d21438030fd0b59bbccaff01540ee679b Mon Sep 17 00:00:00 2001
+From e7137ec217a7d829d0c01834a2cda1597693296c Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Wed, 24 Dec 2025 00:54:44 -0800
 Subject: [PATCH] hid/multitouch: Prevent mode set on Surface Laptop Studio 2
@@ -242,5 +242,5 @@ index c4179f6c3..d59fe2185 100644
  	{ .driver_data = MT_CLS_GOOGLE,
  		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY, USB_VENDOR_ID_GOOGLE,
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.18/0017-powercap.patch
+++ b/patches/6.18/0017-powercap.patch
@@ -1,4 +1,4 @@
-From c142c6d09d7d2d877c7e590d90d9c0aa2b6dd075 Mon Sep 17 00:00:00 2001
+From e149dbd0264306f898a1ae81d42d277ec404e07c Mon Sep 17 00:00:00 2001
 From: Daniel Tang <danielzgtg.opensource@gmail.com>
 Date: Wed, 14 Jan 2026 20:31:38 -0500
 Subject: [PATCH] powercap: intel_rapl: Add PL4 support for Ice Lake
@@ -26,5 +26,5 @@ index c6b9a7deb..e82724768 100644
  	X86_MATCH_VFM(INTEL_ALDERLAKE, NULL),
  	X86_MATCH_VFM(INTEL_ALDERLAKE_L, NULL),
 -- 
-2.52.0
+2.53.0
 


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.18** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.18-surface`
- **Base version**: `v6.18.15`
- **Patches generated**: 17
- **Patches directory**: `patches/6.18/`

### Changes
This PR updates kernel patches to the latest version from the `v6.18-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.18-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.