### PR TITLE
patches/v6.12: Automatic update to v6.12.86

### DIFF
--- a/patches/6.12/0001-secureboot.patch
+++ b/patches/6.12/0001-secureboot.patch
@@ -1,4 +1,4 @@
-From d78b9a6c4a99464f0a4a6317d4a44e22c129a83a Mon Sep 17 00:00:00 2001
+From 5afb68331ac2e7d1e2fac5d0314443b20e821bfb Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 9 Jun 2024 19:48:58 +0200
 Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
@@ -35,7 +35,7 @@ index b5c79f433..a1bbedd98 100644
 -- 
 2.53.0
 
-From ba56e2f141004eecd63bfe191126568bbb50d5fe Mon Sep 17 00:00:00 2001
+From 4f50b7ce2d33eb9bd8e872a43216d8cfa6589369 Mon Sep 17 00:00:00 2001
 From: "J. Eduardo" <j.eduardo@gmail.com>
 Date: Sun, 25 Aug 2024 14:17:45 +0200
 Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter
@@ -53,7 +53,7 @@ Patchset: secureboot
  2 files changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index e88505e94..15961654b 100644
+index 811345669..d89e6b295 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
 @@ -3085,6 +3085,11 @@

--- a/patches/6.12/0002-surface3-oemb.patch
+++ b/patches/6.12/0002-surface3-oemb.patch
@@ -1,4 +1,4 @@
-From 242ddda76132ccbb78fce0c338bd7805ffa371bd Mon Sep 17 00:00:00 2001
+From 64f201fb283d438d092e3ab9ee387231c7402178 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 18 Oct 2020 16:42:44 +0900
 Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI

--- a/patches/6.12/0003-mwifiex.patch
+++ b/patches/6.12/0003-mwifiex.patch
@@ -1,4 +1,4 @@
-From b5f73cc1b4a0cdec1a5e311dd1d79a0e19ea1361 Mon Sep 17 00:00:00 2001
+From b979bc20a77731f5f539595d7e5b4dfafc74c899 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Tue, 3 Nov 2020 13:28:04 +0100
 Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
@@ -165,7 +165,7 @@ index d6ff964ae..5d30ae39d 100644
 -- 
 2.53.0
 
-From 259acade815fa5cdb5067eeac2442c26b4ceb2c6 Mon Sep 17 00:00:00 2001
+From b1d250ce1600f954fa5858dfd847f41688b36543 Mon Sep 17 00:00:00 2001
 From: Tsuchiya Yuto <kitakar@gmail.com>
 Date: Sun, 4 Oct 2020 00:11:49 +0900
 Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
@@ -320,7 +320,7 @@ index 5d30ae39d..c14eb56eb 100644
 -- 
 2.53.0
 
-From eed389098afc172e91855287538ca1bbd3d11a0f Mon Sep 17 00:00:00 2001
+From 10f55ae76ebb19189a3fe4c4fb4cf8c96e837016 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 25 Mar 2021 11:33:02 +0100
 Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell
@@ -356,7 +356,7 @@ Patchset: mwifiex
  1 file changed, 15 insertions(+)
 
 diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
-index 9d3236321..1670a26e5 100644
+index b8bf4dfea..3f72b2335 100644
 --- a/drivers/bluetooth/btusb.c
 +++ b/drivers/bluetooth/btusb.c
 @@ -66,6 +66,7 @@ static struct usb_driver btusb_driver;
@@ -375,7 +375,7 @@ index 9d3236321..1670a26e5 100644
  
  	/* Intel Bluetooth devices */
  	{ USB_DEVICE(0x8087, 0x0025), .driver_info = BTUSB_INTEL_COMBINED },
