### PR TITLE
patches/v6.12: Automatic update to v6.12.75

### DIFF
--- a/patches/6.12/0001-secureboot.patch
+++ b/patches/6.12/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From 8b1b5cd729869a871db085ccc43295634b09b09b Mon Sep 17 00:00:00 2001
+From f63282157cc28e27dd69c5fbc8611d6a00cea8c0 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -33,9 +33,9 @@ index b5c79f433..a1bbedd98 100644
  	.long	0				# SizeOfStackReserve
  	.long	0				# SizeOfStackCommit
 -- 
-2.52.0
+2.53.0
 
-From 8cf83548f5d2bb86f2d715927e42b39583a51153 Mon Sep 17 00:00:00 2001
+From 12c8824b183b5ebfb20cb6c08dbaed2f55c4bb76 Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter
@@ -108,5 +108,5 @@ index 85008ead2..48df5cfaf 100644
  __setup("nohibernate", nohibernate_setup);
 +__setup("lockdown_hibernate", lockdown_hibernate_setup);
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.12/0002-surface3-oemb.patch
+++ b/patches/6.12/0002-surface3-oemb.patch
@@ -1,4 +1,4 @@
-From 9d6c8c98203766acc3fe944da6518fc68183f3b4 Mon Sep 17 00:00:00 2001
+From 1dc3af4d2384e39ad8165fbc07012dfa65afcd00 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI
@@ -97,5 +97,5 @@ index e4c3492a0..0b930c91b 100644
  };
  
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.12/0003-mwifiex.patch
+++ b/patches/6.12/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From ba20c28fc68867c82de5787c33b729478c4843cf Mon Sep 17 00:00:00 2001
+From 798aed8adbfdde633991772d4407d45f48388f3b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -163,9 +163,9 @@ index d6ff964ae..5d30ae39d 100644
  void mwifiex_initialize_quirks(struct pcie_service_card *card);
  int mwifiex_pcie_reset_d3cold_quirk(struct pci_dev *pdev);
 -- 
-2.52.0
+2.53.0
 
-From 1371b01d866820cc362e5f15fbb411df69fd06a5 Mon Sep 17 00:00:00 2001
+From a74a4c7b02c1e7f1d4fe55635559b6105bc9feab Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -318,9 +318,9 @@ index 5d30ae39d..c14eb56eb 100644
  void mwifiex_initialize_quirks(struct pcie_service_card *card);
  int mwifiex_pcie_reset_d3cold_quirk(struct pci_dev *pdev);
 -- 
-2.52.0
+2.53.0
 
-From 47c8c0aaf3d54f2d46a2469c0555e9569b2ce131 Mon Sep 17 00:00:00 2001
+From faec3510de867cc85960b847fecb16f1cca46596 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell
@@ -356,7 +356,7 @@ Patchset: mwifiex
  1 file changed, 15 insertions(+)
 
 diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
-index 490efe4d6..e15f99ee3 100644
+index 9d3236321..1670a26e5 100644
 --- a/drivers/bluetooth/btusb.c
 +++ b/drivers/bluetooth/btusb.c
 @@ -66,6 +66,7 @@ static struct usb_driver btusb_driver;
@@ -375,7 +375,7 @@ index 490efe4d6..e15f99ee3 100644
  
  	/* Intel Bluetooth devices */
  	{ USB_DEVICE(0x8087, 0x0025), .driver_info = BTUSB_INTEL_COMBINED },
