### PR TITLE
patches/v6.12: Automatic update to v6.12.80

### DIFF
--- a/patches/6.12/0001-secureboot.patch
+++ b/patches/6.12/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From d78b9a6c4a99464f0a4a6317d4a44e22c129a83a Mon Sep 17 00:00:00 2001
+From bc3a4f620faa6af43cf1bef048ec6109723f9632 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -35,7 +35,7 @@ index b5c79f433..a1bbedd98 100644
 -- 
 2.53.0
 
-From ba56e2f141004eecd63bfe191126568bbb50d5fe Mon Sep 17 00:00:00 2001
+From b9ca0e01854ee6b4f82c7cf8f285925cb736fe50 Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter
@@ -53,7 +53,7 @@ Patchset: secureboot
  2 files changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index e88505e94..15961654b 100644
+index 811345669..d89e6b295 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
 @@ -3085,6 +3085,11 @@

--- a/patches/6.12/0002-surface3-oemb.patch
+++ b/patches/6.12/0002-surface3-oemb.patch
@@ -1,4 +1,4 @@
-From 242ddda76132ccbb78fce0c338bd7805ffa371bd Mon Sep 17 00:00:00 2001
+From 5a620bc368b844c9b850eb2a80a62552c6fcc364 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI

--- a/patches/6.12/0003-mwifiex.patch
+++ b/patches/6.12/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From b5f73cc1b4a0cdec1a5e311dd1d79a0e19ea1361 Mon Sep 17 00:00:00 2001
+From 9112744ef348161c30c56b221f7528094fe87a54 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -165,7 +165,7 @@ index d6ff964ae..5d30ae39d 100644
 -- 
 2.53.0
 
-From 259acade815fa5cdb5067eeac2442c26b4ceb2c6 Mon Sep 17 00:00:00 2001
+From e0df29fff45eefea745c3c562c6f8e57d6084aa3 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -320,7 +320,7 @@ index 5d30ae39d..c14eb56eb 100644
 -- 
 2.53.0
 
-From eed389098afc172e91855287538ca1bbd3d11a0f Mon Sep 17 00:00:00 2001
+From 47f2457b88b449fecee05e9486d3ee9b0472a00b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell
@@ -356,7 +356,7 @@ Patchset: mwifiex
  1 file changed, 15 insertions(+)
 
 diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
-index 9d3236321..1670a26e5 100644
+index b8bf4dfea..3f72b2335 100644
 --- a/drivers/bluetooth/btusb.c
 +++ b/drivers/bluetooth/btusb.c
 @@ -66,6 +66,7 @@ static struct usb_driver btusb_driver;
@@ -375,7 +375,7 @@ index 9d3236321..1670a26e5 100644
  
  	/* Intel Bluetooth devices */
  	{ USB_DEVICE(0x8087, 0x0025), .driver_info = BTUSB_INTEL_COMBINED },
