### PR TITLE
patches/v6.19: Automatic update to v6.19.14

### DIFF
--- a/patches/6.19/0001-secureboot.patch
+++ b/patches/6.19/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From 7d201613b9e598df5b51b9345a54ecadaac3eb20 Mon Sep 17 00:00:00 2001
+From 1d5af7c6d77df25d8802dd9e4acda90613beb1c9 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -35,7 +35,7 @@ index 9bea5a1e2..25848f886 100644
 -- 
 2.53.0
 
-From 68d5a2a32c55afab7aed55f9334f35bff9f7b119 Mon Sep 17 00:00:00 2001
+From daf3b7b7b67df4a8adc61daf9eed94f9934dd7ae Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter
@@ -53,7 +53,7 @@ Patchset: secureboot
  2 files changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index aa0031108..ca92d0e45 100644
+index f31e9e4c5..648e585dd 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
 @@ -3500,6 +3500,11 @@ Kernel parameters

--- a/patches/6.19/0002-surface3.patch
+++ b/patches/6.19/0002-surface3.patch
@@ -1,4 +1,4 @@
-From 768f0e265602d98b3c51a39a5a4259937fb795b4 Mon Sep 17 00:00:00 2001
+From a2b592aba9b0600331fab253eacbfebee018bf8f Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI
@@ -99,7 +99,7 @@ index e4c3492a0..0b930c91b 100644
 -- 
 2.53.0
 
-From 092d2600301127e07e9f0a9376e78453578d30ba Mon Sep 17 00:00:00 2001
+From cf41b8c2380bd43387260a9046eeab60af3d8bd6 Mon Sep 17 00:00:00 2001
 From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
 Date: Fri, 6 Dec 2019 23:10:30 +0900
 Subject: [PATCH] surface3-spi: workaround: disable DMA mode to avoid crash by

--- a/patches/6.19/0003-mwifiex.patch
+++ b/patches/6.19/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From 1cb8b0055cccf3a466b21fdbb507cef8425980dd Mon Sep 17 00:00:00 2001
+From a6dcc3a75aac2e09967676809c1776eeaedd5f75 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -165,7 +165,7 @@ index d6ff964ae..5d30ae39d 100644
 -- 
 2.53.0
 
-From f5454fb0678f6a0a451cf0da228c9b1b993437c2 Mon Sep 17 00:00:00 2001
+From 2f8b509bd14234dfc6b4c26d9b60ff5a1b58f5a4 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -320,7 +320,7 @@ index 5d30ae39d..c14eb56eb 100644
 -- 
 2.53.0
 
-From 901b2af94faae241a5d8c1b91dd844a4cb6b3ac2 Mon Sep 17 00:00:00 2001
+From e5e4f1893f06e9c5a3d395073cf85be001b76798 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell
@@ -356,7 +356,7 @@ Patchset: mwifiex
  1 file changed, 15 insertions(+)
 
 diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
-index a41bb1e2a..572a9bcd2 100644
+index 4e161dcca..6753856e5 100644
 --- a/drivers/bluetooth/btusb.c
 +++ b/drivers/bluetooth/btusb.c
 @@ -67,6 +67,7 @@ static struct usb_driver btusb_driver;
@@ -375,7 +375,7 @@ index a41bb1e2a..572a9bcd2 100644
  
  	/* Intel Bluetooth devices */
  	{ USB_DEVICE(0x8087, 0x0025), .driver_info = BTUSB_INTEL_COMBINED },