-@@ -4011,6 +4013,19 @@ static int btusb_probe(struct usb_interface *intf,
+@@ -4016,6 +4018,19 @@ static int btusb_probe(struct usb_interface *intf,
  	if (id->driver_info & BTUSB_MARVELL)
  		hdev->set_bdaddr = btusb_set_bdaddr_marvell;
  
@@ -396,5 +396,5 @@ index 490efe4d6..e15f99ee3 100644
  	    (id->driver_info & BTUSB_MEDIATEK)) {
  		hdev->setup = btusb_mtk_setup;
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.12/0004-ath10k.patch
+++ b/patches/6.12/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From abdf26688b6c761b03e6a56d310504e63519544a Mon Sep 17 00:00:00 2001
+From 7968d9bbdae94374e4bcc88220a45b1d66af5385 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files
@@ -116,5 +116,5 @@ index f9b51d98d..e04bac901 100644
  		snprintf(filename, sizeof(filename), "%s/%s/%s",
  			 dir, ar->board_name, file);
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.12/0005-ipts.patch
+++ b/patches/6.12/0005-ipts.patch
@@ -1,4 +1,4 @@
-From 41c0348077f9cb3df9ae7109ad3c60afa373347c Mon Sep 17 00:00:00 2001
+From 082dfdd653011ca5a41e34b255b0b65541137832 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -35,9 +35,9 @@ index 1e4edf896..61d1a8816 100644
  
  	{MEI_PCI_DEVICE(MEI_DEV_ID_TGP_LP, MEI_ME_PCH15_CFG)},
 -- 
-2.52.0
+2.53.0
 
-From f3802a79caac1ebbbf4780580982098c3beb38c7 Mon Sep 17 00:00:00 2001
+From d7b638d008e38b64a9fbf9d215fe949100acede1 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -61,7 +61,7 @@ Patchset: ipts
  1 file changed, 29 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index c799cc67d..65adfc813 100644
+index d4f852f71..b76109d5d 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -40,6 +40,11 @@
@@ -91,7 +91,7 @@ index c799cc67d..65adfc813 100644
  
  const struct iommu_ops intel_iommu_ops;
  static const struct iommu_dirty_ops intel_dirty_ops;
-@@ -2066,6 +2073,9 @@ static int device_def_domain_type(struct device *dev)
+@@ -2064,6 +2071,9 @@ static int device_def_domain_type(struct device *dev)
  
  		if ((iommu_identity_mapping & IDENTMAP_AZALIA) && IS_AZALIA(pdev))
  			return IOMMU_DOMAIN_IDENTITY;
@@ -101,7 +101,7 @@ index c799cc67d..65adfc813 100644
  	}
  
  	return 0;
-@@ -2364,6 +2374,9 @@ static int __init init_dmars(void)
+@@ -2362,6 +2372,9 @@ static int __init init_dmars(void)
  		iommu_set_root_entry(iommu);
  	}
  
@@ -111,7 +111,7 @@ index c799cc67d..65adfc813 100644
  	check_tylersburg_isoch();
  
  	/*
-@@ -4691,6 +4704,18 @@ static void quirk_iommu_igfx(struct pci_dev *dev)
+@@ -4684,6 +4697,18 @@ static void quirk_iommu_igfx(struct pci_dev *dev)
  	disable_igfx_iommu = 1;
  }
  
@@ -130,7 +130,7 @@ index c799cc67d..65adfc813 100644
  /* G4x/GM45 integrated gfx dmar support is totally busted. */
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x2a40, quirk_iommu_igfx);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x2e00, quirk_iommu_igfx);
-@@ -4729,6 +4754,10 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x1632, quirk_iommu_igfx);
+@@ -4722,6 +4747,10 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x1632, quirk_iommu_igfx);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x163A, quirk_iommu_igfx);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x163D, quirk_iommu_igfx);
  
