### PR TITLE
patches/v6.18: Automatic update to v6.18.18

### DIFF
--- a/patches/6.18/0001-secureboot.patch
+++ b/patches/6.18/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From eba5e12b81b4d83ed0e11ecc6a6943f72d80a877 Mon Sep 17 00:00:00 2001
+From b342b1a9a445ba8b8aa73b945f25740e3cd8da58 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -35,7 +35,7 @@ index 9bea5a1e2..25848f886 100644
 -- 
 2.53.0
 
-From 619c5d07ffbbb58b4db1889d92810b617d80efca Mon Sep 17 00:00:00 2001
+From b106412124df576bc860bb2fdf1e1d3678a3fe75 Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter

--- a/patches/6.18/0002-surface3.patch
+++ b/patches/6.18/0002-surface3.patch
@@ -1,4 +1,4 @@
-From 160f6904e9ad7e4a85ef37528386df468ed4a61b Mon Sep 17 00:00:00 2001
+From 0a7aed31749d66652fd63b5843fa6b97febdb2d1 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI
@@ -99,7 +99,7 @@ index e4c3492a0..0b930c91b 100644
 -- 
 2.53.0
 
-From 74659866d3a11f0effe87b52b20a8120a50d02fe Mon Sep 17 00:00:00 2001
+From 4dcd8430344c4c7d852ffc32e3ad29ee7313e371 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
 Subject: [PATCH] surface3-spi: workaround: disable DMA mode to avoid crash by

--- a/patches/6.18/0003-mwifiex.patch
+++ b/patches/6.18/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From 6fef82bcc4edac718ab9f73f653be5bac8251009 Mon Sep 17 00:00:00 2001
+From 126a8c1d504d8377d222b88bc2d19313eacf8244 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -165,7 +165,7 @@ index d6ff964ae..5d30ae39d 100644
 -- 
 2.53.0
 
-From a15f448edf557b3d022f0474d5b67b08399e0746 Mon Sep 17 00:00:00 2001
+From 80cb290812b649955d874929dd84559fbdaaa9d6 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -320,7 +320,7 @@ index 5d30ae39d..c14eb56eb 100644
 -- 
 2.53.0
 
-From 89de4725f7b15a3a27fbe851993c472889a304bb Mon Sep 17 00:00:00 2001
+From c5d8dc3870658c58d7fff6ee6a58163f8335dd9a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell

--- a/patches/6.18/0004-ath10k.patch
+++ b/patches/6.18/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From 3bcff82851b221fb8bddd3e085806afe4d32eb89 Mon Sep 17 00:00:00 2001
+From 69078fd9804149d199b3fa8e713b80760a11b596 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files

--- a/patches/6.18/0005-ipts.patch
+++ b/patches/6.18/0005-ipts.patch
@@ -1,4 +1,4 @@
-From 08a7818553d5e5f08c49233b7c26c1caa7010e5e Mon Sep 17 00:00:00 2001
+From d87fa52961781a386b63b57e26ca965f20a20f9a Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -37,7 +37,7 @@ index 2a6e56955..c19dfba54 100644
 -- 
 2.53.0
 
-From fbe131b36a06da8329f88913aa49b9979525e1d5 Mon Sep 17 00:00:00 2001
+From 9c1a6cafefa706cc777274302be1956509067f7c Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -144,7 +144,7 @@ index 49e83c856..a3e35c77d 100644
 -- 
 2.53.0
 
-From 94d61f62aff23b9d8f14383a9bf5372999c2431c Mon Sep 17 00:00:00 2001
+From 4e909ce1db9f221bec5f6761da1c74868e646567 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus

--- a/patches/6.18/0006-ithc.patch
+++ b/patches/6.18/0006-ithc.patch
@@ -1,4 +1,4 @@
-From d27f63695839ae3cc725c8d7666405dc0f7bb109 Mon Sep 17 00:00:00 2001
+From 7889794c87f8ead7509001798da50606553010d4 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -39,7 +39,7 @@ index 8bcbfe3d9..c78806d35 100644
 -- 
 2.53.0
 
-From 6a4e9c31e39e92ca1fea20632d41df7d67f666f3 Mon Sep 17 00:00:00 2001
+From 0a194a407857f526d06d1e459b81faa5be2e4275 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller

--- a/patches/6.18/0007-surface-sam.patch
+++ b/patches/6.18/0007-surface-sam.patch
@@ -1,4 +1,4 @@
-From 3ba7fa6e5236b7ea4141f9f85d8636066d81dc0a Mon Sep 17 00:00:00 2001
+From d0c0e2cf7bca1d124ec51f129d2ae259d0291cb5 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
 Subject: [PATCH] rtc: Add basic support for RTC via Surface System Aggregator
@@ -181,7 +181,7 @@ index 000000000..f6c17c4e9
 -- 
 2.53.0
 