-@@ -4236,6 +4238,19 @@ static int btusb_probe(struct usb_interface *intf,
+@@ -4239,6 +4241,19 @@ static int btusb_probe(struct usb_interface *intf,
  	if (id->driver_info & BTUSB_MARVELL)
  		hdev->set_bdaddr = btusb_set_bdaddr_marvell;
  

--- a/patches/6.19/0004-ath10k.patch
+++ b/patches/6.19/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From cfd60c7e9860fe0ff2840433934be98f516c03f7 Mon Sep 17 00:00:00 2001
+From f200ca74875dd58c751922663ca475aac2251249 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files

--- a/patches/6.19/0005-ipts.patch
+++ b/patches/6.19/0005-ipts.patch
@@ -1,4 +1,4 @@
-From 28e9cf5ef53f9f3e8da04a85d4928a594ffaf502 Mon Sep 17 00:00:00 2001
+From 8a9bb7c9e9834404cac005684cc2df19b2d9fdbe Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -37,7 +37,7 @@ index 2a6e56955..c19dfba54 100644
 -- 
 2.53.0
 
-From 72740aa77740092fa7f448ac1dd7f2a92af2261a Mon Sep 17 00:00:00 2001
+From b83ad92153cc61fcd1c08523ae1e14c8a7582887 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -144,7 +144,7 @@ index 705828b06..1400bf283 100644
 -- 
 2.53.0
 
-From aa91547471bf61ae51e3b59a8d122d37c6ce8a93 Mon Sep 17 00:00:00 2001
+From 376daa11435185c409bd566fa308a214851c5fe0 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus

--- a/patches/6.19/0006-ithc.patch
+++ b/patches/6.19/0006-ithc.patch
@@ -1,4 +1,4 @@
-From 55e86797e434d35ad49d5fc5ffbc8c17f4bc1404 Mon Sep 17 00:00:00 2001
+From 0170a9d0ea9b5cc160e1c07650b0c892974f2896 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -39,7 +39,7 @@ index 8bcbfe3d9..c78806d35 100644
 -- 
 2.53.0
 
-From 1cf2103b5e8668521b74da4136e06ee5a17144f3 Mon Sep 17 00:00:00 2001
+From 656be03154a64d5c07317e9d300bf5155d80d765 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller

--- a/patches/6.19/0007-surface-sam.patch
+++ b/patches/6.19/0007-surface-sam.patch
@@ -1,4 +1,4 @@
-From ecae0cc0c11be8bf32d363f0c7f3e6d3242bdc9f Mon Sep 17 00:00:00 2001
+From b349e43efd2845700fcb58b4afd00b5efce8905e Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Fri, 17 Jun 2022 02:14:00 +0200
 Subject: [PATCH] rtc: Add basic support for RTC via Surface System Aggregator
@@ -181,7 +181,7 @@ index 000000000..f6c17c4e9
 -- 
 2.53.0
 
-From 3d1173c2c4513aa4da28ac1f3fd883671769ca02 Mon Sep 17 00:00:00 2001
+From 29a7fc57d70b5351add255cde223e181dcdddbe5 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 20 Apr 2025 01:05:14 +0200
 Subject: [PATCH] platform/surface: aggregator_registry: Add Surface Laptop 7

--- a/patches/6.19/0008-surface-sam-over-hid.patch
+++ b/patches/6.19/0008-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From 3ea6bdb7f77252d22d062947f8aa00f383864777 Mon Sep 17 00:00:00 2001
+From dcf9cc334e1935e6ed3c6d57d28c5120dfd138c8 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -109,7 +109,7 @@ index ed90858a2..070c36637 100644
 -- 
 2.53.0
 
-From 2b9da1194a4f203a0707700a59393e6920393c34 Mon Sep 17 00:00:00 2001
+From 49568a1f71a87c7b1150d1986aa83a05ce809729 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch

--- a/patches/6.19/0009-surface-button.patch
+++ b/patches/6.19/0009-surface-button.patch
@@ -1,4 +1,4 @@
-From da7cd214e4a45c233a6be4a97449030592d005e1 Mon Sep 17 00:00:00 2001
+From 90d2013ced5a889ec1138a3728089c9fd64f8d72 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -75,7 +75,7 @@ index b8cad415c..43b5d5638 100644
 -- 
 2.53.0
 
-From 3ec94f2758eaae1d2d7e84e2205ff5ad2c582ae1 Mon Sep 17 00:00:00 2001
+From 6703955590a7e8279ccb54322f0ba2293aba65ca Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd

--- a/patches/6.19/0010-surface-typecover.patch
+++ b/patches/6.19/0010-surface-typecover.patch
@@ -1,4 +1,4 @@
-From ff5baefb34222c3fdeac0852a4a7501bc659e486 Mon Sep 17 00:00:00 2001
+From 7765aca3c684561e238b55ac4d8fd15dea26c1fc Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -23,10 +23,10 @@ Patchset: surface-typecover
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
-index c4d85089d..3d0d35c72 100644
+index 34b1f7df3..6fe00d310 100644
 --- a/drivers/usb/core/quirks.c
 +++ b/drivers/usb/core/quirks.c
-@@ -223,6 +223,9 @@ static const struct usb_device_id usb_quirk_list[] = {
+@@ -229,6 +229,9 @@ static const struct usb_device_id usb_quirk_list[] = {
  	/* Microsoft Surface Dock Ethernet (RTL8153 GigE) */
  	{ USB_DEVICE(0x045e, 0x07c6), .driver_info = USB_QUIRK_NO_LPM },
  
@@ -39,7 +39,7 @@ index c4d85089d..3d0d35c72 100644
 -- 
 2.53.0
 
-From 09af9d07fa295c8f3b7768a74fd7737a7cbaddcf Mon Sep 17 00:00:00 2001
+From e6884a47175364243da97bfc479f71d68b3b5051 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -75,7 +75,7 @@ Patchset: surface-typecover
  1 file changed, 98 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index b8a748bbf..c47a492a1 100644
+index e82a3c4e5..69c2cc124 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -35,7 +35,10 @@
@@ -148,7 +148,7 @@ index b8a748bbf..c47a492a1 100644
  	{ }
  };
  
-@@ -1938,6 +1958,69 @@ static void mt_expired_timeout(struct timer_list *t)
+@@ -1945,6 +1965,69 @@ static void mt_expired_timeout(struct timer_list *t)
  	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
  }
  
@@ -218,7 +218,7 @@ index b8a748bbf..c47a492a1 100644
  static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  {
  	int ret, i;
-@@ -1966,6 +2049,9 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1973,6 +2056,9 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  	td->inputmode_value = MT_INPUTMODE_TOUCHSCREEN;
  	hid_set_drvdata(hdev, td);
  
@@ -228,7 +228,7 @@ index b8a748bbf..c47a492a1 100644
  	INIT_LIST_HEAD(&td->applications);
  	INIT_LIST_HEAD(&td->reports);
  
-@@ -2004,8 +2090,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -2011,8 +2097,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  	timer_setup(&td->release_timer, mt_expired_timeout, 0);
  
  	ret = hid_parse(hdev);
@@ -240,7 +240,7 @@ index b8a748bbf..c47a492a1 100644
  
  	if (mtclass->name == MT_CLS_APPLE_TOUCHBAR &&
  	    !hid_find_field(hdev, HID_INPUT_REPORT,
-@@ -2019,8 +2107,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -2026,8 +2114,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  		hdev->quirks |= HID_QUIRK_NOGET;
  
  	ret = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
@@ -252,7 +252,7 @@ index b8a748bbf..c47a492a1 100644
  
  	ret = sysfs_create_group(&hdev->dev.kobj, &mt_attribute_group);
  	if (ret)
-@@ -2081,6 +2171,7 @@ static void mt_remove(struct hid_device *hdev)
+@@ -2088,6 +2178,7 @@ static void mt_remove(struct hid_device *hdev)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  
@@ -260,7 +260,7 @@ index b8a748bbf..c47a492a1 100644
  	timer_delete_sync(&td->release_timer);
  
  	sysfs_remove_group(&hdev->dev.kobj, &mt_attribute_group);
-@@ -2548,6 +2639,11 @@ static const struct hid_device_id mt_devices[] = {
+@@ -2555,6 +2646,11 @@ static const struct hid_device_id mt_devices[] = {
  		HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
  			USB_DEVICE_ID_APPLE_TOUCHBAR_DISPLAY) },
  
@@ -275,7 +275,7 @@ index b8a748bbf..c47a492a1 100644
 -- 
 2.53.0
 
-From 0344ec52910f491718ad1c2457a11be29096be8f Mon Sep 17 00:00:00 2001
+From ce3ebb1571fd2985f71e6ecf7a917ee1a0f7f747 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet
@@ -304,7 +304,7 @@ Patchset: surface-typecover
  1 file changed, 122 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index c47a492a1..c92ab7949 100644
+index 69c2cc124..8651e7b3d 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -83,6 +83,7 @@ MODULE_LICENSE("GPL");
@@ -332,7 +332,7 @@ index c47a492a1..c92ab7949 100644
  			MT_QUIRK_ALWAYS_VALID |
  			MT_QUIRK_IGNORE_DUPLICATES |
  			MT_QUIRK_HOVERING |
-@@ -1502,6 +1506,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+@@ -1509,6 +1513,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
  	    field->application != HID_CP_CONSUMER_CONTROL &&
  	    field->application != HID_GD_WIRELESS_RADIO_CTLS &&
  	    field->application != HID_GD_SYSTEM_MULTIAXIS &&
@@ -342,7 +342,7 @@ index c47a492a1..c92ab7949 100644
  	    !(field->application == HID_VD_ASUS_CUSTOM_MEDIA_KEYS &&
  	      application->quirks & MT_QUIRK_ASUS_CUSTOM_UP))
  		return -1;
-@@ -1529,6 +1536,21 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+@@ -1536,6 +1543,21 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
  		return 1;
  	}
  
@@ -364,7 +364,7 @@ index c47a492a1..c92ab7949 100644
  	if (rdata->is_mt_collection)
  		return mt_touch_input_mapping(hdev, hi, field, usage, bit, max,
  					      application);
-@@ -1555,6 +1577,7 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+@@ -1562,6 +1584,7 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  	struct mt_report_data *rdata;
@@ -372,7 +372,7 @@ index c47a492a1..c92ab7949 100644
  
  	rdata = mt_find_report_data(td, field->report);
  	if (rdata && rdata->is_mt_collection) {
-@@ -1562,6 +1585,19 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+@@ -1569,6 +1592,19 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
  		return -1;
  	}
  
@@ -392,7 +392,7 @@ index c47a492a1..c92ab7949 100644
  	/* let hid-core decide for the others */
  	return 0;
  }
-@@ -1571,11 +1607,21 @@ static int mt_event(struct hid_device *hid, struct hid_field *field,
+@@ -1578,11 +1614,21 @@ static int mt_event(struct hid_device *hid, struct hid_field *field,
  {
  	struct mt_device *td = hid_get_drvdata(hid);
  	struct mt_report_data *rdata;
@@ -414,7 +414,7 @@ index c47a492a1..c92ab7949 100644
  	return 0;
  }
  
-@@ -1790,6 +1836,42 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app)
+@@ -1797,6 +1843,42 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app)
  		app->quirks &= ~MT_QUIRK_CONTACT_CNT_ACCURATE;
  }
  
@@ -457,7 +457,7 @@ index c47a492a1..c92ab7949 100644
  static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
-@@ -1848,6 +1930,13 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
+@@ -1855,6 +1937,13 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
  		/* force BTN_STYLUS to allow tablet matching in udev */
  		__set_bit(BTN_STYLUS, hi->input->keybit);
  		break;
@@ -471,7 +471,7 @@ index c47a492a1..c92ab7949 100644
  	default:
  		suffix = "UNKNOWN";
  		break;
-@@ -1958,30 +2047,6 @@ static void mt_expired_timeout(struct timer_list *t)
+@@ -1965,30 +2054,6 @@ static void mt_expired_timeout(struct timer_list *t)
  	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
  }
  