@@ -142,9 +142,9 @@ index c799cc67d..65adfc813 100644
  {
  	if (risky_device(dev))
 -- 
-2.52.0
+2.53.0
 
-From 4e08db916e493aa8197a2d7a29f23d439ece7abf Mon Sep 17 00:00:00 2001
+From b3941d2544c88073cb878214ab2e66e0686b75f7 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus
@@ -211,10 +211,10 @@ Patchset: ipts
  create mode 100644 drivers/hid/ipts/thread.h
 
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index 95a4ede27..777d4619d 100644
+index f283f271d..4ce843941 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
-@@ -1388,4 +1388,6 @@ source "drivers/hid/amd-sfh-hid/Kconfig"
+@@ -1389,4 +1389,6 @@ source "drivers/hid/amd-sfh-hid/Kconfig"
  
  source "drivers/hid/surface-hid/Kconfig"
  
@@ -3237,5 +3237,5 @@ index 000000000..1f966b8b3
 +
 +#endif /* IPTS_THREAD_H */
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.12/0006-ithc.patch
+++ b/patches/6.12/0006-ithc.patch
@@ -1,4 +1,4 @@
-From 8a87179788582177344e3631f95e620104cb6e90 Mon Sep 17 00:00:00 2001
+From a8dd4515a251300b4af7fe1ffb15965ca2faef43 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -37,9 +37,9 @@ index 066e4cd6e..7b320d09d 100644
  	 * DMA alias provides us with a PCI device and alias.  The only case
  	 * where the it will return an alias on a different bus than the
 -- 
-2.52.0
+2.53.0
 
-From 081ec805c41368484ab34868192862970aa6fc8d Mon Sep 17 00:00:00 2001
+From dbf06fe7e07b0d0bee7397f24e32b7fa1e701f79 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller
@@ -86,10 +86,10 @@ Patchset: ithc
  create mode 100644 drivers/hid/ithc/ithc.h
 
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index 777d4619d..d23316df4 100644
+index 4ce843941..b051b7068 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
-@@ -1390,4 +1390,6 @@ source "drivers/hid/surface-hid/Kconfig"
+@@ -1391,4 +1391,6 @@ source "drivers/hid/surface-hid/Kconfig"
  
  source "drivers/hid/ipts/Kconfig"
  
@@ -2767,5 +2767,5 @@ index 000000000..aec320d4e
 +int ithc_reset(struct ithc *ithc);
 +
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.12/0007-surface-sam-over-hid.patch
+++ b/patches/6.12/0007-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From 2f42938beeefa2b8f5773f2fc913c3f13e8a3aef Mon Sep 17 00:00:00 2001
+From 074069a49db9b964a7c333773c60ede7e894ca79 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -107,9 +107,9 @@ index f43067f67..1761ca30e 100644
  		dev_warn(&adapter->dev, "protocol 0x%02x not supported for client 0x%02x\n",
  			 accessor_type, client->addr);
 -- 
-2.52.0
+2.53.0
 
-From 7aaf3683c5bd5b4d6648fdf9b62651150b4a7fd0 Mon Sep 17 00:00:00 2001
+From 9add8295b24884319a8a9272c715f5f2dde59b34 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch
@@ -304,5 +304,5 @@ index 000000000..68db23773
 +MODULE_DESCRIPTION("Discrete GPU Power-Switch for Surface Book 1");
 +MODULE_LICENSE("GPL");
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.12/0008-surface-button.patch
+++ b/patches/6.12/0008-surface-button.patch
@@ -1,4 +1,4 @@
-From 4aa6a238f270308804dd79d4c08821c6f4ef72d3 Mon Sep 17 00:00:00 2001
+From bc61a69145db166f29787abd02b1898828073213 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -73,9 +73,9 @@ index 5c5d407fe..4e1bfe90e 100644
  
  /*
 -- 
-2.52.0
+2.53.0
 
-From f24443be9df034a21f1e4ed326c5bb2a5ea71d66 Mon Sep 17 00:00:00 2001
+From 3216bf1e9f5d00624a16d123d350143e8e39726d Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd
@@ -145,5 +145,5 @@ index 2755601f9..4240c98ca 100644
  
  
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.12/0009-surface-typecover.patch
+++ b/patches/6.12/0009-surface-typecover.patch
@@ -1,4 +1,4 @@
-From f9b45cc859c8379e5f12d738f414292146328bbe Mon Sep 17 00:00:00 2001
+From aaa252e721fcf23ff0b6f9b7ee83251b9b3a16a9 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -37,9 +37,9 @@ index 323a949bb..abc2cdecd 100644
  	{ USB_DEVICE(0x046a, 0x0023), .driver_info = USB_QUIRK_RESET_RESUME },
  
 -- 
-2.52.0
+2.53.0
 
-From af01dfc089d8eebc52c1828c885e43749316b54a Mon Sep 17 00:00:00 2001
+From 236e83e7f1dac6387ed6eb5026d7353e3fce34fa Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -75,7 +75,7 @@ Patchset: surface-typecover
  1 file changed, 98 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index fcfc508d1..be4e0ebbc 100644
+index c3a914458..6ca3a3684 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -34,7 +34,10 @@
@@ -259,7 +259,7 @@ index fcfc508d1..be4e0ebbc 100644
  	del_timer_sync(&td->release_timer);
  
  	sysfs_remove_group(&hdev->dev.kobj, &mt_attribute_group);
-@@ -2315,6 +2406,11 @@ static const struct hid_device_id mt_devices[] = {
+@@ -2318,6 +2409,11 @@ static const struct hid_device_id mt_devices[] = {
  		MT_USB_DEVICE(USB_VENDOR_ID_XIROKU,
  			USB_DEVICE_ID_XIROKU_CSR2) },
  
@@ -272,9 +272,9 @@ index fcfc508d1..be4e0ebbc 100644
  	{ .driver_data = MT_CLS_GOOGLE,
  		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY, USB_VENDOR_ID_GOOGLE,
 -- 
-2.52.0
+2.53.0
 
-From 3874b935193791b6d142f64fb16071a77da3aa3e Mon Sep 17 00:00:00 2001
+From c12afb37f5aa25dd21704dac225007f8cfb88168 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet
@@ -303,7 +303,7 @@ Patchset: surface-typecover
  1 file changed, 122 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index be4e0ebbc..a1df34afc 100644
+index 6ca3a3684..5c6ae7de7 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -77,6 +77,7 @@ MODULE_LICENSE("GPL");
@@ -571,5 +571,5 @@ index be4e0ebbc..a1df34afc 100644
  	unregister_pm_notifier(&td->pm_notifier);
  	del_timer_sync(&td->release_timer);
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.12/0010-surface-shutdown.patch
+++ b/patches/6.12/0010-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From f9dad7420d256b7fa2b822db3112eeb32066f704 Mon Sep 17 00:00:00 2001
+From de65614845eabc804c3c4f471a60206e7ae823c0 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod
@@ -23,7 +23,7 @@ Patchset: surface-shutdown
  3 files changed, 40 insertions(+)
 
 diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
-index a00a2ce01..9754d756c 100644
+index 9846ab70c..38e674a1b 100644
 --- a/drivers/pci/pci-driver.c
 +++ b/drivers/pci/pci-driver.c
 @@ -505,6 +505,9 @@ static void pci_device_shutdown(struct device *dev)
@@ -37,10 +37,10 @@ index a00a2ce01..9754d756c 100644
  
  	if (drv && drv->shutdown)
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index 18fa918b4..7a7613264 100644
+index 3d05ea35c..62bca34b0 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -6338,3 +6338,39 @@ static void pci_mask_replay_timer_timeout(struct pci_dev *pdev)
+@@ -6365,3 +6365,39 @@ static void pci_mask_replay_timer_timeout(struct pci_dev *pdev)
  DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_GLI, 0x9750, pci_mask_replay_timer_timeout);
  DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_GLI, 0x9755, pci_mask_replay_timer_timeout);
  #endif
@@ -93,5 +93,5 @@ index 242ee3843..96753fb66 100644
  	atomic_t	enable_cnt;	/* pci_enable_device has been called */
  
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.12/0011-surface-gpe.patch
+++ b/patches/6.12/0011-surface-gpe.patch
@@ -1,4 +1,4 @@
-From 35390087776e895b07f81f0af75cb21814b61e9e Mon Sep 17 00:00:00 2001
+From 4527bcfd0904e8041c190b623defe9da5051e49b Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9
@@ -47,5 +47,5 @@ index 62fd4004d..103fc4468 100644
  		.ident = "Surface Book 1",
  		.matches = {
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.12/0012-cameras.patch
+++ b/patches/6.12/0012-cameras.patch
@@ -1,4 +1,4 @@
-From d0296461bb4c7a98b2a8fc0234c841a8c0adea30 Mon Sep 17 00:00:00 2001
+From a3bc58e818797607dc0b6a584fde113b6c1adbe0 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -72,9 +72,9 @@ index ba98763ce..6021907ec 100644
  	 * Do not enumerate devices with enumeration_by_parent flag set as
  	 * they will be enumerated by their respective parents.
 -- 
-2.52.0
+2.53.0
 
-From 759e596605e96b0f66e3cda1cd757386c80fc2f6 Mon Sep 17 00:00:00 2001
+From 9c829df1fa12a5a94ff55887c09186509bd5a781 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -100,7 +100,7 @@ Patchset: cameras
  1 file changed, 30 insertions(+)
 
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index 65adfc813..3dcabd6c5 100644
+index b76109d5d..06b2d4a85 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -45,6 +45,13 @@
@@ -132,7 +132,7 @@ index 65adfc813..3dcabd6c5 100644
  #define IDENTMAP_IPTS		16
  
  const struct iommu_ops intel_iommu_ops;
-@@ -2074,6 +2083,9 @@ static int device_def_domain_type(struct device *dev)
+@@ -2072,6 +2081,9 @@ static int device_def_domain_type(struct device *dev)
  		if ((iommu_identity_mapping & IDENTMAP_AZALIA) && IS_AZALIA(pdev))
  			return IOMMU_DOMAIN_IDENTITY;
  
@@ -142,7 +142,7 @@ index 65adfc813..3dcabd6c5 100644
  		if ((iommu_identity_mapping & IDENTMAP_IPTS) && IS_IPTS(pdev))
  			return IOMMU_DOMAIN_IDENTITY;
  	}
-@@ -2374,6 +2386,9 @@ static int __init init_dmars(void)
+@@ -2372,6 +2384,9 @@ static int __init init_dmars(void)
  		iommu_set_root_entry(iommu);
  	}
  
