### PR TITLE
.github: Remove 'Maximize disk space'

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -10,20 +10,12 @@ on:
 
   repository_dispatch:
   workflow_dispatch:
-  
+
 jobs:
   build:
     name: Build Kernel
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 5120
-          remove-dotnet: true
-          remove-android: true
-          remove-docker-images: true
-
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -16,14 +16,6 @@ jobs:
     name: Build Kernel
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 5120
-          remove-dotnet: true
-          remove-android: true
-          remove-docker-images: true
-
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/fedora-40.yml
+++ b/.github/workflows/fedora-40.yml
@@ -17,14 +17,6 @@ jobs:
     name: Build Kernel
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 5120
-          remove-dotnet: true
-          remove-android: true
-          remove-docker-images: true
-
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/fedora-41.yml
+++ b/.github/workflows/fedora-41.yml
@@ -17,14 +17,6 @@ jobs:
     name: Build Kernel
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 5120
-          remove-dotnet: true
-          remove-android: true
-          remove-docker-images: true
-
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/fedora-42.yml
+++ b/.github/workflows/fedora-42.yml
@@ -17,14 +17,6 @@ jobs:
     name: Build Kernel
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 5120
-          remove-dotnet: true
-          remove-android: true
-          remove-docker-images: true
-
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/fedora-43.yml
+++ b/.github/workflows/fedora-43.yml
@@ -17,14 +17,6 @@ jobs:
     name: Build Kernel
     runs-on: ubuntu-latest
     steps:
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 5120
-          remove-dotnet: true
-          remove-android: true
-          remove-docker-images: true
-
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/rebase-kernel.yml
+++ b/.github/workflows/rebase-kernel.yml
@@ -34,15 +34,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 10240  # Reserve 10GB for build
-          remove-dotnet: true
-          remove-android: true
-          remove-docker-images: true
-          remove-haskell: true
-
       - name: Checkout linux-surface repo
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
The 'Maximize disk space' stage is not needed anymore. The current GitHub public workers have enough disk space for the kernel to build.

Also, this, at least partially, addresses #2055 . I can confirm this fixes the Debian build and doesn't break the Arch build. Debian fails due to not enough space at `/tmp`. It is caused by 'Maximize disk space'. Fedora fails at a later stage on my fork so i can't be sure but it seems this at least fixes the reported issue with Fedora too.