### PR TITLE
patches/v6.18: Automatic update to v6.18.23

### DIFF
--- a/patches/6.18/0001-secureboot.patch
+++ b/patches/6.18/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From b342b1a9a445ba8b8aa73b945f25740e3cd8da58 Mon Sep 17 00:00:00 2001
+From fb0a9b457a29bafedff164f5f788cb02329b80d9 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -35,7 +35,7 @@ index 9bea5a1e2..25848f886 100644
 -- 
 2.53.0
 
-From b106412124df576bc860bb2fdf1e1d3678a3fe75 Mon Sep 17 00:00:00 2001
+From 66b94d116fd49803bb7425526f5bdd9c2c178648 Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter
@@ -53,7 +53,7 @@ Patchset: secureboot
  2 files changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index 6c42061ca..f7cb5669b 100644
+index ab4e03f91..4bbafc25f 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
 @@ -3342,6 +3342,11 @@

--- a/patches/6.18/0002-surface3.patch
+++ b/patches/6.18/0002-surface3.patch
@@ -1,4 +1,4 @@
-From 0a7aed31749d66652fd63b5843fa6b97febdb2d1 Mon Sep 17 00:00:00 2001
+From e7d02f8093a14a1df2954d9c7daab3d3d6accdce Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI
@@ -99,7 +99,7 @@ index e4c3492a0..0b930c91b 100644
 -- 
 2.53.0
 
-From 4dcd8430344c4c7d852ffc32e3ad29ee7313e371 Mon Sep 17 00:00:00 2001
+From 7b6841b6a66a1d66918202f44e03949daf4a1864 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
 Subject: [PATCH] surface3-spi: workaround: disable DMA mode to avoid crash by

--- a/patches/6.18/0003-mwifiex.patch
+++ b/patches/6.18/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From 126a8c1d504d8377d222b88bc2d19313eacf8244 Mon Sep 17 00:00:00 2001
+From ecbdfcf858773b59c01cc6b1824f23af77dab9cd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -165,7 +165,7 @@ index d6ff964ae..5d30ae39d 100644
 -- 
 2.53.0
 
-From 80cb290812b649955d874929dd84559fbdaaa9d6 Mon Sep 17 00:00:00 2001
+From 1f124510ac15ba15b43e02b9503453878596e00f Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -320,7 +320,7 @@ index 5d30ae39d..c14eb56eb 100644
 -- 
 2.53.0
 
-From c5d8dc3870658c58d7fff6ee6a58163f8335dd9a Mon Sep 17 00:00:00 2001
+From d9bee29193d3692dba264f2463e01a05072eb7fe Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell
@@ -356,7 +356,7 @@ Patchset: mwifiex
  1 file changed, 15 insertions(+)
 
 diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
-index 7c7955afa..c1c464bf3 100644
+index 40f0c3b4e..f1573b6ef 100644
 --- a/drivers/bluetooth/btusb.c
 +++ b/drivers/bluetooth/btusb.c
 @@ -67,6 +67,7 @@ static struct usb_driver btusb_driver;
@@ -375,7 +375,7 @@ index 7c7955afa..c1c464bf3 100644
  
  	/* Intel Bluetooth devices */
  	{ USB_DEVICE(0x8087, 0x0025), .driver_info = BTUSB_INTEL_COMBINED },