@@ -152,7 +152,7 @@ index 65adfc813..3dcabd6c5 100644
  	if (!dmar_map_ipts)
  		iommu_identity_mapping |= IDENTMAP_IPTS;
  
-@@ -4704,6 +4719,18 @@ static void quirk_iommu_igfx(struct pci_dev *dev)
+@@ -4697,6 +4712,18 @@ static void quirk_iommu_igfx(struct pci_dev *dev)
  	disable_igfx_iommu = 1;
  }
  
@@ -171,7 +171,7 @@ index 65adfc813..3dcabd6c5 100644
  static void quirk_iommu_ipts(struct pci_dev *dev)
  {
  	if (!IS_IPTS(dev))
-@@ -4754,6 +4781,9 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x1632, quirk_iommu_igfx);
+@@ -4747,6 +4774,9 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x1632, quirk_iommu_igfx);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x163A, quirk_iommu_igfx);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x163D, quirk_iommu_igfx);
  
@@ -182,9 +182,9 @@ index 65adfc813..3dcabd6c5 100644
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x9D3E, quirk_iommu_ipts);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x34E4, quirk_iommu_ipts);
 -- 
-2.52.0
+2.53.0
 
-From 1f9943aad6051f1db715ee97dadffd4c370c0114 Mon Sep 17 00:00:00 2001
+From 618e368e26613480c69f895577fc8a0abf3e7531 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -219,9 +219,9 @@ index 81ac4c691..f453c9043 100644
  
  	return 0;
 -- 