-@@ -4016,6 +4018,19 @@ static int btusb_probe(struct usb_interface *intf,
+@@ -4019,6 +4021,19 @@ static int btusb_probe(struct usb_interface *intf,
  	if (id->driver_info & BTUSB_MARVELL)
  		hdev->set_bdaddr = btusb_set_bdaddr_marvell;
  

--- a/patches/6.12/0004-ath10k.patch
+++ b/patches/6.12/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From 4125e5a84b2370376ab1c108fbff63ccee48d3b0 Mon Sep 17 00:00:00 2001
+From 10049e985910b063a7af449924c363895d385cf3 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files

--- a/patches/6.12/0005-ipts.patch
+++ b/patches/6.12/0005-ipts.patch
@@ -1,4 +1,4 @@
-From 4dbb2841ec84f5c7612d22baffe291f7e5b1c74e Mon Sep 17 00:00:00 2001
+From 5ff0be6136cc8e5d9abf9f871ff4f28ca2b76728 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -37,7 +37,7 @@ index 1e4edf896..61d1a8816 100644
 -- 
 2.53.0
 
-From 77f4b43a690d491d4be35f52d334e07f24162958 Mon Sep 17 00:00:00 2001
+From aff038cff2dd7dd398afd203e5bde6eb5701d7c8 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -144,7 +144,7 @@ index d4f852f71..b76109d5d 100644
 -- 
 2.53.0
 
-From 8df48859297fd0730bf9d231343176cd6f2ecedd Mon Sep 17 00:00:00 2001
+From 49bdd8a7e8ce613d5ab41b0f07ff5003a3f71ff4 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus

--- a/patches/6.12/0006-ithc.patch
+++ b/patches/6.12/0006-ithc.patch
@@ -1,4 +1,4 @@
-From 10da29a50dc86540c5162137ed52c5c99823b185 Mon Sep 17 00:00:00 2001
+From 4c5c533c39f54be79bc2ab9f0913c8dc66135e89 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -39,7 +39,7 @@ index 066e4cd6e..7b320d09d 100644
 -- 
 2.53.0
 
-From db66ed7a0570276e8d561777fa3ba2f97bd449c6 Mon Sep 17 00:00:00 2001
+From a70870d835ea6d4859776f59e3b02f66b34d1084 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller

--- a/patches/6.12/0007-surface-sam-over-hid.patch
+++ b/patches/6.12/0007-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From 04627863b4690e94b904bdebd26e1532b6112c26 Mon Sep 17 00:00:00 2001
+From 4751ac2c5b20ef8ca078404cbdc3dbdfc8c7d76a Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -109,7 +109,7 @@ index f43067f67..1761ca30e 100644
 -- 
 2.53.0
 
-From 1d7c291867bb34ababa60243f125c26da2ec85e9 Mon Sep 17 00:00:00 2001
+From 6725dae08b2ed30e8fe477db5fa4ca10bf61947c Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch

--- a/patches/6.12/0008-surface-button.patch
+++ b/patches/6.12/0008-surface-button.patch
@@ -1,4 +1,4 @@
-From 82584739abaac5bfc5adfaeb3ea03facf77de7ce Mon Sep 17 00:00:00 2001
+From 22981ceb3da8675f558cd7ea77728ad2d9634ffb Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -75,7 +75,7 @@ index 5c5d407fe..4e1bfe90e 100644
 -- 
 2.53.0
 
-From d5ecaa5cb6ac3a5eeb443b8bae1dc077df4bda75 Mon Sep 17 00:00:00 2001
+From f6e2a33fd9699af413c0689dc472983b0d427b2f Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd

--- a/patches/6.12/0009-surface-typecover.patch
+++ b/patches/6.12/0009-surface-typecover.patch
@@ -1,4 +1,4 @@
-From 142804a88c118139dcc4f69ed27717e6d5c8156f Mon Sep 17 00:00:00 2001
+From dc78c6099662be541788428f23916d33a14ef5f9 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -23,10 +23,10 @@ Patchset: surface-typecover
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
-index 323a949bb..abc2cdecd 100644
+index 53b08d6cf..ee19a74f0 100644
 --- a/drivers/usb/core/quirks.c
 +++ b/drivers/usb/core/quirks.c
-@@ -223,6 +223,9 @@ static const struct usb_device_id usb_quirk_list[] = {
+@@ -229,6 +229,9 @@ static const struct usb_device_id usb_quirk_list[] = {
  	/* Microsoft Surface Dock Ethernet (RTL8153 GigE) */
  	{ USB_DEVICE(0x045e, 0x07c6), .driver_info = USB_QUIRK_NO_LPM },
  
@@ -39,7 +39,7 @@ index 323a949bb..abc2cdecd 100644
 -- 
 2.53.0
 
-From 74b286ffe37d7836327742b71f78f00880412a34 Mon Sep 17 00:00:00 2001
+From c8066458bba4fae2a82a32eeb2ac45020a71194c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -274,7 +274,7 @@ index eb1489884..0a6cf8926 100644
 -- 
 2.53.0
 
-From 51b8f39ff7aaf9ef241f95ec40f727f55440c5e7 Mon Sep 17 00:00:00 2001
+From 329ff7e526a9dd9187c8aad299a66672ca118f44 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet

--- a/patches/6.12/0010-surface-shutdown.patch
+++ b/patches/6.12/0010-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From fe77fe0cb314d0202ca005b064c439e96b7a5920 Mon Sep 17 00:00:00 2001
+From d12b3c7aa25d5ea04c23d9828ed3bf3dc69d2244 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod

--- a/patches/6.12/0011-surface-gpe.patch
+++ b/patches/6.12/0011-surface-gpe.patch
@@ -1,4 +1,4 @@
-From d199f675da076339d1617e2562f714d791010959 Mon Sep 17 00:00:00 2001
+From 6203ac4f123287603d3d108a1c2e2675182d8e0a Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9

--- a/patches/6.12/0012-cameras.patch
+++ b/patches/6.12/0012-cameras.patch
@@ -1,4 +1,4 @@
-From cb78d8125731975857cacbb981babad2563f6133 Mon Sep 17 00:00:00 2001
+From 566b2dc3057351a929d1b049afd09461c44aa47d Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -74,7 +74,7 @@ index ba98763ce..6021907ec 100644
 -- 
 2.53.0
 
-From 4896c5dd64257633ca4d42237f17f0ae37edeafe Mon Sep 17 00:00:00 2001
+From 661dd4b96cdcd51a90974945c1601d8ae1a3bdc2 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -184,7 +184,7 @@ index b76109d5d..06b2d4a85 100644
 -- 
 2.53.0
 
-From 3500e8e7e174ca3d2a4e0659263570633ea40818 Mon Sep 17 00:00:00 2001
+From 71a462d3de63bb1848702b56554bf8f438defd87 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -221,7 +221,7 @@ index 81ac4c691..f453c9043 100644
 -- 
 2.53.0
 
-From 09848cfdbb28c7cb8ef310661ef84aea2b2d5571 Mon Sep 17 00:00:00 2001
+From b5142c7729971ca583de9e7a4d0e99e564f79719 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Thu, 2 Mar 2023 12:59:39 +0000
 Subject: [PATCH] platform/x86: int3472: Remap reset GPIO for INT347E
@@ -277,7 +277,7 @@ index 9e69ac9cf..d6003198a 100644
 -- 
 2.53.0
 
-From 19f7efbb8c697246464d4556715776e81713266a Mon Sep 17 00:00:00 2001
+From b32e05d246b7cc3b0da16bf88e51509f490ddcbc Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -316,7 +316,7 @@ index 3226888d7..3bfe45b76 100644
 -- 
 2.53.0
 
-From d73081eebba9db15ff01cb6208ec6f6a4fee7993 Mon Sep 17 00:00:00 2001
+From 61ddcd7f46ff6c64fde6c264782a7e21e22a2d4c Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -367,7 +367,7 @@ index f19c8adf2..923ed1b5a 100644
 -- 
 2.53.0
 
-From 36fb55a4db8fc2fa00db4b21351a197a556837c2 Mon Sep 17 00:00:00 2001
+From 32a7965ae1a54d9e382eed8e34ef656fdb9aaf2a Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -408,7 +408,7 @@ index f453c9043..b8ad6b413 100644
 -- 
 2.53.0
 
-From 082f363ec90ef3f959e0d2196e7262bb631b48ef Mon Sep 17 00:00:00 2001
+From 672be10e820f95d949703d2c222689beea668626 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -449,7 +449,7 @@ index 7807fa329..2d2abb25b 100644
 -- 
 2.53.0
 
-From ce274f610494db183eb9af63caf7be993a213e1e Mon Sep 17 00:00:00 2001
+From ca0d1deecfd07c975856d89fe7ac6375e43a71f8 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -700,7 +700,7 @@ index 000000000..35aeb5db8
 -- 
 2.53.0
 
-From 265db8eb0cd4a576d4c1fc0326211c7d033ee49e Mon Sep 17 00:00:00 2001
+From 92ed8468626539f1da1b2324d4e522b964c4aa16 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2

--- a/patches/6.12/0013-amd-gpio.patch
+++ b/patches/6.12/0013-amd-gpio.patch
@@ -1,4 +1,4 @@
-From bf7336bc7535b912923ac679762f78a547507371 Mon Sep 17 00:00:00 2001
+From 30ad428d4d3160781888e565078b5b37090861ac Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -65,7 +65,7 @@ index a1acff778..8cb5d2c5f 100644
 -- 
 2.53.0
 
-From 2bc288e1402dd22595170a9bf212395dd27982e6 Mon Sep 17 00:00:00 2001
+From f5301dbb7e8c37b27b77813a41bc160be1b33c80 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override

--- a/patches/6.12/0014-rtc.patch
+++ b/patches/6.12/0014-rtc.patch
@@ -1,4 +1,4 @@
-From 1d252cfb63fc691888327a706233fb81f28d29ee Mon Sep 17 00:00:00 2001
+From 26181da0df4f3d2143585b223473c82df076d282 Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.12** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.12-surface`
- **Base version**: `v6.12.80`
- **Patches generated**: 14
- **Patches directory**: `patches/6.12/`

### Changes
This PR updates kernel patches to the latest version from the `v6.12-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.12-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.