-@@ -4201,6 +4203,19 @@ static int btusb_probe(struct usb_interface *intf,
+@@ -4204,6 +4206,19 @@ static int btusb_probe(struct usb_interface *intf,
  	if (id->driver_info & BTUSB_MARVELL)
  		hdev->set_bdaddr = btusb_set_bdaddr_marvell;
  

--- a/patches/6.18/0004-ath10k.patch
+++ b/patches/6.18/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From 69078fd9804149d199b3fa8e713b80760a11b596 Mon Sep 17 00:00:00 2001
+From dcd13e01631b5dab0fb7bd823bf26caadb9c71d5 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files

--- a/patches/6.18/0005-ipts.patch
+++ b/patches/6.18/0005-ipts.patch
@@ -1,4 +1,4 @@
-From d87fa52961781a386b63b57e26ca965f20a20f9a Mon Sep 17 00:00:00 2001
+From 7ae8f0a4b266bd2e904f4a06d84ff5805a920c54 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -37,7 +37,7 @@ index 2a6e56955..c19dfba54 100644
 -- 
 2.53.0
 
-From 9c1a6cafefa706cc777274302be1956509067f7c Mon Sep 17 00:00:00 2001
+From 9f3827ae1fdd9f4842fb645b4391b20a38f74ef3 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -144,7 +144,7 @@ index 49e83c856..a3e35c77d 100644
 -- 
 2.53.0
 
-From 4e909ce1db9f221bec5f6761da1c74868e646567 Mon Sep 17 00:00:00 2001
+From 58b9959851543e07948c71f987ab658a6fa47f72 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus

--- a/patches/6.18/0006-ithc.patch
+++ b/patches/6.18/0006-ithc.patch
@@ -1,4 +1,4 @@
-From 7889794c87f8ead7509001798da50606553010d4 Mon Sep 17 00:00:00 2001
+From 6b8f4b24d8f28a70849b77891f7dfbf3ad9d8240 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -39,7 +39,7 @@ index 8bcbfe3d9..c78806d35 100644
 -- 
 2.53.0
 
-From 0a194a407857f526d06d1e459b81faa5be2e4275 Mon Sep 17 00:00:00 2001
+From cc940c8ee4bb32cd7dafed5a3551e850c04b314f Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller

--- a/patches/6.18/0007-surface-sam.patch
+++ b/patches/6.18/0007-surface-sam.patch
@@ -1,4 +1,4 @@
-From d0c0e2cf7bca1d124ec51f129d2ae259d0291cb5 Mon Sep 17 00:00:00 2001
+From 5b476e65c698a51765c1ad428588308409551814 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
 Subject: [PATCH] rtc: Add basic support for RTC via Surface System Aggregator
@@ -181,7 +181,7 @@ index 000000000..f6c17c4e9
 -- 
 2.53.0
 
-From da4d9417542e3a5ba645dc5c069c8709344c6d7d Mon Sep 17 00:00:00 2001
+From 42f0c5510ed164b53161e716e09bcf5f213df729 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
 Subject: [PATCH] platform/surface: aggregator_registry: Add Surface Laptop 7

--- a/patches/6.18/0008-surface-sam-over-hid.patch
+++ b/patches/6.18/0008-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From a7cb180b16908683b3716d74a61c98c7f5fc1b46 Mon Sep 17 00:00:00 2001
+From ed68d21cd942a32691e27d2fff3697577f86c743 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -109,7 +109,7 @@ index ed90858a2..070c36637 100644
 -- 
 2.53.0
 
-From 6b54c1290d843259d1c732221e863ae35d648a2d Mon Sep 17 00:00:00 2001
+From 1c18bd1447447644b4876fbd84b8463b43316899 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch

--- a/patches/6.18/0009-surface-button.patch
+++ b/patches/6.18/0009-surface-button.patch
@@ -1,4 +1,4 @@
-From 298e817335b8804e0b889f25237d4282917a46b0 Mon Sep 17 00:00:00 2001
+From d9c48b0de9b9ab38121704fb554118cd8ecc6cf8 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -75,7 +75,7 @@ index b8cad415c..43b5d5638 100644
 -- 
 2.53.0
 
-From 55c5ef0db3fd3ec8ef996ab1cf229f5b6a01c659 Mon Sep 17 00:00:00 2001
+From 198f6854ca6ce37aef5e972965961e21757b5811 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd

--- a/patches/6.18/0010-surface-typecover.patch
+++ b/patches/6.18/0010-surface-typecover.patch
@@ -1,4 +1,4 @@
-From 65586462f66578997979fffce0d14c364e97bd24 Mon Sep 17 00:00:00 2001
+From a5cebe5c45a119c6e30fc5bc8f68d5c990a6cfc7 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -23,10 +23,10 @@ Patchset: surface-typecover
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
-index c4d85089d..3d0d35c72 100644
+index 34b1f7df3..6fe00d310 100644
 --- a/drivers/usb/core/quirks.c
 +++ b/drivers/usb/core/quirks.c
-@@ -223,6 +223,9 @@ static const struct usb_device_id usb_quirk_list[] = {
+@@ -229,6 +229,9 @@ static const struct usb_device_id usb_quirk_list[] = {
  	/* Microsoft Surface Dock Ethernet (RTL8153 GigE) */
  	{ USB_DEVICE(0x045e, 0x07c6), .driver_info = USB_QUIRK_NO_LPM },
  
@@ -39,7 +39,7 @@ index c4d85089d..3d0d35c72 100644
 -- 
 2.53.0
 
-From 66f68837779ede11cda8e29afc46ce0f43cfa081 Mon Sep 17 00:00:00 2001
+From 856c08cb02e34c2568539eab7e8874923c95c2da Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -75,7 +75,7 @@ Patchset: surface-typecover
  1 file changed, 98 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index af19e089b..ab040ea64 100644
+index 21bfaf9bb..0e1e191e1 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -35,7 +35,10 @@
@@ -147,7 +147,7 @@ index af19e089b..ab040ea64 100644
  	{ }
  };
  
-@@ -1928,6 +1948,69 @@ static void mt_expired_timeout(struct timer_list *t)
+@@ -1935,6 +1955,69 @@ static void mt_expired_timeout(struct timer_list *t)
  	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
  }
  
@@ -217,7 +217,7 @@ index af19e089b..ab040ea64 100644
  static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  {
  	int ret, i;
-@@ -1956,6 +2039,9 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1963,6 +2046,9 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  	td->inputmode_value = MT_INPUTMODE_TOUCHSCREEN;
  	hid_set_drvdata(hdev, td);
  
@@ -227,7 +227,7 @@ index af19e089b..ab040ea64 100644
  	INIT_LIST_HEAD(&td->applications);
  	INIT_LIST_HEAD(&td->reports);
  
-@@ -1994,8 +2080,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -2001,8 +2087,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  	timer_setup(&td->release_timer, mt_expired_timeout, 0);
  
  	ret = hid_parse(hdev);
@@ -239,7 +239,7 @@ index af19e089b..ab040ea64 100644
  
  	if (mtclass->name == MT_CLS_APPLE_TOUCHBAR &&
  	    !hid_find_field(hdev, HID_INPUT_REPORT,
-@@ -2009,8 +2097,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -2016,8 +2104,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  		hdev->quirks |= HID_QUIRK_NOGET;
  
  	ret = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
@@ -251,7 +251,7 @@ index af19e089b..ab040ea64 100644
  
  	ret = sysfs_create_group(&hdev->dev.kobj, &mt_attribute_group);
  	if (ret)
-@@ -2071,6 +2161,7 @@ static void mt_remove(struct hid_device *hdev)
+@@ -2078,6 +2168,7 @@ static void mt_remove(struct hid_device *hdev)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  
@@ -259,7 +259,7 @@ index af19e089b..ab040ea64 100644
  	timer_delete_sync(&td->release_timer);
  
  	sysfs_remove_group(&hdev->dev.kobj, &mt_attribute_group);
-@@ -2538,6 +2629,11 @@ static const struct hid_device_id mt_devices[] = {
+@@ -2545,6 +2636,11 @@ static const struct hid_device_id mt_devices[] = {
  		HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
  			USB_DEVICE_ID_APPLE_TOUCHBAR_DISPLAY) },
  
@@ -274,7 +274,7 @@ index af19e089b..ab040ea64 100644
 -- 
 2.53.0
 
-From 6612b8a0b4db1e57a95fad53ebfe68ba90bc8faf Mon Sep 17 00:00:00 2001
+From abb18308737c4941b2ecbecf83ccb943510eb92e Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet
@@ -303,7 +303,7 @@ Patchset: surface-typecover
  1 file changed, 122 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index ab040ea64..ee9c073af 100644
+index 0e1e191e1..cab90b5c3 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -83,6 +83,7 @@ MODULE_LICENSE("GPL");
@@ -331,7 +331,7 @@ index ab040ea64..ee9c073af 100644
  			MT_QUIRK_ALWAYS_VALID |
  			MT_QUIRK_IGNORE_DUPLICATES |
  			MT_QUIRK_HOVERING |
-@@ -1492,6 +1496,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+@@ -1499,6 +1503,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
  	    field->application != HID_CP_CONSUMER_CONTROL &&
  	    field->application != HID_GD_WIRELESS_RADIO_CTLS &&
  	    field->application != HID_GD_SYSTEM_MULTIAXIS &&
@@ -341,7 +341,7 @@ index ab040ea64..ee9c073af 100644
  	    !(field->application == HID_VD_ASUS_CUSTOM_MEDIA_KEYS &&
  	      application->quirks & MT_QUIRK_ASUS_CUSTOM_UP))
  		return -1;
-@@ -1519,6 +1526,21 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+@@ -1526,6 +1533,21 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
  		return 1;
  	}
  
@@ -363,7 +363,7 @@ index ab040ea64..ee9c073af 100644
  	if (rdata->is_mt_collection)
  		return mt_touch_input_mapping(hdev, hi, field, usage, bit, max,
  					      application);
-@@ -1545,6 +1567,7 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+@@ -1552,6 +1574,7 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  	struct mt_report_data *rdata;
@@ -371,7 +371,7 @@ index ab040ea64..ee9c073af 100644
  
  	rdata = mt_find_report_data(td, field->report);
  	if (rdata && rdata->is_mt_collection) {
-@@ -1552,6 +1575,19 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+@@ -1559,6 +1582,19 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
  		return -1;
  	}
  
@@ -391,7 +391,7 @@ index ab040ea64..ee9c073af 100644
  	/* let hid-core decide for the others */
  	return 0;
  }
-@@ -1561,11 +1597,21 @@ static int mt_event(struct hid_device *hid, struct hid_field *field,
+@@ -1568,11 +1604,21 @@ static int mt_event(struct hid_device *hid, struct hid_field *field,
  {
  	struct mt_device *td = hid_get_drvdata(hid);
  	struct mt_report_data *rdata;
@@ -413,7 +413,7 @@ index ab040ea64..ee9c073af 100644
  	return 0;
  }
  
-@@ -1780,6 +1826,42 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app)
+@@ -1787,6 +1833,42 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app)
  		app->quirks &= ~MT_QUIRK_CONTACT_CNT_ACCURATE;
  }
  
@@ -456,7 +456,7 @@ index ab040ea64..ee9c073af 100644
  static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
-@@ -1838,6 +1920,13 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
+@@ -1845,6 +1927,13 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
  		/* force BTN_STYLUS to allow tablet matching in udev */
  		__set_bit(BTN_STYLUS, hi->input->keybit);
  		break;
@@ -470,7 +470,7 @@ index ab040ea64..ee9c073af 100644
  	default:
  		suffix = "UNKNOWN";
  		break;
-@@ -1948,30 +2037,6 @@ static void mt_expired_timeout(struct timer_list *t)
+@@ -1955,30 +2044,6 @@ static void mt_expired_timeout(struct timer_list *t)
  	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
  }
  