-2.52.0
+2.53.0
 
-From f8915a8e39e48cc7812980b2a5e3921c4233e77e Mon Sep 17 00:00:00 2001
+From c191689bf64dffb9dc7598ade76620f031fedf7f Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Thu, 2 Mar 2023 12:59:39 +0000
 Subject: [PATCH] platform/x86: int3472: Remap reset GPIO for INT347E
@@ -275,9 +275,9 @@ index 9e69ac9cf..d6003198a 100644
  					    agpio, func, gpio_flags);
  	if (ret)
 -- 
-2.52.0
+2.53.0
 
-From 24fe1fd44f8dce69d810881dd42f02db50ff82d2 Mon Sep 17 00:00:00 2001
+From de57e33625c7f504b49e7b65c8ff9d9d673c9ed1 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -314,9 +314,9 @@ index 3226888d7..3bfe45b76 100644
  				     V4L2_CID_TEST_PATTERN,
  				     ARRAY_SIZE(ov7251_test_pattern_menu) - 1,
 -- 
-2.52.0
+2.53.0
 
-From ff6de3ab3241447e8076cf58462215901a5e625b Mon Sep 17 00:00:00 2001
+From d59aa4812493c858ac2160bbbe0576b4ca10b639 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -335,10 +335,10 @@ Patchset: cameras
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/media/v4l2-core/v4l2-async.c b/drivers/media/v4l2-core/v4l2-async.c
-index ee884a822..4f6bafd90 100644
+index 1c08bba9e..57a990d7d 100644
 --- a/drivers/media/v4l2-core/v4l2-async.c
 +++ b/drivers/media/v4l2-core/v4l2-async.c
