### PR TITLE
contrib: add brydge-10.5-keyboard recipe + BLE pairing sync helper

### DIFF
--- a/contrib/brydge-10.5-keyboard/README.md
+++ b/contrib/brydge-10.5-keyboard/README.md
@@ -1,0 +1,285 @@
+# Brydge 10.5 Go+ keyboard on Linux
+
+A full recipe for getting the **Brydge 10.5 Go+** keyboard — the detachable
+keyboard/trackpad designed specifically for the Microsoft Surface Go / Go 2
+— working end-to-end under Linux, including:
+
+1. **Trackpad regression workaround**: install-and-pin BlueZ 5.62 on Ubuntu
+   22.04, because BlueZ ≥ 5.64 breaks the trackpad on this keyboard's
+   composite HID descriptor.
+2. **Initial BLE pairing**: the pairing workflow (passkey entry, LE Legacy
+   with MITM) — standard, but worth documenting because the failure modes
+   are opaque if you've never done LE Legacy before.
+3. **Dual-boot key sync (Windows → Linux)**: a Python helper that reads
+   a Windows registry `.reg` export and writes a matching BlueZ pairing
+   file, so you don't have to re-pair the keyboard every time you boot
+   the other OS. Includes the empirically-verified byte-order conventions
+   for LE keys, which differ from Classic Bluetooth.
+
+Tested configuration: **Surface Go 2** running **Ubuntu 22.04 LTS** with
+the **`linux-surface`** kernel (verified on 6.18.7) and a **Brydge 10.5
+Go+** keyboard (ACPI/USB VID `03F6`, PID `A001`, Iton Technology Corp
+company ID `1014`, part of the Brydge Pro / Go / Go+ product line).
+
+## The keyboard
+
+The Brydge 10.5 Go+ is a Bluetooth Low Energy HID-over-GATT peripheral
+presenting itself as a composite device:
+
+- **Keyboard** (input): standard HID keyboard descriptor
+- **Pointer/trackpad** (input): HID mouse + multitouch descriptor
+- **Battery service** (BLE GATT 0x180f)
+- **HID service** (BLE GATT 0x1812)
+- **Device information service** (BLE GATT 0x180a)
+- **Nordic Semiconductor DFU** (GATT 0xfe59) — firmware update channel
+
+Pairing uses **LE Legacy pairing with Passkey Entry**: you type a 6-digit
+number on the keyboard when prompted. This gives MITM protection, produces
+a single symmetric LTK, and stores `Authenticated=1` in BlueZ's info file.
+
+## Problem 1: BlueZ 5.64 breaks the trackpad
+
+On **Ubuntu 22.04** with the stock `bluez` package (5.64), after pairing
+successfully, keyboard input works but the **trackpad produces no cursor
+motion**. The trackpad's `input` node in `/dev/input/eventN` exists and
+is classified correctly by `udev`, but it emits zero events. `evtest` on
+the node just shows the connection info and never prints a single `EV_REL`.
+
+The regression is in bluez, not the kernel — the same keyboard on the
+same hardware works correctly if you downgrade `bluez` + `libbluetooth3`
++ `bluez-obexd` to **5.62-2** (sourced from
+[snapshot.debian.org](https://snapshot.debian.org/package/bluez/5.62-2/)
+since Ubuntu 22.04 never shipped 5.62).
+
+### Workaround
+
+Use the included script:
+
+```bash
+sudo ./install-bluez-5.62.sh
+```
+
+It downloads `bluez_5.62-2_amd64.deb`, `libbluetooth3_5.62-2_amd64.deb`,
+and `bluez-obexd_5.62-2_amd64.deb` from
+<https://snapshot.debian.org/archive/debian/20211227T152656Z/pool/main/b/bluez/>,
+installs them with `--allow-downgrades`, `apt-mark hold`s them so
+`apt upgrade` won't silently reinstall 5.64, and restarts `bluetooth.service`.
+
+Verify:
+
+```bash
+/usr/libexec/bluetooth/bluetoothd --version
+# 5.62
+```
+
+**To reverse** (back to stock 5.64):
+
+```bash
+sudo apt-mark unhold bluez libbluetooth3 bluez-obexd
+sudo apt install --reinstall bluez libbluetooth3 bluez-obexd
+```
+
+### Why not just patch bluez upstream
+
+I haven't tracked down the specific commit in bluez 5.63 or 5.64 that
+causes the regression. If someone else wants to bisect, a good starting
+point is the HID profile code in `profiles/input/hog-lib.c` and
+`src/profile.c` — the symptom (HID characteristics read but no input
+events delivered) points at the GATT→uhid translation path. A patch
+upstream would be better than pinning an old version forever, but
+5.62 is the practical fix today.
+
+## Problem 2: Initial pairing
+
+Standard BLE pairing flow. Nothing special, but included for completeness:
+
+```bash
+bluetoothctl
+# inside bluetoothctl:
+power on
+agent on
+default-agent
+scan on
+# wait for "NEW Device XX:XX:XX:XX:XX:XX Brydge 10.5 Go+"
+pair XX:XX:XX:XX:XX:XX
+# the keyboard will prompt you (via a beep / indicator LED) to type a
+# 6-digit passkey that bluetoothctl prints on your terminal. Type it on
+# the keyboard and press Enter.
+trust XX:XX:XX:XX:XX:XX
+connect XX:XX:XX:XX:XX:XX
+scan off
+```
+
+After this, `Trusted=true` in `/var/lib/bluetooth/<adapter>/<device>/info`
+will make the keyboard auto-reconnect on every subsequent boot as long
+as it's powered and in range.
+
+Expected output in `dmesg`:
+
+```
+input: Brydge 10.5 Go+ Keyboard as /devices/virtual/misc/uhid/.../input/inputN
+input: Brydge 10.5 Go+ Mouse as /devices/virtual/misc/uhid/.../input/inputN+1
+input: Brydge 10.5 Go+ as /devices/virtual/misc/uhid/.../input/inputN+2  (trackpad)
+hid-generic     0005:03F6:A001.XXXX: input,hidraw: BLUETOOTH HID v0.01 Keyboard [Brydge 10.5 Go+] on <adapter-mac>
+hid-multitouch  0005:03F6:A001.XXXX: input,hidraw: BLUETOOTH HID v0.01 Device   [Brydge 10.5 Go+] on <adapter-mac>
+```
+
+The `hid-multitouch` binding is the trackpad — if you're on stock bluez
+5.64, you'll see this line but no cursor movement. That's the regression.
+
+## Problem 3: Dual-boot key sync (Windows → Linux)
+
+If you dual-boot Windows and re-pair the keyboard on Windows (Option A
+from most dual-boot-bluetooth tutorials), the keyboard now has a fresh
+LTK/EDiv/Rand that Linux doesn't know about — so when you boot back into
+Linux, the keyboard connects at the HCI level but encryption fails and
+the session disconnects with `Authentication Failure`.
+
+The existing tool for this is [bt-dualboot], but **bt-dualboot only
+handles Classic Bluetooth (BR/EDR)** — it reads link keys from the
+adapter-level values in the Windows registry and ignores the LE device
+subkeys entirely, where our LTK / EDiv / Rand / IRK actually live. See
+[bt-dualboot PR #34][pr34] for an upstream attempt to add LE support
+that's been sitting unreviewed for over a year.
+
+[bt-dualboot]: https://github.com/x2es/bt-dualboot
+[pr34]: https://github.com/x2es/bt-dualboot/pull/34
+
+This contrib includes a one-shot Python helper that does the LE sync
+manually:
+
+```bash
+# 1. Mount Windows read-only
+sudo mkdir -p /mnt/win
+sudo mount -t ntfs-3g -o ro /dev/nvmeXnYpZ /mnt/win
+
+# 2. Export the BTHPORT keys subtree to a .reg file (use reged, NOT
+#    `chntpw -e` with a heredoc — chntpw's REPL loops on EOF and can
+#    fill your disk before you notice)
+sudo reged -x /mnt/win/Windows/System32/config/SYSTEM \
+    'HKEY_LOCAL_MACHINE\SYSTEM' \
+    '\ControlSet001\Services\BTHPORT\Parameters\Keys\<adapter-hex>' \
+    out.reg
+
+# 3. List LE devices and pick the one you want to sync
+sudo ./sync-ble-pairing-from-windows.py list out.reg
+
+# 4. Apply the chosen subkey to BlueZ
+sudo ./sync-ble-pairing-from-windows.py apply out.reg <hex-subkey> \
+    --adapter-mac AC:67:5D:04:67:D4
+
+# 5. Restart bluetoothd; the keyboard should auto-connect on next power-up
+sudo systemctl restart bluetooth
+sudo umount /mnt/win
+```
+
+If encryption fails after `restart bluetooth` — you'll see the failure
+in `journalctl -u bluetooth -f` as a rapid loop of `Authentication Failure`
+and `Disconnect Complete` — retry step 4 with `--force-sc` to use
+`Authenticated=2` instead of the default Legacy `1`. Most BLE peripherals
+(including the Brydge 10.5 Go+) use Legacy pairing and `Authenticated=1`
+is correct, but Apple's Magic Keyboard, Logitech MX Keys, and other
+modern devices use LE Secure Connections and need `2`.
+
+### The byte-order conventions (empirically verified)
+
+| Field | Windows registry | BlueZ info file | Reversal? |
+|---|---|---|---|
+| `IRK` | `hex:fb,1f,...a1` | `[IdentityResolvingKey] Key=A127...FB` | **Yes**, reverse the bytes |
+| `LTK` | `hex:b5,17,...c5` | `[LongTermKey] Key=B517...C5` | **No**, keep the Windows byte order |
+| `ERand` | `hex(b):67,6e,...3d` (LE u64) | `[LongTermKey] Rand=<decimal>` | Convert LE bytes → u64 → decimal |
+| `EDIV` | `dword:000051db` | `[LongTermKey] EDiv=<decimal>` | dword → decimal |
+| `Address` | `hex(b):a2,bc,...e4,00,00` | directory-name MAC `E4:20:66:A2:BC:A2` | Reverse the 6 MAC bytes |
+| `AddressType` | `dword:00000001` (random) | `[General] AddressType=static` | dword → string |
+
+The IRK reversal is the one most people assume *also* applies to the
+LTK — it does not. Reversing the LTK produces `HCI Encryption Change
+Status: Connection Timeout (0x08)` followed by the peripheral issuing
+an `SMP: Security Request` asking for a fresh pairing, because the key
+math doesn't match what the peripheral has stored.
+
+The `sync-ble-pairing-from-windows.py` helper applies these conventions
+automatically.
+
+### Diagnosing sync failures with `btmon`
+
+If the sync doesn't work and you want to understand *why*, `btmon` captures
+the HCI traffic during a connect attempt:
+
+```bash
+sudo btmon -w /tmp/trace.snoop &
+BTMON_PID=$!
+bluetoothctl connect <mac>
+# ... wait ~6 seconds ...
+sudo kill -INT $BTMON_PID
+sudo btmon -r /tmp/trace.snoop | grep -iE \
+    'LE Start Enc|Encryption Change|SMP:|Security Req|Authentication Fail|Disconnect'
+```
+
+What to look for:
+- **`LE Start Encryption`** (`cmd 0x08|0x0019`) shows the kernel sending
+  `Random number`, `Encrypted diversifier`, and `Long term key` — the
+  bytes here should match what's in your BlueZ info file. If they don't,
+  BlueZ didn't load the info file correctly (syntax error? wrong path?).
+- **`Encryption Change Status: Success (0x00)`** → the LTK is correct.
+  Done.
+- **`Encryption Change Status: Connection Timeout (0x08)`** + peripheral
+  `SMP: Security Request` → the LTK math value is wrong. Usually a
+  byte-order issue or a stale value from a previous pairing.
+- **`Authentication Requirement: ... Legacy, No Keypresses (0x05)`** in
+  the peripheral's Security Request → the device does Legacy pairing,
+  use `Authenticated=1`.
+- **`Authentication Requirement: ... Secure Connections, ... (0x0d)`**
+  in the peripheral's Security Request → use `Authenticated=2`.
+
+## Repository contents
+
+```
+contrib/brydge-10.5-keyboard/
+├── README.md                              ← this file
+├── install-bluez-5.62.sh                  ← downgrade + pin bluez for the trackpad
+└── sync-ble-pairing-from-windows.py       ← Windows → Linux BLE pairing sync helper
+```
+
+## Known limitations
+
+- **Ubuntu 22.04 / Debian-family only.** The install script uses apt and
+  pulls Debian .debs from snapshot.debian.org. Fedora / Arch users will
+  need to build bluez 5.62 from source — the tarball is at
+  <https://www.kernel.org/pub/linux/bluetooth/bluez-5.62.tar.xz>.
+- **x86_64 only.** The .deb URLs hard-code `_amd64.deb`. ARM Surface
+  users (Pro X, Pro 9 SQ3) need the `_arm64.deb` or `_armel.deb` variants
+  from the same snapshot directory.
+- **Not tested with LE Secure Connections peripherals.** The sync script
+  defaults to `Authenticated=1` because the Brydge is Legacy. The
+  `--force-sc` flag exists for LESC devices but hasn't been exercised
+  against a real LESC peripheral yet — file an issue if it doesn't work
+  for your device.
+- **No automatic Windows direction.** If you re-pair on Linux you'll
+  need to re-pair on Windows too (the script doesn't write into the
+  Windows registry). Adding that direction would mean handling
+  byte-order conversion in reverse and modifying Windows-side .reg
+  files via `reged -I`, which is doable but out of scope for this
+  contrib. See the main linux-surface issue tracker if you want to
+  pick it up.
+- **`[SlaveLongTermKey]`** isn't handled. A few older LE peripherals
+  use split LTKs (one per direction). The Brydge uses a single
+  symmetric LTK even in Legacy mode. If your device needs a slave
+  LTK, the script won't sync it.
+
+## References
+
+- [linux-surface/linux-surface#1569][1569] — parent tracking issue for
+  IPU3 camera tuning on Surface devices (separate from this work, but
+  another "Surface peripheral needs userspace workaround" story)
+- [bt-dualboot PR #34][pr34] — open attempt to add LE LongTermKey
+  support to bt-dualboot, partially solves the problem but doesn't
+  cover Windows-side subkey reading, byte-order conventions, or the
+  `Authenticated` field
+- [BlueZ upstream][bluez] — https://git.kernel.org/pub/scm/bluetooth/bluez.git/
+- [SMP spec, Core Spec v5.3 Vol 3 Part H][smp] — the authoritative
+  reference for LE pairing AuthReq bits
+
+[1569]: https://github.com/linux-surface/linux-surface/issues/1569
+[bluez]: https://git.kernel.org/pub/scm/bluetooth/bluez.git/
+[smp]: https://www.bluetooth.com/specifications/specs/core-specification-5-3/

--- a/contrib/brydge-10.5-keyboard/install-bluez-5.62.sh
+++ b/contrib/brydge-10.5-keyboard/install-bluez-5.62.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Install BlueZ 5.62 from the Debian snapshot archive to work around a
+# trackpad regression in BlueZ ≥ 5.64 that affects the Brydge 10.5 Go+
+# keyboard (and other HID-over-GATT devices that present keyboard + mouse
+# + trackpad as a composite HID descriptor).
+#
+# Symptom: on Ubuntu 22.04's stock bluez 5.64, the keyboard keys work but
+# the trackpad does NOT deliver cursor events — the input device shows
+# up in /dev/input/eventN but reports zero relative motion. Downgrading
+# the bluez daemon to 5.62 restores trackpad functionality.
+#
+# We pull the .debs from snapshot.debian.org (which archives every Debian
+# package version ever) because Ubuntu 22.04 never shipped 5.62 — Debian
+# did, in bullseye-backports / bookworm around late 2021.
+#
+# This is a deliberately simple install: download, install via apt, hold.
+# apt-mark hold prevents jammy-updates from silently reinstalling 5.64 the
+# next time you run `apt upgrade`.
+#
+# To reverse: sudo apt-mark unhold bluez libbluetooth3 bluez-obexd && \
+#             sudo apt install --reinstall bluez libbluetooth3 bluez-obexd
+
+set -euo pipefail
+
+TS="20211227T152656Z"   # snapshot.debian.org timestamp where 5.62-2 lives
+BASE="https://snapshot.debian.org/archive/debian/${TS}/pool/main/b/bluez"
+PKGS=(
+    "bluez_5.62-2_amd64.deb"
+    "bluez-obexd_5.62-2_amd64.deb"
+    "libbluetooth3_5.62-2_amd64.deb"
+)
+WORK="$(mktemp -d /tmp/bluez-5.62.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+if [[ $EUID -ne 0 ]]; then
+    echo "ERROR: must run as root (use sudo)" >&2
+    exit 1
+fi
+
+echo "==> Downloading BlueZ 5.62-2 .debs from snapshot.debian.org"
+for p in "${PKGS[@]}"; do
+    echo "  - $p"
+    curl -sSLf --retry 3 -o "$WORK/$p" "$BASE/$p"
+done
+
+echo "==> Installing"
+apt-get install -y --allow-downgrades \
+    "$WORK/libbluetooth3_5.62-2_amd64.deb" \
+    "$WORK/bluez_5.62-2_amd64.deb" \
+    "$WORK/bluez-obexd_5.62-2_amd64.deb"
+
+echo "==> Holding bluez packages to prevent automatic upgrade"
+apt-mark hold bluez libbluetooth3 bluez-obexd
+
+echo "==> Restarting bluetoothd"
+systemctl restart bluetooth.service
+
+echo "==> Installed versions:"
+dpkg -l bluez libbluetooth3 bluez-obexd 2>&1 | awk '/^[hi]/ {printf "  %-20s %s\n", $2, $3}'
+echo
+echo "==> Daemon version:"
+/usr/libexec/bluetooth/bluetoothd --version 2>&1 || \
+    /usr/lib/bluetooth/bluetoothd --version 2>&1 || \
+    echo "  (could not locate bluetoothd binary)"
+echo
+echo "Done. Reconnect your Brydge 10.5 Go+ — the trackpad should now work."

--- a/contrib/brydge-10.5-keyboard/sync-ble-pairing-from-windows.py
+++ b/contrib/brydge-10.5-keyboard/sync-ble-pairing-from-windows.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""
+Sync a single BLE device pairing from a Windows .reg export into BlueZ.
+
+Use case: dual-boot Windows/Linux with a BLE peripheral (keyboard, mouse,
+headset) that was (re)paired on Windows and is now refusing to connect on
+Linux because the stored LTK/EDiv/Rand are stale.
+
+This script does NOT mount the Windows registry or decide which pairing
+to sync — you do that yourself with `reged -x` and this script's --list
+output. It only reads a .reg file you produced and writes a BlueZ-format
+info file.
+
+Prerequisites
+-------------
+* Windows partition mounted (ro is fine).
+* chntpw/reged installed: `sudo apt install chntpw`.
+* Exported BTHPORT keys to a .reg file:
+    sudo reged -x /mnt/win/Windows/System32/config/SYSTEM \\
+        'HKEY_LOCAL_MACHINE\\SYSTEM' \\
+        '\\ControlSet001\\Services\\BTHPORT\\Parameters\\Keys\\<adapter-hex>' \\
+        out.reg
+  (use chntpw/reged, NOT chntpw -e with heredoc — it will loop forever and
+  fill your disk. See
+  https://github.com/linux-surface/linux-surface/issues/<whatever>)
+
+Workflow
+--------
+1. `sudo ./sync-ble-pairing-from-windows.py --list out.reg`
+   → prints every LE subkey with its address, IRK, LTK, EDiv/Rand, and
+     (critically) the matching BlueZ directory if one exists.
+2. Pick the device you want to sync and run:
+   `sudo ./sync-ble-pairing-from-windows.py --apply out.reg <hex-subkey> \\
+       --adapter-mac AC:67:5D:04:67:D4`
+3. Restart bluetoothd: `sudo systemctl restart bluetooth`
+4. Power on the device. It should connect within a few seconds.
+
+Byte-order conventions (empirically verified, April 2026)
+---------------------------------------------------------
+These differ from what you might expect by analogy with Classic Bluetooth
+sync tools (e.g. bt-dualboot, which only handles BR/EDR link keys anyway):
+
+* **IRK**: byte-reversed between Windows and Linux. Windows stores it
+  in one order; BlueZ's `Key=` hex string in `[IdentityResolvingKey]`
+  is the reverse. We verify this by cross-checking that the reversed
+  bytes match an existing Linux IRK for the same physical device.
+* **LTK**: NOT reversed. Windows `hex:b5,17,c0,...` becomes Linux
+  `Key=B517C0...` directly. Reversing the LTK produces
+  `HCI Encryption Change Status: Connection Timeout (0x08)` followed
+  by peripheral-initiated `SMP Security Request` — i.e. the peripheral
+  doesn't recognize the session and asks to re-pair.
+* **ERand**: Windows `hex(b):` is a little-endian u64. Convert to
+  BlueZ `Rand=<decimal>` via `int.from_bytes(bytes, "little")`.
+* **EDIV**: Windows dword → BlueZ decimal, straight conversion.
+* **Address**: Windows 8-byte blob is 6 MAC bytes little-endian +
+  2 padding bytes. Reverse the 6 to get the big-endian colon-separated
+  BlueZ MAC.
+* **Authenticated**: `1` for LE Legacy pairing (passkey entry / just-works
+  with MITM), `2` for LE Secure Connections. If you're not sure, try `1`
+  first — more peripherals are Legacy than SC, and the symptom of a wrong
+  choice is always a connection timeout, never corruption.
+
+What this script does NOT handle
+--------------------------------
+* BR/EDR (Classic Bluetooth) device sync — use bt-dualboot for those.
+* Writing from Linux back to Windows (so if you re-pair on Linux, you
+  still have to re-pair on Windows). This tool is one-directional:
+  Windows → Linux.
+* [SlaveLongTermKey] for LE Legacy pairings that split directions.
+  Most modern peripherals use a single symmetric LTK even in Legacy;
+  if your device needs a slave LTK you'll have to add it by hand.
+* Preserving `[ConnectionParameters]`, `[DeviceID]`, service UUIDs,
+  etc. beyond what was already in an existing info file. If a Linux
+  info file already exists for this device (matched by IRK), we merge
+  with it; otherwise we write a minimal info file and let bluetoothd
+  fill in the rest on first connect.
+"""
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+
+# ----- .reg parser -------------------------------------------------------
+
+_HEX_BYTE = re.compile(r"^[0-9a-fA-F]{2}$")
+
+
+def parse_reg_file(path):
+    """Parse a reged -x export into a dict of subkey -> {value: (type, bytes)}.
+
+    We only need two value types:
+      dword:XXXXXXXX  -> int
+      hex(b):xx,xx... -> bytes (REG_QWORD, little-endian)
+      hex:xx,xx...    -> bytes (REG_BINARY, order-preserved)
+    """
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        text = f.read()
+
+    out = {}
+    current = None
+    value_buffer = None
+    pending_line = ""
+
+    def commit_value(name, raw):
+        raw = raw.strip()
+        if raw.startswith("dword:"):
+            out[current][name] = ("dword", int(raw[6:], 16))
+        elif raw.startswith("hex(b):"):
+            b = bytes(int(x, 16) for x in raw[7:].split(",") if _HEX_BYTE.match(x))
+            out[current][name] = ("hexb", b)
+        elif raw.startswith("hex:"):
+            b = bytes(int(x, 16) for x in raw[4:].split(",") if _HEX_BYTE.match(x))
+            out[current][name] = ("hex", b)
+        else:
+            out[current][name] = ("raw", raw)
+
+    pending_name = None
+    pending_raw = ""
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip("\\")
+        if pending_name is not None:
+            pending_raw += line.strip()
+            if not raw_line.rstrip().endswith("\\"):
+                commit_value(pending_name, pending_raw)
+                pending_name = None
+                pending_raw = ""
+            continue
+
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            current = stripped[1:-1]
+            out.setdefault(current, {})
+            continue
+        if current is None:
+            continue
+        if "=" not in stripped:
+            continue
+        name, _, rest = stripped.partition("=")
+        name = name.strip().strip('"')
+        if raw_line.rstrip().endswith("\\"):
+            pending_name = name
+            pending_raw = rest.strip()
+        else:
+            commit_value(name, rest)
+
+    return out
+
+
+# ----- Windows → BlueZ field conversions ---------------------------------
+
+def to_linux_irk(win_bytes: bytes) -> str:
+    return win_bytes[::-1].hex().upper()
+
+
+def to_linux_ltk(win_bytes: bytes) -> str:
+    # Intentionally NOT reversed — see module docstring.
+    return win_bytes.hex().upper()
+
+
+def to_linux_rand(win_qword_le_bytes: bytes) -> int:
+    return int.from_bytes(win_qword_le_bytes, "little")
+
+
+def to_linux_mac(win_address_bytes: bytes) -> str:
+    return ":".join(f"{b:02X}" for b in win_address_bytes[:6][::-1])
+
+
+def win_authreq_uses_sc(authreq_dword: int) -> bool:
+    """DEPRECATED: bit 3 of the Windows-stored AuthReq octet indicates the
+    central's *capability* (LE Secure Connections supported), not the
+    negotiated mode. A peripheral that only supports Legacy will respond
+    with its own AuthReq (SC bit clear) and the session ends up Legacy
+    even though Windows stores 0x2d. We keep this function for reference
+    but we NO LONGER use it to auto-select Authenticated — see
+    DEFAULT_AUTHENTICATED below.
+    """
+    return bool(authreq_dword & 0x08)
+
+
+# Default [LongTermKey] Authenticated= for LE Legacy pairing with MITM
+# (passkey entry). This is the common case for Bluetooth HID peripherals
+# (keyboards, mice) with physical number pads for typing a pairing code.
+# Override with --force-sc if your device actually negotiates LESC.
+DEFAULT_AUTHENTICATED = 1
+
+
+# ----- LE subkey extraction ----------------------------------------------
+
+LE_KEY_FIELDS = ("LTK", "KeyLength", "ERand", "EDIV", "IRK", "Address", "AddressType", "AuthReq")
+
+
+def iter_le_subkeys(reg, adapter_hex):
+    prefix = f"HKEY_LOCAL_MACHINE\\SYSTEM\\ControlSet001\\Services\\BTHPORT\\Parameters\\Keys\\{adapter_hex}\\"
+    for section in reg:
+        if not section.startswith(prefix):
+            continue
+        subkey = section[len(prefix):]
+        # Subkey names are 12-hex-char device MACs.
+        if not re.match(r"^[0-9a-f]{12}$", subkey):
+            continue
+        values = reg[section]
+        # Must have at least LTK to be a useful LE pairing.
+        if "LTK" not in values:
+            continue
+        entry = {"subkey": subkey, "section": section}
+        for f in LE_KEY_FIELDS:
+            entry[f] = values.get(f)
+        yield entry
+
+
+def guess_adapter_hex(reg):
+    for section in reg:
+        m = re.search(
+            r"ControlSet001\\Services\\BTHPORT\\Parameters\\Keys\\([0-9a-f]{12})$",
+            section,
+        )
+        if m:
+            return m.group(1)
+    return None
+
+
+# ----- BlueZ info file writing -------------------------------------------
+
+def load_existing_info(info_path: Path):
+    """Return a simple {section: {key: value}} dict from an existing info
+    file, or {} if it doesn't exist."""
+    if not info_path.exists():
+        return {}
+    out = {}
+    current = None
+    for raw in info_path.read_text().splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            current = line[1:-1]
+            out.setdefault(current, {})
+            continue
+        if "=" in line and current is not None:
+            k, _, v = line.partition("=")
+            out[current][k.strip()] = v.strip()
+    return out
+
+
+def render_info(merged):
+    lines = []
+    for section, kv in merged.items():
+        lines.append(f"[{section}]")
+        for k, v in kv.items():
+            lines.append(f"{k}={v}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_info(entry, existing, authenticated):
+    merged = {
+        section: dict(kv) for section, kv in existing.items()
+    }
+
+    general = merged.setdefault("General", {})
+    general.setdefault("Name", "Unknown BLE Device")
+    general["AddressType"] = "static"  # addr-type 1 = random static
+    general.setdefault("SupportedTechnologies", "LE;")
+    general.setdefault("Trusted", "true")
+    general.setdefault("Blocked", "false")
+    general.setdefault("WakeAllowed", "true")
+
+    irk_bytes = entry["IRK"][1] if entry["IRK"] else None
+    ltk_bytes = entry["LTK"][1]
+    rand_bytes = entry["ERand"][1] if entry["ERand"] else None
+    ediv_int = entry["EDIV"][1] if entry["EDIV"] else 0
+
+    if irk_bytes:
+        merged["IdentityResolvingKey"] = {"Key": to_linux_irk(irk_bytes)}
+
+    merged["LongTermKey"] = {
+        "Key": to_linux_ltk(ltk_bytes),
+        "Authenticated": str(authenticated),
+        "EncSize": "16",
+        "EDiv": str(ediv_int),
+        "Rand": str(to_linux_rand(rand_bytes) if rand_bytes else 0),
+    }
+
+    # Drop any stale [SlaveLongTermKey] left over from a previous Legacy
+    # pairing — modern peripherals use symmetric LTK.
+    merged.pop("SlaveLongTermKey", None)
+    return merged
+
+
+# ----- CLI ----------------------------------------------------------------
+
+def cmd_list(args):
+    reg = parse_reg_file(args.reg_file)
+    adapter_hex = args.adapter_hex or guess_adapter_hex(reg)
+    if not adapter_hex:
+        print("Could not determine adapter hex from .reg. Pass --adapter-hex.",
+              file=sys.stderr)
+        return 1
+
+    print(f"Adapter (reg hex): {adapter_hex}")
+    print(f"Adapter MAC:       {':'.join(adapter_hex[i:i+2].upper() for i in range(0, 12, 2))}")
+    print()
+
+    found = 0
+    for entry in iter_le_subkeys(reg, adapter_hex):
+        found += 1
+        mac = to_linux_mac(entry["Address"][1]) if entry["Address"] else "(no Address value)"
+        irk = to_linux_irk(entry["IRK"][1]) if entry["IRK"] else "(no IRK — not resolvable)"
+        ediv = entry["EDIV"][1] if entry["EDIV"] else 0
+        authreq = entry["AuthReq"][1] if entry["AuthReq"] else 0
+        sc_capable = win_authreq_uses_sc(authreq)
+        print(f"  Subkey:        {entry['subkey']}")
+        print(f"  Address:       {mac}")
+        print(f"  AuthReq:       0x{authreq:02x} (central capability — NOT negotiated mode)")
+        print(f"                 SC bit {'set' if sc_capable else 'clear'}")
+        print(f"  EDIV:          {ediv}")
+        print(f"  IRK (Linux):   {irk}")
+        print(f"  LTK (Linux):   {to_linux_ltk(entry['LTK'][1])}")
+        print()
+    if found == 0:
+        print("No LE device subkeys under this adapter.")
+        return 1
+    print("NOTE: the 'apply' subcommand will default to Authenticated=1 (LE")
+    print("Legacy) for the [LongTermKey] section. If encryption fails after")
+    print("applying, try again with --force-sc to use Authenticated=2 instead.")
+    return 0
+
+
+def cmd_apply(args):
+    reg = parse_reg_file(args.reg_file)
+    adapter_hex = args.adapter_hex or guess_adapter_hex(reg)
+    if not adapter_hex:
+        print("Could not determine adapter hex. Pass --adapter-hex.", file=sys.stderr)
+        return 1
+
+    target = None
+    for entry in iter_le_subkeys(reg, adapter_hex):
+        if entry["subkey"].lower() == args.subkey.lower():
+            target = entry
+            break
+    if target is None:
+        print(f"No LE device subkey {args.subkey} under adapter {adapter_hex}",
+              file=sys.stderr)
+        return 1
+
+    if not target["Address"]:
+        print("Target has no Address value; cannot form a BlueZ directory name.",
+              file=sys.stderr)
+        return 1
+
+    mac = to_linux_mac(target["Address"][1])
+    if args.force_sc:
+        authenticated = 2
+    else:
+        # Default to Legacy. See the DEFAULT_AUTHENTICATED docstring for why
+        # we don't trust the Windows AuthReq SC bit for auto-detection.
+        authenticated = DEFAULT_AUTHENTICATED
+
+    adapter_mac = args.adapter_mac
+    if not adapter_mac:
+        adapter_mac = ":".join(adapter_hex[i:i+2].upper() for i in range(0, 12, 2))
+
+    dir_path = Path(f"/var/lib/bluetooth/{adapter_mac}/{mac}")
+    info_path = dir_path / "info"
+
+    if os.geteuid() != 0:
+        print(f"Need root to write to {info_path}", file=sys.stderr)
+        return 2
+
+    existing = load_existing_info(info_path)
+    merged = build_info(target, existing, authenticated)
+
+    dir_path.mkdir(parents=True, exist_ok=True)
+    os.chmod(dir_path, 0o700)
+    info_path.write_text(render_info(merged))
+    os.chmod(info_path, 0o600)
+
+    print(f"Wrote {info_path}")
+    print(f"  LTK:           {merged['LongTermKey']['Key']}")
+    print(f"  IRK:           {merged.get('IdentityResolvingKey', {}).get('Key', '(none)')}")
+    print(f"  EDiv:          {merged['LongTermKey']['EDiv']}")
+    print(f"  Rand:          {merged['LongTermKey']['Rand']}")
+    print(f"  Authenticated: {merged['LongTermKey']['Authenticated']}"
+          f" ({'LESC' if authenticated == 2 else 'Legacy'})")
+    print()
+    print("Next steps:")
+    print("  sudo systemctl restart bluetooth")
+    print("  # power on the device; it should auto-connect within a few seconds")
+    print("  # verify: bluetoothctl info", mac)
+    print()
+    print("If connection fails with 'Connection Timeout' in btmon:")
+    print("  - Try --force-legacy or --force-sc to flip the Authenticated value")
+    print("  - If that doesn't help, check the btmon trace for the actual LTK")
+    print("    the kernel is sending and compare to the value above")
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Sync a BLE device pairing from a Windows .reg export into BlueZ",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_list = sub.add_parser("list", help="show LE devices in the .reg export")
+    p_list.add_argument("reg_file", help="output of `reged -x ... SYSTEM ...`")
+    p_list.add_argument("--adapter-hex", help="adapter MAC as lowercase hex (no colons)")
+    p_list.set_defaults(func=cmd_list)
+
+    p_apply = sub.add_parser("apply", help="write a BlueZ info file for a specific LE device")
+    p_apply.add_argument("reg_file", help="output of `reged -x ... SYSTEM ...`")
+    p_apply.add_argument("subkey", help="device subkey (12 lowercase hex chars)")
+    p_apply.add_argument("--adapter-hex", help="adapter MAC as lowercase hex (no colons)")
+    p_apply.add_argument("--adapter-mac", help="adapter MAC in BlueZ format (e.g. AC:67:5D:04:67:D4)")
+    p_apply.add_argument("--force-legacy", action="store_true",
+                          help="set Authenticated=1 regardless of Windows AuthReq SC bit")
+    p_apply.add_argument("--force-sc", action="store_true",
+                          help="set Authenticated=2 regardless of Windows AuthReq SC bit")
+    p_apply.set_defaults(func=cmd_apply)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `contrib/brydge-10.5-keyboard/` with three components for Surface Go / Go 2 users running the **Brydge 10.5 Go+** detachable keyboard (composite BLE HID: keyboard + mouse + trackpad, Iton Technology Corp, VID `03F6`/PID `A001`) on Linux:

1. **`install-bluez-5.62.sh`** — downgrade-and-pin helper for the trackpad regression
2. **`sync-ble-pairing-from-windows.py`** — a Python helper that syncs a BLE pairing from a Windows registry `.reg` export into a BlueZ info file, for dual-booters
3. **`README.md`** — the writeup tying the three together

No kernel patches, no packaging changes. Everything under `contrib/` per the existing convention.

## The three problems it solves

### 1. BlueZ ≥ 5.64 breaks the trackpad

On Ubuntu 22.04 with the stock `bluez` 5.64, the Brydge 10.5 Go+ pairs successfully, keyboard input works, but **the trackpad produces no cursor motion**. The input node exists, `hid-multitouch` binds, `evtest` shows the device — but zero `EV_REL` events ever emit. I haven't bisected the exact bluez commit responsible; downgrading the bluez daemon to **5.62** restores trackpad functionality and everything else keeps working.

The script pulls the .debs from [snapshot.debian.org](https://snapshot.debian.org/package/bluez/5.62-2/) (Ubuntu 22.04 never shipped 5.62), installs them with `--allow-downgrades`, and `apt-mark hold`s them so a future `apt upgrade` can't silently clobber the fix. There's also a one-command reverse path in the README for when upstream bluez gets fixed.

### 2. Initial pairing is straightforward but worth documenting

Standard LE Legacy pairing with passkey entry — the keyboard shows the prompt, you type 6 digits, you're bonded. The README documents the expected `dmesg` output (`Brydge 10.5 Go+ Keyboard` + `Mouse` + composite trackpad HID devices) so people can tell whether the trackpad regression has bitten them or not.

### 3. Dual-boot key sync: the LTK byte-order gotcha

The usual tool for Windows↔Linux Bluetooth sync is [bt-dualboot](https://github.com/x2es/bt-dualboot). **It doesn't handle LE** — `bt_windows/devices.py` only reads adapter-level `"MAC"=hex:...` values (Classic Bluetooth link keys) and ignores the LE device subkeys under the adapter key entirely. [PR #34](https://github.com/x2es/bt-dualboot/pull/34) attempts to add LE support but has been sitting unreviewed for over a year and only addresses the Linux reading side, not Windows-side subkey extraction or byte-order conventions.

So the included `sync-ble-pairing-from-windows.py` is a standalone Python helper:

```bash
sudo reged -x /mnt/win/Windows/System32/config/SYSTEM 'HKEY_LOCAL_MACHINE\SYSTEM' \
    '\ControlSet001\Services\BTHPORT\Parameters\Keys\<adapter-hex>' out.reg
sudo ./sync-ble-pairing-from-windows.py list out.reg
sudo ./sync-ble-pairing-from-windows.py apply out.reg <subkey> --adapter-mac AC:...
sudo systemctl restart bluetooth
```

The script handles the empirically-verified byte-order conventions for LE keys, which differ from Classic Bluetooth:

| Field | Reversal? | Notes |
|---|---|---|
| IRK | **yes** | Windows → Linux reverses the 16 bytes |
| LTK | **no** | Same byte order on both sides. Reversing produces `Connection Timeout (0x08)` on `Encryption Change` |
| ERand | conversion | Windows `hex(b)` is LE u64 → BlueZ decimal |
| EDIV | conversion | dword → decimal |
| Address | reverse 6 of 8 | Windows stores 6 MAC bytes LE + 2 padding |

I verified these by running `btmon -w` during a failing and a succeeding connect attempt and comparing the `HCI LE Start Encryption` payloads against the peripheral's `SMP Security Request` response. The failure mode for a wrong LTK byte order is characteristic: kernel sends `LE Start Encryption`, peripheral echoes back `SMP: Security Request ... Legacy`, kernel gets `Encryption Change Status: Connection Timeout (0x08)` and disconnects with `Reason: Authentication Failure (0x05)`. It took several iterations on a real keyboard to get this right, so baking it into a script feels better than leaving it as folklore in a gist somewhere.

## Known scope gaps (documented in README, flagging here for reviewers)

- **x86_64 only**: the install script hard-codes `_amd64.deb`. ARM Surface devices would need `_arm64.deb` from the same snapshot directory
- **One-directional sync**: Windows → Linux only. If you re-pair on Linux you still need to re-pair on Windows (adding the other direction means writing into the Windows registry with `reged -I`, doable but out of scope here)
- **No `[SlaveLongTermKey]` handling**: the Brydge uses a single symmetric LTK; older LE peripherals with split LTKs aren't supported
- **Not a proper upstream bluez fix**: I pin 5.62 instead of bisecting and patching the regression. A bisect/patch contribution to bluez upstream would obsolete this workaround and would be welcome

## Related

- [linux-surface/linux-surface#1569](https://github.com/linux-surface/linux-surface/issues/1569) — the parallel "Surface peripheral needs userspace workaround" story for IPU3 cameras (separate from this; a companion PR for that one was recently merged into this same `contrib/` directory)
- [x2es/bt-dualboot#34](https://github.com/x2es/bt-dualboot/pull/34) — open upstream attempt at LE support in bt-dualboot; I've added a comment there cross-linking this PR and summarizing the byte-order findings in case anyone wants to pick up the upstream work
- bluez upstream: https://git.kernel.org/pub/scm/bluetooth/bluez.git/