-From 58c3cb2fbdedd7c57ddb040217355ff718975fa5 Mon Sep 17 00:00:00 2001
+From da4d9417542e3a5ba645dc5c069c8709344c6d7d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
 Subject: [PATCH] platform/surface: aggregator_registry: Add Surface Laptop 7

--- a/patches/6.18/0008-surface-sam-over-hid.patch
+++ b/patches/6.18/0008-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From bffb18859041b06d2a02156b19f987103916d86b Mon Sep 17 00:00:00 2001
+From a7cb180b16908683b3716d74a61c98c7f5fc1b46 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -109,7 +109,7 @@ index ed90858a2..070c36637 100644
 -- 
 2.53.0
 
-From 0a73b819912d300caccd86b2a5d6aee5eb161f3e Mon Sep 17 00:00:00 2001
+From 6b54c1290d843259d1c732221e863ae35d648a2d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch

--- a/patches/6.18/0009-surface-button.patch
+++ b/patches/6.18/0009-surface-button.patch
@@ -1,4 +1,4 @@
-From a7f4f1bfba7c8d96baadf1212006957c533f0d8a Mon Sep 17 00:00:00 2001
+From 298e817335b8804e0b889f25237d4282917a46b0 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -75,7 +75,7 @@ index b8cad415c..43b5d5638 100644
 -- 
 2.53.0
 
-From b4ca6508297bbaf5ec174aae5abbb0f7ca46f611 Mon Sep 17 00:00:00 2001
+From 55c5ef0db3fd3ec8ef996ab1cf229f5b6a01c659 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd

--- a/patches/6.18/0010-surface-typecover.patch
+++ b/patches/6.18/0010-surface-typecover.patch
@@ -1,4 +1,4 @@
-From 3016f423ab0e10093a4ab502ca73830eb6760ea7 Mon Sep 17 00:00:00 2001
+From 65586462f66578997979fffce0d14c364e97bd24 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -39,7 +39,7 @@ index c4d85089d..3d0d35c72 100644
 -- 
 2.53.0
 
-From 36fe9a8a785b46e63aadc92ff71ffa99d24069ac Mon Sep 17 00:00:00 2001
+From 66f68837779ede11cda8e29afc46ce0f43cfa081 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -274,7 +274,7 @@ index af19e089b..ab040ea64 100644
 -- 
 2.53.0
 
-From 40bf0ca78f732f1041154d32180ddcb44571cad2 Mon Sep 17 00:00:00 2001
+From 6612b8a0b4db1e57a95fad53ebfe68ba90bc8faf Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet

--- a/patches/6.18/0011-surface-shutdown.patch
+++ b/patches/6.18/0011-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From 5e53f226080bd78c28c436c087c7ba7743add4f7 Mon Sep 17 00:00:00 2001
+From f4dbafd07e1b1f9f5c1656646443c6e58528a62d Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
@@ -95,7 +95,7 @@ index 05aeee8c8..006ea71ce 100644
 -- 
 2.53.0
 
-From 12f8026700b5bc2d333b6da7528c31c82f379edb Mon Sep 17 00:00:00 2001
+From fd4fa0b63f720afbebfd215e5337ecf847eb3c9c Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Wed, 7 Jan 2026 01:06:25 +0100
 Subject: [PATCH] PCI: Add Surface Laptop Studio 2 devices to shutdown ops

--- a/patches/6.18/0012-surface-gpe.patch
+++ b/patches/6.18/0012-surface-gpe.patch
@@ -1,4 +1,4 @@
-From 766818fce3dbaefe80ab8c7b09bf83114d5d5d3e Mon Sep 17 00:00:00 2001
+From 6a418143256e871795b4ddb618e151e1186e341c Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9

--- a/patches/6.18/0013-cameras.patch
+++ b/patches/6.18/0013-cameras.patch
@@ -1,4 +1,4 @@
-From d693daba3c12c84c53d38ab8e21e04963035734a Mon Sep 17 00:00:00 2001
+From 6d89ae89f9a4b6613019c0964c1c59e823755abf Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -74,7 +74,7 @@ index ef16d58b2..a6bad2679 100644
 -- 
 2.53.0
 
-From c6ba60b1e0f18c27516419a7c611fbf7885e773c Mon Sep 17 00:00:00 2001
+From c6b57220a5b99a279d2eb4197f290c9ff2127a9e Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -184,7 +184,7 @@ index a3e35c77d..28567ba59 100644
 -- 
 2.53.0
 
-From 86a9e06fbb44086759a3b055638c00d4a489b21d Mon Sep 17 00:00:00 2001
+From adfe6d571518a91dc024839f490d68dc83892814 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -221,7 +221,7 @@ index 013340569..9e0763bdc 100644
 -- 
 2.53.0
 
-From 45343ef53c4105b306b313789527661a81c52d04 Mon Sep 17 00:00:00 2001
+From 2a5f75ce5abfd79f192bcabecfaaddb494a126ef Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -260,7 +260,7 @@ index 27afc3fc0..28b192c9a 100644
 -- 
 2.53.0
 