@@ -502,7 +502,7 @@ index c47a492a1..c92ab7949 100644
  static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
  {
  	struct usb_device *udev = hid_to_usb_dev(hdev);
-@@ -1990,8 +2055,9 @@ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
+@@ -1997,8 +2062,9 @@ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
  	/* Wake up the device in case it's already suspended */
  	pm_runtime_get_sync(&udev->dev);
  
@@ -514,7 +514,7 @@ index c47a492a1..c92ab7949 100644
  		hid_err(hdev, "couldn't find backlight field\n");
  		goto out;
  	}
-@@ -2149,13 +2215,24 @@ static int mt_suspend(struct hid_device *hdev, pm_message_t state)
+@@ -2156,13 +2222,24 @@ static int mt_suspend(struct hid_device *hdev, pm_message_t state)
  
  static int mt_reset_resume(struct hid_device *hdev)
  {
@@ -539,7 +539,7 @@ index c47a492a1..c92ab7949 100644
  	/* Some Elan legacy devices require SET_IDLE to be set on resume.
  	 * It should be safe to send it to other devices too.
  	 * Tested on 3M, Stantum, Cypress, Zytronic, eGalax, and Elan panels. */
-@@ -2164,12 +2241,31 @@ static int mt_resume(struct hid_device *hdev)
+@@ -2171,12 +2248,31 @@ static int mt_resume(struct hid_device *hdev)
  
  	mt_set_modes(hdev, HID_LATENCY_NORMAL, TOUCHPAD_REPORT_ALL);
  

--- a/patches/6.19/0011-surface-shutdown.patch
+++ b/patches/6.19/0011-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From dd2208ea4f12d8eafde91b5fd6861db06cb7710e Mon Sep 17 00:00:00 2001
+From 381fbf10b4ac2f1b58feedcf44b360b948841869 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
@@ -95,7 +95,7 @@ index e958ff744..2053f3396 100644
 -- 
 2.53.0
 
-From 4951c289333bfc16f42fac59a5d02afbdd1979c9 Mon Sep 17 00:00:00 2001
+From 469eb1fce0f4f11f09d8260806f660112c2ace89 Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Wed, 7 Jan 2026 01:06:25 +0100
 Subject: [PATCH] PCI: Add Surface Laptop Studio 2 devices to shutdown ops

--- a/patches/6.19/0012-surface-gpe.patch
+++ b/patches/6.19/0012-surface-gpe.patch
@@ -1,4 +1,4 @@
-From 958fc5f748b02cf51b294f693215d1c1d40fd66e Mon Sep 17 00:00:00 2001
+From dd8ebe5d33648913c3ba616864064db707c24ff7 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9

--- a/patches/6.19/0013-cameras.patch
+++ b/patches/6.19/0013-cameras.patch
@@ -1,4 +1,4 @@
-From c1c1eb1b2d1d034dfe351ea51efd25ef502db25e Mon Sep 17 00:00:00 2001
+From 0a11e8ca4b7496ac69768bd982a1c99811f6c17c Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -74,7 +74,7 @@ index b78f6be2f..801171e2a 100644
 -- 
 2.53.0
 
-From 4b553e59c7d3ff31429e4dd08a0460b11bab94dd Mon Sep 17 00:00:00 2001
+From 7a81c46920dd69243c77743507e330b6f4fb6501 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -184,7 +184,7 @@ index 1400bf283..cca97e5b2 100644
 -- 
 2.53.0
 
-From e161e5012e6858f2715f72668ea2fc0d7aeb89da Mon Sep 17 00:00:00 2001
+From 974381488654a97c24b1a84afdc57b7968833f7d Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -221,7 +221,7 @@ index 013340569..9e0763bdc 100644
 -- 
 2.53.0
 
-From 9c649457de8b93596baaa80f4f8c00e3d9baba20 Mon Sep 17 00:00:00 2001
+From 06ef10273e642c25c6f0c7170b0715ab7c115e8b Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -260,7 +260,7 @@ index 27afc3fc0..28b192c9a 100644
 -- 
 2.53.0
 
-From a83903189bc92cdd72dd802072f2518bbad79ee3 Mon Sep 17 00:00:00 2001
+From e8e63a0cee95bf7313be431d6513e2933a64a962 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -311,7 +311,7 @@ index cb153ce42..f11b499e1 100644
 -- 
 2.53.0
 
-From bd907090c2084997d86042ba1961a066e5f6cce8 Mon Sep 17 00:00:00 2001
+From bbac78207229d80cad0802f7d999e7313b05c64f Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -352,7 +352,7 @@ index 9e0763bdc..0976b2679 100644
 -- 
 2.53.0
 
-From b4551d25d8d3b88500baa0b2d0cd3e5b60438daf Mon Sep 17 00:00:00 2001
+From 2e6e51db530adce46f6b1e7437aa1db3592fe276 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -393,7 +393,7 @@ index 7807fa329..2d2abb25b 100644
 -- 
 2.53.0
 
-From 3a215fa6681957570a03d2fa2a936c4400a0248c Mon Sep 17 00:00:00 2001
+From 6fad9bb7bc66f2282f75c634f97558952248a396 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -644,7 +644,7 @@ index 000000000..35aeb5db8
 -- 
 2.53.0
 
-From b581a619711c71600e9f083e3f8d3a36092cb11f Mon Sep 17 00:00:00 2001
+From 090dced854e24718fb91aa5ff4d06f26cb1d538a Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2
@@ -676,7 +676,7 @@ index 595583359..b89765521 100644
 -- 
 2.53.0
 
-From b1dc230fffb35a88809f6c7877416887c1fb3d20 Mon Sep 17 00:00:00 2001
+From fdd1c11fc5a866ed3e4a257b5613c2fd50f8ba72 Mon Sep 17 00:00:00 2001
 From: Tooraj Taraz <tooraj.taraz@yahoo.com>
 Date: Wed, 31 Dec 2025 00:35:50 +0100
 Subject: [PATCH] Add camera support for Surface Pro 9
@@ -1017,7 +1017,7 @@ index 1505fc3ef..20962e8ac 100644
 -- 
 2.53.0
 
-From f51a44f59234d641cd068c4c1ba7c643dfe4c0ef Mon Sep 17 00:00:00 2001
+From 66e9380af05eeda7d4213114f689714491de8a9a Mon Sep 17 00:00:00 2001
 From: gabrielstedman <gabrielstedman@users.noreply.github.com>
 Date: Fri, 13 Mar 2026 08:52:07 +0000
 Subject: [PATCH] media: ipu-bridge: Add front camera rotation quirks for

--- a/patches/6.19/0014-amd-gpio.patch
+++ b/patches/6.19/0014-amd-gpio.patch
@@ -1,4 +1,4 @@
-From 2ffa10c995b5823878f9b56f4d5eceb3a87d9cb4 Mon Sep 17 00:00:00 2001
+From 95d72e4abccf3e181062d5ec92cd3ca476964207 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -65,7 +65,7 @@ index d6138b2b6..67094184c 100644
 -- 
 2.53.0
 
-From 3b8b8afd11fb27fc4d120a260e0c0cbdf3d86b01 Mon Sep 17 00:00:00 2001
+From 577f6c7ad9d575261a388caf9197a209dccdfead Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override

--- a/patches/6.19/0015-rtc.patch
+++ b/patches/6.19/0015-rtc.patch
@@ -1,4 +1,4 @@
-From 5eabba9ccc2f5ffa4017887d669b7c0d4f05e793 Mon Sep 17 00:00:00 2001
+From 4fbcba072df025a06c620f7558a2f0aae60b7b4a Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms

--- a/patches/6.19/0016-hid-surface.patch
+++ b/patches/6.19/0016-hid-surface.patch
@@ -1,4 +1,4 @@
-From ceceaa9e24416cdb4fa910ff6a2edcd83ec19d49 Mon Sep 17 00:00:00 2001
+From 712e767cf48b814acec54d6b3c1266693d97401e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ciar=C3=A1n=20Coffey?= <github@ccoffey.ie>
 Date: Fri, 10 Oct 2025 19:04:03 +0100
 Subject: [PATCH] HID: Add hid-surface driver to filter BTN_0 (FN key)
@@ -156,7 +156,7 @@ index 000000000..a171ea656
 -- 
 2.53.0
 
-From 57d61aff0b53b089227f5a794363fec829114fc5 Mon Sep 17 00:00:00 2001
+From 0c2fbead4937c3f06bef64bd123998f72f57f370 Mon Sep 17 00:00:00 2001
 From: LegendaryFire <tristan.balon@outlook.com>
 Date: Fri, 13 Mar 2026 10:16:37 +0100
 Subject: [PATCH] hid/multitouch: Prevent mode set on Surface Laptop Studio 2
@@ -171,7 +171,7 @@ Patchset: hid-surface
  1 file changed, 31 insertions(+)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index c92ab7949..331e1553d 100644
+index 8651e7b3d..1947e0923 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -84,6 +84,7 @@ MODULE_LICENSE("GPL");
@@ -201,7 +201,7 @@ index c92ab7949..331e1553d 100644
  	{ }
  };
  