-@@ -4016,6 +4018,19 @@ static int btusb_probe(struct usb_interface *intf,
+@@ -4019,6 +4021,19 @@ static int btusb_probe(struct usb_interface *intf,
  	if (id->driver_info & BTUSB_MARVELL)
  		hdev->set_bdaddr = btusb_set_bdaddr_marvell;
  

--- a/patches/6.12/0004-ath10k.patch
+++ b/patches/6.12/0004-ath10k.patch
@@ -1,4 +1,4 @@
-From 4125e5a84b2370376ab1c108fbff63ccee48d3b0 Mon Sep 17 00:00:00 2001
+From 1a1ad04cd6873318211851cafa4810408fe9c298 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 27 Feb 2021 00:45:52 +0100
 Subject: [PATCH] ath10k: Add module parameters to override board files

--- a/patches/6.12/0005-ipts.patch
+++ b/patches/6.12/0005-ipts.patch
@@ -1,4 +1,4 @@
-From 4dbb2841ec84f5c7612d22baffe291f7e5b1c74e Mon Sep 17 00:00:00 2001
+From bc00b62ff5aebb255a5bec5d8e1255efad0253bb Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Thu, 30 Jul 2020 13:21:53 +0200
 Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
@@ -37,7 +37,7 @@ index 1e4edf896..61d1a8816 100644
 -- 
 2.53.0
 
-From 77f4b43a690d491d4be35f52d334e07f24162958 Mon Sep 17 00:00:00 2001
+From 9eed70ddb0e5e63489c82053083c24ce8fc122c2 Mon Sep 17 00:00:00 2001
 From: Liban Hannan <liban.p@gmail.com>
 Date: Tue, 12 Apr 2022 23:31:12 +0100
 Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
@@ -144,7 +144,7 @@ index d4f852f71..b76109d5d 100644
 -- 
 2.53.0
 
-From 8df48859297fd0730bf9d231343176cd6f2ecedd Mon Sep 17 00:00:00 2001
+From ef1b92354637da21cc898e56318f4a3af4e3050e Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:00:59 +0100
 Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus

--- a/patches/6.12/0006-ithc.patch
+++ b/patches/6.12/0006-ithc.patch
@@ -1,4 +1,4 @@
-From 10da29a50dc86540c5162137ed52c5c99823b185 Mon Sep 17 00:00:00 2001
+From 82349f8309678b734664710e0013c9f0ea471160 Mon Sep 17 00:00:00 2001
 From: Dorian Stoll <dorian.stoll@tmsp.io>
 Date: Sun, 11 Dec 2022 12:03:38 +0100
 Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
@@ -39,7 +39,7 @@ index 066e4cd6e..7b320d09d 100644
 -- 
 2.53.0
 
-From db66ed7a0570276e8d561777fa3ba2f97bd449c6 Mon Sep 17 00:00:00 2001
+From 0abe1af20d40af3863c4e5eaedc319543f92e224 Mon Sep 17 00:00:00 2001
 From: quo <tuple@list.ru>
 Date: Sun, 11 Dec 2022 12:10:54 +0100
 Subject: [PATCH] hid: Add support for Intel Touch Host Controller

--- a/patches/6.12/0007-surface-sam-over-hid.patch
+++ b/patches/6.12/0007-surface-sam-over-hid.patch
@@ -1,4 +1,4 @@
-From 04627863b4690e94b904bdebd26e1532b6112c26 Mon Sep 17 00:00:00 2001
+From ba70fa8a2fdb96583e296c5cb3f6a3aa2a5d8ec3 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 25 Jul 2020 17:19:53 +0200
 Subject: [PATCH] i2c: acpi: Implement RawBytes read access
@@ -109,7 +109,7 @@ index f43067f67..1761ca30e 100644
 -- 
 2.53.0
 
-From 1d7c291867bb34ababa60243f125c26da2ec85e9 Mon Sep 17 00:00:00 2001
+From f202cdfd0415468f5b88a4012efbfa94ced935c9 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 13 Feb 2021 16:41:18 +0100
 Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch

--- a/patches/6.12/0008-surface-button.patch
+++ b/patches/6.12/0008-surface-button.patch
@@ -1,4 +1,4 @@
-From 82584739abaac5bfc5adfaeb3ea03facf77de7ce Mon Sep 17 00:00:00 2001
+From 167c033049be0fac2dbb5e3008162bbc8dceb800 Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:05:09 +1100
 Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
@@ -75,7 +75,7 @@ index 5c5d407fe..4e1bfe90e 100644
 -- 
 2.53.0
 
-From d5ecaa5cb6ac3a5eeb443b8bae1dc077df4bda75 Mon Sep 17 00:00:00 2001
+From fcb8d6810b6ac061a5d23c951af12f4e5fccc90d Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Tue, 5 Oct 2021 00:22:57 +1100
 Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd

--- a/patches/6.12/0009-surface-typecover.patch
+++ b/patches/6.12/0009-surface-typecover.patch
@@ -1,4 +1,4 @@
-From 142804a88c118139dcc4f69ed27717e6d5c8156f Mon Sep 17 00:00:00 2001
+From d915f4bb93ccba26b487f993faeeb4fe4848f282 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sat, 18 Feb 2023 01:02:49 +0100
 Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
@@ -23,10 +23,10 @@ Patchset: surface-typecover
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
-index 323a949bb..abc2cdecd 100644
+index 7442ac03f..bb68e4be4 100644
 --- a/drivers/usb/core/quirks.c
 +++ b/drivers/usb/core/quirks.c
-@@ -223,6 +223,9 @@ static const struct usb_device_id usb_quirk_list[] = {
+@@ -229,6 +229,9 @@ static const struct usb_device_id usb_quirk_list[] = {
  	/* Microsoft Surface Dock Ethernet (RTL8153 GigE) */
  	{ USB_DEVICE(0x045e, 0x07c6), .driver_info = USB_QUIRK_NO_LPM },
  
@@ -39,7 +39,7 @@ index 323a949bb..abc2cdecd 100644
 -- 
 2.53.0
 
-From 74b286ffe37d7836327742b71f78f00880412a34 Mon Sep 17 00:00:00 2001
+From b3022f20755108007840960b1cd373ebd6104cdd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
 Date: Thu, 5 Nov 2020 13:09:45 +0100
 Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
@@ -75,7 +75,7 @@ Patchset: surface-typecover
  1 file changed, 98 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index eb1489884..0a6cf8926 100644
+index fcf9a806f..64bc1d5ab 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -34,7 +34,10 @@
@@ -147,7 +147,7 @@ index eb1489884..0a6cf8926 100644
  	{ }
  };
  
-@@ -1836,6 +1856,69 @@ static void mt_expired_timeout(struct timer_list *t)
+@@ -1843,6 +1863,69 @@ static void mt_expired_timeout(struct timer_list *t)
  	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
  }
  
@@ -217,7 +217,7 @@ index eb1489884..0a6cf8926 100644
  static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  {
  	int ret, i;
-@@ -1859,6 +1942,9 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1866,6 +1949,9 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  	td->inputmode_value = MT_INPUTMODE_TOUCHSCREEN;
  	hid_set_drvdata(hdev, td);
  
@@ -227,7 +227,7 @@ index eb1489884..0a6cf8926 100644
  	INIT_LIST_HEAD(&td->applications);
  	INIT_LIST_HEAD(&td->reports);
  
-@@ -1897,8 +1983,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1904,8 +1990,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  	timer_setup(&td->release_timer, mt_expired_timeout, 0);
  
  	ret = hid_parse(hdev);
@@ -239,7 +239,7 @@ index eb1489884..0a6cf8926 100644
  
  	if (mtclass->quirks & MT_QUIRK_FIX_CONST_CONTACT_ID)
  		mt_fix_const_fields(hdev, HID_DG_CONTACTID);
-@@ -1907,8 +1995,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+@@ -1914,8 +2002,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
  		hdev->quirks |= HID_QUIRK_NOGET;
  
  	ret = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
@@ -251,7 +251,7 @@ index eb1489884..0a6cf8926 100644
  
  	ret = sysfs_create_group(&hdev->dev.kobj, &mt_attribute_group);
  	if (ret)
-@@ -1958,6 +2048,7 @@ static void mt_remove(struct hid_device *hdev)
+@@ -1965,6 +2055,7 @@ static void mt_remove(struct hid_device *hdev)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  
@@ -259,7 +259,7 @@ index eb1489884..0a6cf8926 100644
  	del_timer_sync(&td->release_timer);
  
  	sysfs_remove_group(&hdev->dev.kobj, &mt_attribute_group);
-@@ -2397,6 +2488,11 @@ static const struct hid_device_id mt_devices[] = {
+@@ -2404,6 +2495,11 @@ static const struct hid_device_id mt_devices[] = {
  		MT_USB_DEVICE(USB_VENDOR_ID_XIROKU,
  			USB_DEVICE_ID_XIROKU_CSR2) },
  
@@ -274,7 +274,7 @@ index eb1489884..0a6cf8926 100644
 -- 
 2.53.0
 
-From 51b8f39ff7aaf9ef241f95ec40f727f55440c5e7 Mon Sep 17 00:00:00 2001
+From 56a1680673e9ffceeb423991d9d710463e137ff9 Mon Sep 17 00:00:00 2001
 From: PJungkamp <p.jungkamp@gmail.com>
 Date: Fri, 25 Feb 2022 12:04:25 +0100
 Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet
@@ -303,7 +303,7 @@ Patchset: surface-typecover
  1 file changed, 122 insertions(+), 26 deletions(-)
 
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 0a6cf8926..6518bb81b 100644
+index 64bc1d5ab..a38985fa4 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -78,6 +78,7 @@ MODULE_LICENSE("GPL");
@@ -331,7 +331,7 @@ index 0a6cf8926..6518bb81b 100644
  			MT_QUIRK_ALWAYS_VALID |
  			MT_QUIRK_IGNORE_DUPLICATES |
  			MT_QUIRK_HOVERING |
-@@ -1412,6 +1416,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+@@ -1419,6 +1423,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
  	    field->application != HID_CP_CONSUMER_CONTROL &&
  	    field->application != HID_GD_WIRELESS_RADIO_CTLS &&
  	    field->application != HID_GD_SYSTEM_MULTIAXIS &&
@@ -341,7 +341,7 @@ index 0a6cf8926..6518bb81b 100644
  	    !(field->application == HID_VD_ASUS_CUSTOM_MEDIA_KEYS &&
  	      application->quirks & MT_QUIRK_ASUS_CUSTOM_UP))
  		return -1;
-@@ -1439,6 +1446,21 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+@@ -1446,6 +1453,21 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
  		return 1;
  	}
  
@@ -363,7 +363,7 @@ index 0a6cf8926..6518bb81b 100644
  	if (rdata->is_mt_collection)
  		return mt_touch_input_mapping(hdev, hi, field, usage, bit, max,
  					      application);
-@@ -1460,6 +1482,7 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+@@ -1467,6 +1489,7 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
  	struct mt_report_data *rdata;
@@ -371,7 +371,7 @@ index 0a6cf8926..6518bb81b 100644
  
  	rdata = mt_find_report_data(td, field->report);
  	if (rdata && rdata->is_mt_collection) {
-@@ -1467,6 +1490,19 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+@@ -1474,6 +1497,19 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
  		return -1;
  	}
  
@@ -391,7 +391,7 @@ index 0a6cf8926..6518bb81b 100644
  	/* let hid-core decide for the others */
  	return 0;
  }
-@@ -1476,11 +1512,21 @@ static int mt_event(struct hid_device *hid, struct hid_field *field,
+@@ -1483,11 +1519,21 @@ static int mt_event(struct hid_device *hid, struct hid_field *field,
  {
  	struct mt_device *td = hid_get_drvdata(hid);
  	struct mt_report_data *rdata;
@@ -413,7 +413,7 @@ index 0a6cf8926..6518bb81b 100644
  	return 0;
  }
  
-@@ -1697,6 +1743,42 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app)
+@@ -1704,6 +1750,42 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app)
  		app->quirks &= ~MT_QUIRK_CONTACT_CNT_ACCURATE;
  }
  