-@@ -799,6 +799,10 @@ int __v4l2_async_register_subdev(struct v4l2_subdev *sd, struct module *module)
+@@ -811,6 +811,10 @@ int __v4l2_async_register_subdev(struct v4l2_subdev *sd, struct module *module)
  
  	INIT_LIST_HEAD(&sd->asc_list);
  
@@ -365,9 +365,9 @@ index f19c8adf2..923ed1b5a 100644
  	if (ret < 0)
  		goto out_cleanup;
 -- 
-2.52.0
+2.53.0
 
-From b928afccb5e17b202cfd8a55e960b0360a2dc0f7 Mon Sep 17 00:00:00 2001
+From 3ff8eea3018971c071645fe4b928490ed73c4b95 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -406,9 +406,9 @@ index f453c9043..b8ad6b413 100644
  		for (i = 0; i < board_data->n_gpiod_lookups; i++)
  			gpiod_add_lookup_table(board_data->tps68470_gpio_lookup_tables[i]);
 -- 
-2.52.0
+2.53.0
 
-From 5230e237ca2ebcdcc24e1c43384ce3f76c515aa0 Mon Sep 17 00:00:00 2001
+From 2de1f078536cf9622238aac3aa9be7eea6be08f6 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -447,9 +447,9 @@ index 7807fa329..2d2abb25b 100644
 +
  #endif /* __LINUX_MFD_TPS68470_H */
 -- 
-2.52.0
+2.53.0
 
-From 55d90afcd6b17799059e0a1c7ee7b37276a838ba Mon Sep 17 00:00:00 2001
+From a2562288de6015bea6e3941782bd8219a1506d28 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -698,9 +698,9 @@ index 000000000..35aeb5db8
 +MODULE_DESCRIPTION("LED driver for TPS68470 PMIC");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.52.0
+2.53.0
 
-From 7040a2341b90a9d6792d2c5f763ed52a37e28318 Mon Sep 17 00:00:00 2001
+From 1e5431f0c4ec3537f44613d922d159bbbbb69c5c Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2
@@ -730,5 +730,5 @@ index c626ed845..0094cfda5 100644
  	cci_write(dw9719->regmap, DW9719_CONTROL, 1, &ret);
  
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.12/0013-amd-gpio.patch
+++ b/patches/6.12/0013-amd-gpio.patch
@@ -1,4 +1,4 @@
-From d2977155e31799f8789cbcef4fd860038361c158 Mon Sep 17 00:00:00 2001
+From 1ea5a9f4dea2e36cc17d622032846af34621a5bf Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -63,9 +63,9 @@ index 63adda8a1..00914222a 100644
  	mp_config_acpi_legacy_irqs();
  
 -- 
-2.52.0
+2.53.0
 
-From 19369b388a100af758315e58bcb8a2f71488ebef Mon Sep 17 00:00:00 2001
+From ee57390ffd2a21523b88c1f85abd6a6a11b651c1 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override
@@ -105,5 +105,5 @@ index 00914222a..2b35bb58b 100644
  };
  
 -- 
-2.52.0
+2.53.0
 

--- a/patches/6.12/0014-rtc.patch
+++ b/patches/6.12/0014-rtc.patch
@@ -1,4 +1,4 @@
-From 73e1b53a85f74573a273a42358563a9748ee952c Mon Sep 17 00:00:00 2001
+From 70437e4e402bbcbbd5c2548dc817450ad5481cfb Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms
@@ -106,5 +106,5 @@ index b75ceaab7..3dfcfd32d 100644
  		ret = sysfs_create_group(&dev->kobj, &acpi_tad_dc_attr_group);
  		if (ret)
 -- 
-2.52.0
+2.53.0
 


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.12** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.12-surface`
- **Base version**: `v6.12.75`
- **Patches generated**: 14
- **Patches directory**: `patches/6.12/`

### Changes
This PR updates kernel patches to the latest version from the `v6.12-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.12-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.