-@@ -2276,6 +2282,17 @@ static void mt_remove(struct hid_device *hdev)
+@@ -2283,6 +2289,17 @@ static void mt_remove(struct hid_device *hdev)
  
  static void mt_on_hid_hw_open(struct hid_device *hdev)
  {
@@ -219,7 +219,7 @@ index c92ab7949..331e1553d 100644
  	mt_set_modes(hdev, HID_LATENCY_NORMAL, TOUCHPAD_REPORT_ALL);
  }
  
-@@ -2283,6 +2300,15 @@ static void mt_on_hid_hw_close(struct hid_device *hdev)
+@@ -2290,6 +2307,15 @@ static void mt_on_hid_hw_close(struct hid_device *hdev)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  
@@ -235,7 +235,7 @@ index c92ab7949..331e1553d 100644
  	if (td->mtclass.quirks & MT_QUIRK_KEEP_LATENCY_ON_CLOSE)
  		mt_set_modes(hdev, HID_LATENCY_NORMAL, TOUCHPAD_REPORT_NONE);
  	else
-@@ -2740,6 +2766,11 @@ static const struct hid_device_id mt_devices[] = {
+@@ -2747,6 +2773,11 @@ static const struct hid_device_id mt_devices[] = {
  		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY,
  			USB_VENDOR_ID_MICROSOFT, 0x09c0) },
  


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.19** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.19-surface`
- **Base version**: `v6.19.14`
- **Patches generated**: 16
- **Patches directory**: `patches/6.19/`

### Changes
This PR updates kernel patches to the latest version from the `v6.19-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.19-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.