@@ -456,7 +456,7 @@ index 0a6cf8926..6518bb81b 100644
  static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
  {
  	struct mt_device *td = hid_get_drvdata(hdev);
-@@ -1746,6 +1828,13 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
+@@ -1753,6 +1835,13 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
  		/* force BTN_STYLUS to allow tablet matching in udev */
  		__set_bit(BTN_STYLUS, hi->input->keybit);
  		break;
@@ -470,7 +470,7 @@ index 0a6cf8926..6518bb81b 100644
  	default:
  		suffix = "UNKNOWN";
  		break;
-@@ -1856,30 +1945,6 @@ static void mt_expired_timeout(struct timer_list *t)
+@@ -1863,30 +1952,6 @@ static void mt_expired_timeout(struct timer_list *t)
  	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
  }
  
@@ -501,7 +501,7 @@ index 0a6cf8926..6518bb81b 100644
  static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
  {
  	struct usb_device *udev = hid_to_usb_dev(hdev);
-@@ -1888,8 +1953,9 @@ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
+@@ -1895,8 +1960,9 @@ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
  	/* Wake up the device in case it's already suspended */
  	pm_runtime_get_sync(&udev->dev);
  
@@ -513,7 +513,7 @@ index 0a6cf8926..6518bb81b 100644
  		hid_err(hdev, "couldn't find backlight field\n");
  		goto out;
  	}