-From 32cea2dfe991c162cc0392db93ecee4d88a0ce76 Mon Sep 17 00:00:00 2001
+From 91a6592078b6ac05615ebb6de7936f24723e6364 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -311,7 +311,7 @@ index cb153ce42..f11b499e1 100644
 -- 
 2.53.0
 
-From 3ea45d9e1f9663a9b89962d6f99e9ed85e0fdbf9 Mon Sep 17 00:00:00 2001
+From 71d9f6f5a29533047a4ba72646f1a6c3bf2ccfc5 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -352,7 +352,7 @@ index 9e0763bdc..0976b2679 100644
 -- 
 2.53.0
 
-From 533c08f4994d9e3af95aaf417149646f2a12123c Mon Sep 17 00:00:00 2001
+From 3b5333d4354852e552f2250b2cefa33a3d307e0d Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -393,7 +393,7 @@ index 7807fa329..2d2abb25b 100644
 -- 
 2.53.0
 
-From 86d68e16a7aee5b4f0568b842a5b2b8a7907b916 Mon Sep 17 00:00:00 2001
+From 14bab8cfe711721bedae032517272f5c1eda237c Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -644,7 +644,7 @@ index 000000000..35aeb5db8
 -- 
 2.53.0
 
-From 38402757f9881b3afd7b1b33c9c0a66f9a80379f Mon Sep 17 00:00:00 2001
+From 8385a094f55efa199beac99879304d048a9ed696 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2
@@ -676,7 +676,7 @@ index 032fbcb98..e03a1d8cd 100644
 -- 
 2.53.0
 
-From 652839ecc85fc2856d0a6c52498d61c04851c41f Mon Sep 17 00:00:00 2001
+From 6caa822dedfe4d4a164070424caae770db458798 Mon Sep 17 00:00:00 2001
 From: Tooraj Taraz <tooraj.taraz@yahoo.com>
 Date: Wed, 31 Dec 2025 00:35:50 +0100
 Subject: [PATCH] Add camera support for Surface Pro 9
@@ -1017,7 +1017,7 @@ index 1505fc3ef..20962e8ac 100644
 -- 
 2.53.0
 
-From 70b17884899e2d0abd5503efd9aff0ea05473233 Mon Sep 17 00:00:00 2001
+From b8440f1dcf2ce055afd00c733546fa209c74c09d Mon Sep 17 00:00:00 2001
 From: gabrielstedman <gabrielstedman@users.noreply.github.com>
 Date: Fri, 13 Mar 2026 08:52:07 +0000
 Subject: [PATCH] media: ipu-bridge: Add front camera rotation quirks for

--- a/patches/6.18/0014-amd-gpio.patch
+++ b/patches/6.18/0014-amd-gpio.patch
@@ -1,4 +1,4 @@
-From 8ff4b5a2af058663e766fc8edf8f24f8c21b007a Mon Sep 17 00:00:00 2001
+From a6c275f92edf5ac7d5528a240a961d3697e0e900 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -65,7 +65,7 @@ index d6138b2b6..67094184c 100644
 -- 
 2.53.0
 
-From 0fb8ce91b92a1f4e90a29abb12ef276c3a1c9528 Mon Sep 17 00:00:00 2001
+From 9b1d1ebf89898d157aed1cc245368a992fbef83e Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override

--- a/patches/6.18/0015-rtc.patch
+++ b/patches/6.18/0015-rtc.patch
@@ -1,4 +1,4 @@
-From 4658081050d245b515333e5639b118e3fa6168dd Mon Sep 17 00:00:00 2001
+From 6103981ac27c5d9ff98baada8ed6befeafab2242 Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms

--- a/patches/6.18/0016-hid-surface.patch
+++ b/patches/6.18/0016-hid-surface.patch
@@ -1,4 +1,4 @@
-From 8e9bab94eaad38d01e2df96a6a3888cfb727f488 Mon Sep 17 00:00:00 2001
+From 9f5befc32ec4d2f7124a03afd88b0b3070b822c6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ciar=C3=A1n=20Coffey?= <github@ccoffey.ie>
 Date: Fri, 10 Oct 2025 19:04:03 +0100
 Subject: [PATCH] HID: Add hid-surface driver to filter BTN_0 (FN key)
@@ -156,7 +156,7 @@ index 000000000..a171ea656
 -- 
 2.53.0
 
-From 79ae9d899ddc4ac988403fe349166dfd0dadc081 Mon Sep 17 00:00:00 2001
+From 0c2e6a571542e179a7461d38efd2ce8d590a3f35 Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Fri, 13 Mar 2026 10:16:37 +0100
 Subject: [PATCH] hid/multitouch: Prevent mode set on Surface Laptop Studio 2


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.18** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.18-surface`
- **Base version**: `v6.18.18`
- **Patches generated**: 16
- **Patches directory**: `patches/6.18/`

### Changes
This PR updates kernel patches to the latest version from the `v6.18-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.18-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.