@@ -501,7 +501,7 @@ index ab040ea64..ee9c073af 100644
  static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
  {
  	struct usb_device *udev = hid_to_usb_dev(hdev);
-@@ -1980,8 +2045,9 @@ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
+@@ -1987,8 +2052,9 @@ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
  	/* Wake up the device in case it's already suspended */
  	pm_runtime_get_sync(&udev->dev);
  
@@ -513,7 +513,7 @@ index ab040ea64..ee9c073af 100644
  		hid_err(hdev, "couldn't find backlight field\n");
  		goto out;
  	}
-@@ -2139,13 +2205,24 @@ static int mt_suspend(struct hid_device *hdev, pm_message_t state)
+@@ -2146,13 +2212,24 @@ static int mt_suspend(struct hid_device *hdev, pm_message_t state)
  
  static int mt_reset_resume(struct hid_device *hdev)
  {
@@ -538,7 +538,7 @@ index ab040ea64..ee9c073af 100644
  	/* Some Elan legacy devices require SET_IDLE to be set on resume.
  	 * It should be safe to send it to other devices too.
  	 * Tested on 3M, Stantum, Cypress, Zytronic, eGalax, and Elan panels. */
-@@ -2154,12 +2231,31 @@ static int mt_resume(struct hid_device *hdev)
+@@ -2161,12 +2238,31 @@ static int mt_resume(struct hid_device *hdev)
  
  	mt_set_modes(hdev, HID_LATENCY_NORMAL, TOUCHPAD_REPORT_ALL);
  

--- a/patches/6.18/0011-surface-shutdown.patch
+++ b/patches/6.18/0011-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From f4dbafd07e1b1f9f5c1656646443c6e58528a62d Mon Sep 17 00:00:00 2001
+From 35b330c9e8be245712b6b03a24067238a925f717 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
@@ -95,7 +95,7 @@ index 05aeee8c8..006ea71ce 100644
 -- 
 2.53.0
 
-From fd4fa0b63f720afbebfd215e5337ecf847eb3c9c Mon Sep 17 00:00:00 2001
+From 7eeafbda8f7d958adb3bcb13c23c4bbd5d140a43 Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Wed, 7 Jan 2026 01:06:25 +0100
 Subject: [PATCH] PCI: Add Surface Laptop Studio 2 devices to shutdown ops

--- a/patches/6.18/0012-surface-gpe.patch
+++ b/patches/6.18/0012-surface-gpe.patch
@@ -1,4 +1,4 @@
-From 6a418143256e871795b4ddb618e151e1186e341c Mon Sep 17 00:00:00 2001
+From be1d19bd4bde5da443c407678fdf330af5529a8c Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9

--- a/patches/6.18/0013-cameras.patch
+++ b/patches/6.18/0013-cameras.patch
@@ -1,4 +1,4 @@
-From 6d89ae89f9a4b6613019c0964c1c59e823755abf Mon Sep 17 00:00:00 2001
+From 585aa9b0d1e95bd5257ece7a46e9b8acc1102b94 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -74,7 +74,7 @@ index ef16d58b2..a6bad2679 100644
 -- 
 2.53.0
 
-From c6b57220a5b99a279d2eb4197f290c9ff2127a9e Mon Sep 17 00:00:00 2001
+From 0c09862e51373ccd764859cbb726e1b73a915463 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -184,7 +184,7 @@ index a3e35c77d..28567ba59 100644
 -- 
 2.53.0
 
-From adfe6d571518a91dc024839f490d68dc83892814 Mon Sep 17 00:00:00 2001
+From 0953de627f07f802ffdaf6572a1e6f8aa4e97967 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -221,7 +221,7 @@ index 013340569..9e0763bdc 100644
 -- 
 2.53.0
 
-From 2a5f75ce5abfd79f192bcabecfaaddb494a126ef Mon Sep 17 00:00:00 2001
+From 672d16969b765e2920064c7f2b19c4cfc68f89f6 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -260,7 +260,7 @@ index 27afc3fc0..28b192c9a 100644
 -- 
 2.53.0
 
-From 91a6592078b6ac05615ebb6de7936f24723e6364 Mon Sep 17 00:00:00 2001
+From 9fc5f1f439b88c84ccd6c5da69ca3b68cead2660 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -311,7 +311,7 @@ index cb153ce42..f11b499e1 100644
 -- 
 2.53.0
 
-From 71d9f6f5a29533047a4ba72646f1a6c3bf2ccfc5 Mon Sep 17 00:00:00 2001
+From 750fb29899e231f43be8df95a550fe182532f45b Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -352,7 +352,7 @@ index 9e0763bdc..0976b2679 100644
 -- 
 2.53.0
 
-From 3b5333d4354852e552f2250b2cefa33a3d307e0d Mon Sep 17 00:00:00 2001
+From be363880c69e7639aab3f297231d65414f027de6 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -393,7 +393,7 @@ index 7807fa329..2d2abb25b 100644
 -- 
 2.53.0
 
-From 14bab8cfe711721bedae032517272f5c1eda237c Mon Sep 17 00:00:00 2001
+From a5d095dd4555d42b82119fc60124a3f76fcb16ff Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -644,7 +644,7 @@ index 000000000..35aeb5db8
 -- 
 2.53.0
 
-From 8385a094f55efa199beac99879304d048a9ed696 Mon Sep 17 00:00:00 2001
+From 73810e8a4677be537ac581c537a3ac740948ae05 Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2
@@ -676,7 +676,7 @@ index 032fbcb98..e03a1d8cd 100644
 -- 
 2.53.0
 
-From 6caa822dedfe4d4a164070424caae770db458798 Mon Sep 17 00:00:00 2001
+From d37380ee4a2051eb3c0ee9dc3f7b8a4be14f01c7 Mon Sep 17 00:00:00 2001
 From: Tooraj Taraz <tooraj.taraz@yahoo.com>
 Date: Wed, 31 Dec 2025 00:35:50 +0100
 Subject: [PATCH] Add camera support for Surface Pro 9
@@ -1017,7 +1017,7 @@ index 1505fc3ef..20962e8ac 100644
 -- 
 2.53.0
 
-From b8440f1dcf2ce055afd00c733546fa209c74c09d Mon Sep 17 00:00:00 2001
+From ea86d6e2b4e995b03855aee0a6da2c53d0555a7c Mon Sep 17 00:00:00 2001
 From: gabrielstedman <gabrielstedman@users.noreply.github.com>
 Date: Fri, 13 Mar 2026 08:52:07 +0000
 Subject: [PATCH] media: ipu-bridge: Add front camera rotation quirks for

--- a/patches/6.18/0014-amd-gpio.patch
+++ b/patches/6.18/0014-amd-gpio.patch
@@ -1,4 +1,4 @@
-From a6c275f92edf5ac7d5528a240a961d3697e0e900 Mon Sep 17 00:00:00 2001
+From 449ec6c56021ddb814e872d0d1dd8ffdd7cb8d55 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -65,7 +65,7 @@ index d6138b2b6..67094184c 100644
 -- 
 2.53.0
 
-From 9b1d1ebf89898d157aed1cc245368a992fbef83e Mon Sep 17 00:00:00 2001
+From 21c736b3d4859262e0b36ad5db06b374d5643278 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override

--- a/patches/6.18/0015-rtc.patch
+++ b/patches/6.18/0015-rtc.patch
@@ -1,4 +1,4 @@
-From 6103981ac27c5d9ff98baada8ed6befeafab2242 Mon Sep 17 00:00:00 2001
+From bb4272ff83d10013d08f545467898a9076cc4e75 Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms

--- a/patches/6.18/0016-hid-surface.patch
+++ b/patches/6.18/0016-hid-surface.patch
@@ -1,4 +1,4 @@
-From 9f5befc32ec4d2f7124a03afd88b0b3070b822c6 Mon Sep 17 00:00:00 2001
+From 74affb42d0ecfb9ad8dac496af0949fa2fb01007 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ciar=C3=A1n=20Coffey?= <github@ccoffey.ie>
 Date: Fri, 10 Oct 2025 19:04:03 +0100
 Subject: [PATCH] HID: Add hid-surface driver to filter BTN_0 (FN key)
@@ -156,7 +156,7 @@ index 000000000..a171ea656
 -- 
 2.53.0
 
-From 0c2e6a571542e179a7461d38efd2ce8d590a3f35 Mon Sep 17 00:00:00 2001
+From 8ddef290ab5dc30510220e3f7f8ec380897679f8 Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Fri, 13 Mar 2026 10:16:37 +0100
 Subject: [PATCH] hid/multitouch: Prevent mode set on Surface Laptop Studio 2
@@ -171,7 +171,7 @@ Patchset: hid-surface
  1 file changed, 31 insertions(+)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index ee9c073af..d6f2a286c 100644
+index cab90b5c3..a2ec352e5 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -84,6 +84,7 @@ MODULE_LICENSE("GPL");
@@ -201,7 +201,7 @@ index ee9c073af..d6f2a286c 100644
  	{ }
  };
  