-@@ -2026,13 +2092,24 @@ static int mt_suspend(struct hid_device *hdev, pm_message_t state)
+@@ -2033,13 +2099,24 @@ static int mt_suspend(struct hid_device *hdev, pm_message_t state)
  
  static int mt_reset_resume(struct hid_device *hdev)
  {
@@ -538,7 +538,7 @@ index 0a6cf8926..6518bb81b 100644
  	/* Some Elan legacy devices require SET_IDLE to be set on resume.
  	 * It should be safe to send it to other devices too.
  	 * Tested on 3M, Stantum, Cypress, Zytronic, eGalax, and Elan panels. */
-@@ -2041,12 +2118,31 @@ static int mt_resume(struct hid_device *hdev)
+@@ -2048,12 +2125,31 @@ static int mt_resume(struct hid_device *hdev)
  
  	mt_set_modes(hdev, HID_LATENCY_NORMAL, true, true);
  

--- a/patches/6.12/0010-surface-shutdown.patch
+++ b/patches/6.12/0010-surface-shutdown.patch
@@ -1,4 +1,4 @@
-From fe77fe0cb314d0202ca005b064c439e96b7a5920 Mon Sep 17 00:00:00 2001
+From fb8495ae402374a99e04520454e6ae02d078723a Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 19 Feb 2023 22:12:24 +0100
 Subject: [PATCH] PCI: Add quirk to prevent calling shutdown mehtod
@@ -23,7 +23,7 @@ Patchset: surface-shutdown
  3 files changed, 40 insertions(+)
 
 diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
-index 9846ab70c..38e674a1b 100644
+index a00a2ce01..9754d756c 100644
 --- a/drivers/pci/pci-driver.c
 +++ b/drivers/pci/pci-driver.c
 @@ -505,6 +505,9 @@ static void pci_device_shutdown(struct device *dev)

--- a/patches/6.12/0011-surface-gpe.patch
+++ b/patches/6.12/0011-surface-gpe.patch
@@ -1,4 +1,4 @@
-From d199f675da076339d1617e2562f714d791010959 Mon Sep 17 00:00:00 2001
+From 8feaedc3d3578a269d6d8ac563421a259ea1c540 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Sun, 12 Mar 2023 01:41:57 +0100
 Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9

--- a/patches/6.12/0012-cameras.patch
+++ b/patches/6.12/0012-cameras.patch
@@ -1,4 +1,4 @@
-From cb78d8125731975857cacbb981babad2563f6133 Mon Sep 17 00:00:00 2001
+From 6d64beee941b5f3f2330194591464aef98aac72a Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Sun, 10 Oct 2021 20:56:57 +0200
 Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
@@ -74,7 +74,7 @@ index ba98763ce..6021907ec 100644
 -- 
 2.53.0
 
-From 4896c5dd64257633ca4d42237f17f0ae37edeafe Mon Sep 17 00:00:00 2001
+From 97ad5ec163ad427e6d69717cced0afd098d8c121 Mon Sep 17 00:00:00 2001
 From: zouxiaoh <xiaohong.zou@intel.com>
 Date: Fri, 25 Jun 2021 08:52:59 +0800
 Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
@@ -184,7 +184,7 @@ index b76109d5d..06b2d4a85 100644
 -- 
 2.53.0
 
-From 3500e8e7e174ca3d2a4e0659263570633ea40818 Mon Sep 17 00:00:00 2001
+From dbf77fb4ab971f39854db2f35d4880dc1c503f70 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <djrscally@gmail.com>
 Date: Sun, 10 Oct 2021 20:57:02 +0200
 Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
@@ -221,7 +221,7 @@ index 81ac4c691..f453c9043 100644
 -- 
 2.53.0
 
-From 09848cfdbb28c7cb8ef310661ef84aea2b2d5571 Mon Sep 17 00:00:00 2001
+From 25c76b48a7105e7a65ca7eba0f1ce31e2b27565d Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Thu, 2 Mar 2023 12:59:39 +0000
 Subject: [PATCH] platform/x86: int3472: Remap reset GPIO for INT347E
@@ -277,7 +277,7 @@ index 9e69ac9cf..d6003198a 100644
 -- 
 2.53.0
 
-From 19f7efbb8c697246464d4556715776e81713266a Mon Sep 17 00:00:00 2001
+From 5068355cad57fecbc34dd8ca16782e55bd904358 Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Tue, 21 Mar 2023 13:45:26 +0000
 Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
@@ -316,7 +316,7 @@ index 3226888d7..3bfe45b76 100644
 -- 
 2.53.0
 
-From d73081eebba9db15ff01cb6208ec6f6a4fee7993 Mon Sep 17 00:00:00 2001
+From 0aa6fcc503746aac08c13261575e6b2072d028db Mon Sep 17 00:00:00 2001
 From: Daniel Scally <dan.scally@ideasonboard.com>
 Date: Wed, 22 Mar 2023 11:01:42 +0000
 Subject: [PATCH] media: v4l2-core: Acquire privacy led in
@@ -367,7 +367,7 @@ index f19c8adf2..923ed1b5a 100644
 -- 
 2.53.0
 
-From 36fb55a4db8fc2fa00db4b21351a197a556837c2 Mon Sep 17 00:00:00 2001
+From ffd6f9682feaadca687b9768348a79c03cfd4509 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:16 +0800
 Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
@@ -408,7 +408,7 @@ index f453c9043..b8ad6b413 100644
 -- 
 2.53.0
 
-From 082f363ec90ef3f959e0d2196e7262bb631b48ef Mon Sep 17 00:00:00 2001
+From 3b5272ecd79adbb2524d02831e0bcdd32938711f Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:17 +0800
 Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
@@ -449,7 +449,7 @@ index 7807fa329..2d2abb25b 100644
 -- 
 2.53.0
 
-From ce274f610494db183eb9af63caf7be993a213e1e Mon Sep 17 00:00:00 2001
+From 27258f3a8381dd11677d74720762ec9da2de9c65 Mon Sep 17 00:00:00 2001
 From: Kate Hsuan <hpa@redhat.com>
 Date: Tue, 21 Mar 2023 23:37:18 +0800
 Subject: [PATCH] leds: tps68470: Add LED control for tps68470
@@ -700,7 +700,7 @@ index 000000000..35aeb5db8
 -- 
 2.53.0
 
-From 265db8eb0cd4a576d4c1fc0326211c7d033ee49e Mon Sep 17 00:00:00 2001
+From 0ff0044f72c63304e1a129b3cc76a9b3ce70d82f Mon Sep 17 00:00:00 2001
 From: mojyack <mojyack@gmail.com>
 Date: Tue, 26 Mar 2024 05:55:44 +0900
 Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2

--- a/patches/6.12/0013-amd-gpio.patch
+++ b/patches/6.12/0013-amd-gpio.patch
@@ -1,4 +1,4 @@
-From bf7336bc7535b912923ac679762f78a547507371 Mon Sep 17 00:00:00 2001
+From f0289dea3f40f5bdce508e3e372239612c12a08d Mon Sep 17 00:00:00 2001
 From: Sachi King <nakato@nakato.io>
 Date: Sat, 29 May 2021 17:47:38 +1000
 Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
@@ -65,7 +65,7 @@ index a1acff778..8cb5d2c5f 100644
 -- 
 2.53.0
 
-From 2bc288e1402dd22595170a9bf212395dd27982e6 Mon Sep 17 00:00:00 2001
+From 91060058810ebd2ed718492614514b1242043821 Mon Sep 17 00:00:00 2001
 From: Maximilian Luz <luzmaximilian@gmail.com>
 Date: Thu, 3 Jun 2021 14:04:26 +0200
 Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override

--- a/patches/6.12/0014-rtc.patch
+++ b/patches/6.12/0014-rtc.patch
@@ -1,4 +1,4 @@
-From 1d252cfb63fc691888327a706233fb81f28d29ee Mon Sep 17 00:00:00 2001
+From eed24ff9aacbbc50d86fe894eb72d7a5a84229e4 Mon Sep 17 00:00:00 2001
 From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
 Date: Mon, 5 Dec 2022 16:08:46 +0100
 Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms


### PR DESCRIPTION
## Summary

Automatic patch update for kernel version **v6.12** from the linux-surface/kernel repository.

### Details
- **Kernel branch**: `v6.12-surface`
- **Base version**: `v6.12.86`
- **Patches generated**: 14
- **Patches directory**: `patches/6.12/`

### Changes
This PR updates kernel patches to the latest version from the `v6.12-surface` branch in the [linux-surface/kernel](https://github.com/linux-surface/kernel/tree/v6.12-surface) repository.

Patches were generated using `git-format-patchsets` with flags: `-t --no-confirm`

## Automation

Generated automatically by the patch generation workflow.

---
**Note:** Please review the changes carefully before merging.