### PR TITLE
Remove disk space maximizer from workflow

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -6,23 +6,23 @@ env:
 on:
   push:
     tags:
-      - 'arch-*'
+      - "arch-*"
 
   repository_dispatch:
   workflow_dispatch:
-  
+
 jobs:
   build:
     name: Build Kernel
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 5120
-          remove-dotnet: true
-          remove-android: true
-          remove-docker-images: true
+      # - name: Maximize disk space
+      #   uses: easimon/maximize-build-space@master
+      #   with:
+      #     root-reserve-mb: 5120
+      #     remove-dotnet: true
+      #     remove-android: true
+      #     remove-docker-images: true
 
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     tags:
-      - 'debian-*'
+      - "debian-*"
 
   repository_dispatch:
   workflow_dispatch:
@@ -16,13 +16,13 @@ jobs:
     name: Build Kernel
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 5120
-          remove-dotnet: true
-          remove-android: true
-          remove-docker-images: true
+      # - name: Maximize disk space
+      #   uses: easimon/maximize-build-space@master
+      #   with:
+      #     root-reserve-mb: 5120
+      #     remove-dotnet: true
+      #     remove-android: true
+      #     remove-docker-images: true
 
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/fedora-40.yml
+++ b/.github/workflows/fedora-40.yml
@@ -7,7 +7,7 @@ env:
 on:
   push:
     tags:
-      - 'fedora-40-*'
+      - "fedora-40-*"
 
   repository_dispatch:
   workflow_dispatch:
@@ -17,13 +17,13 @@ jobs:
     name: Build Kernel
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 5120
-          remove-dotnet: true
-          remove-android: true
-          remove-docker-images: true
+      # - name: Maximize disk space
+      #   uses: easimon/maximize-build-space@master
+      #   with:
+      #     root-reserve-mb: 5120
+      #     remove-dotnet: true
+      #     remove-android: true
+      #     remove-docker-images: true
 
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/fedora-41.yml
+++ b/.github/workflows/fedora-41.yml
@@ -7,7 +7,7 @@ env:
 on:
   push:
     tags:
-      - 'fedora-41-*'
+      - "fedora-41-*"
 
   repository_dispatch:
   workflow_dispatch:
@@ -17,13 +17,13 @@ jobs:
     name: Build Kernel
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 5120
-          remove-dotnet: true
-          remove-android: true
-          remove-docker-images: true
+      # - name: Maximize disk space
+      #   uses: easimon/maximize-build-space@master
+      #   with:
+      #     root-reserve-mb: 5120
+      #     remove-dotnet: true
+      #     remove-android: true
+      #     remove-docker-images: true
 
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/fedora-42.yml
+++ b/.github/workflows/fedora-42.yml
@@ -7,7 +7,7 @@ env:
 on:
   push:
     tags:
-      - 'fedora-42-*'
+      - "fedora-42-*"
 
   repository_dispatch:
   workflow_dispatch:
@@ -17,13 +17,13 @@ jobs:
     name: Build Kernel
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 5120
-          remove-dotnet: true
-          remove-android: true
-          remove-docker-images: true
+      # - name: Maximize disk space
+      #   uses: easimon/maximize-build-space@master
+      #   with:
+      #     root-reserve-mb: 5120
+      #     remove-dotnet: true
+      #     remove-android: true
+      #     remove-docker-images: true
 
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/fedora-43.yml
+++ b/.github/workflows/fedora-43.yml
@@ -7,7 +7,7 @@ env:
 on:
   push:
     tags:
-      - 'fedora-43-*'
+      - "fedora-43-*"
 
   repository_dispatch:
   workflow_dispatch:
@@ -17,13 +17,13 @@ jobs:
     name: Build Kernel
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 5120
-          remove-dotnet: true
-          remove-android: true
-          remove-docker-images: true
+      # - name: Maximize disk space
+      #   uses: easimon/maximize-build-space@master
+      #   with:
+      #     root-reserve-mb: 5120
+      #     remove-dotnet: true
+      #     remove-android: true
+      #     remove-docker-images: true
 
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
Trying to fix the latest build failures.
According to the logs:
- The maximizer only freed less than 2GB (out of 90G already available)
- Its LVM volume (mounted to `/home/runner/work/linux-surface/linux-surface`) took up almost all `/` space which caused docker & dnf etc. to fail because they need root space.