-@@ -2266,6 +2272,17 @@ static void mt_remove(struct hid_device *hdev)
+@@ -2273,6 +2279,17 @@ static void mt_remove(struct hid_device *hdev)
  
  static void mt_on_hid_hw_open(struct hid_device *hdev)
  {
@@ -219,7 +219,7 @@ index ee9c073af..d6f2a286c 100644
  	mt_set_modes(hdev, HID_LATENCY_NORMAL, TOUCHPAD_REPORT_ALL);
  }
  
-@@ -2273,6 +2290,15 @@ static void mt_on_hid_hw_close(struct hid_device *hdev)
+@@ -2280,6 +2297,15 @@ static void mt_on_hid_hw_close(struct hid_device *hdev)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  
@@ -235,7 +235,7 @@ index ee9c073af..d6f2a286c 100644
  	if (td->mtclass.quirks & MT_QUIRK_KEEP_LATENCY_ON_CLOSE)
  		mt_set_modes(hdev, HID_LATENCY_NORMAL, TOUCHPAD_REPORT_NONE);
  	else
-@@ -2730,6 +2756,11 @@ static const struct hid_device_id mt_devices[] = {
+@@ -2737,6 +2763,11 @@ static const struct hid_device_id mt_devices[] = {
  		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY,
  			USB_VENDOR_ID_MICROSOFT, 0x09c0) },
  


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.18** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.18-surface`
- **Base version**: `v6.18.23`
- **Patches generated**: 16
- **Patches directory**: `patches/6.18/`

### Changes
This PR updates kernel patches to the latest version from the `v6.18-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.18-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.