### PR TITLE
patches/6.19: cameras: add dw9719 i2c_device_id table fix

### DIFF
--- a/patches/6.19/0013-cameras.patch
+++ b/patches/6.19/0013-cameras.patch
@@ -1057,7 +1057,56 @@ index f5456330b..3418ff475 100644
 +	},
  	{} /* Terminating entry */
  };
- 
--- 
+
+--
 2.53.0
 
+From 0000000000000000000000000000000000000001 Mon Sep 17 00:00:00 2001
+From: Sakari Ailus <sakari.ailus@linux.intel.com>
+Date: Thu, 26 Mar 2026 17:49:09 +0000
+Subject: [PATCH] media: i2c: dw9719: Add I2C device ID table
+
+The I2C device id table is necessary as the device may be, besides
+through system firmware, also instantiated in the IPU bridge so
+matching takes place using the I2C device id table.
+
+Without this table, Surface devices using the dw9719 VCM (voice coil
+motor for autofocus) fail to bind the VCM driver. On Surface Book 2
+and similar devices, this prevents the ipu3-cio2 notifier from
+completing, leaving cameras without media links and with no V4L2
+subdevice nodes — so libcamera reports no cameras.
+
+Link: https://lore.kernel.org/all/20260326174909.2746696-1-sakari.ailus@linux.intel.com/
+Signed-off-by: Sakari Ailus <sakari.ailus@linux.intel.com>
+Patchset: cameras
+---
+ drivers/media/i2c/dw9719.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/dw9719.c b/drivers/media/i2c/dw9719.c
+--- a/drivers/media/i2c/dw9719.c
++++ b/drivers/media/i2c/dw9719.c
+@@ -451,6 +451,15 @@ static const struct of_device_id dw9719_of_table[] = {
+ };
+ MODULE_DEVICE_TABLE(of, dw9719_of_table);
+
++static const struct i2c_device_id dw9719_id_table[] = {
++	{ .name = "dw9718s", .driver_data = (kernel_ulong_t)DW9718S },
++	{ .name = "dw9719", .driver_data = (kernel_ulong_t)DW9719 },
++	{ .name = "dw9761", .driver_data = (kernel_ulong_t)DW9761 },
++	{ .name = "dw9800k", .driver_data = (kernel_ulong_t)DW9800K },
++	{ }
++};
++MODULE_DEVICE_TABLE(i2c, dw9719_id_table);
++
+ static DEFINE_RUNTIME_DEV_PM_OPS(dw9719_pm_ops, dw9719_suspend, dw9719_resume,
+ 				 NULL);
+
+@@ -463,4 +472,5 @@ static struct i2c_driver dw9719_i2c_driver = {
+ 	.probe = dw9719_probe,
+ 	.remove = dw9719_remove,
++	.id_table = dw9719_id_table,
+ };
+ module_i2c_driver(dw9719_i2c_driver);
+--
+2.53.0

--- a/patches/6.19/0013-cameras.patch
+++ b/patches/6.19/0013-cameras.patch
@@ -1086,7 +1086,7 @@ Patchset: cameras
 diff --git a/drivers/media/i2c/dw9719.c b/drivers/media/i2c/dw9719.c
 --- a/drivers/media/i2c/dw9719.c
 +++ b/drivers/media/i2c/dw9719.c
-@@ -451,6 +451,15 @@ static const struct of_device_id dw9719_of_table[] = {
+@@ -454,6 +454,15 @@ static const struct of_device_id dw9719_of_table[] = {
  };
  MODULE_DEVICE_TABLE(of, dw9719_of_table);
 
@@ -1102,7 +1102,7 @@ diff --git a/drivers/media/i2c/dw9719.c b/drivers/media/i2c/dw9719.c
  static DEFINE_RUNTIME_DEV_PM_OPS(dw9719_pm_ops, dw9719_suspend, dw9719_resume,
  				 NULL);
 
-@@ -463,4 +472,5 @@ static struct i2c_driver dw9719_i2c_driver = {
+@@ -466,4 +475,5 @@ static struct i2c_driver dw9719_i2c_driver = {
  	.probe = dw9719_probe,
  	.remove = dw9719_remove,
 +	.id_table = dw9719_id_table,


### PR DESCRIPTION
## Summary

Adds back the `i2c_device_id` table to the dw9719 VCM driver for kernel 6.19, fixing a regression that prevents cameras from working on Surface devices that use the dw9719 voice coil motor (ov8865 autofocus).

**Root cause**: Upstream commit "media: i2c: dw9719: Remove unused i2c device id table" in kernel 6.19 removed the `i2c_device_id` table. However, on Surface devices, the VCM is instantiated by the IPU bridge via I2C, so it requires I2C device matching. Without the table, `dw9719_i2c_driver` has no `i2c:dw9719` alias and the driver never binds.

**Cascade failure**: Without the VCM bound, `cio2_notifier_complete()` does not fire, so `v4l2_device_register_subdev_nodes()` is never called. The ipu3-csi2 entities get no V4L2 subdevice nodes, and libcamera reports "Skip ipu3-csi2 0: no device node" → empty camera list.

This patch is taken from Sakari Ailus's upstream fix:
https://lore.kernel.org/all/20260326174909.2746696-1-sakari.ailus@linux.intel.com/

## Affected issues

- Fixes #2087
- Fixes #2101
- Related: #1468 (Surface Book 2 cameras on kernel 6.12 — different root cause, but same symptom)

## Test plan

- [x] Kernel builds with the patch applied
- [x] `modinfo dw9719` shows `alias: i2c:dw9719` (and dw9718s, dw9761, dw9800k)
- [x] `media-ctl -p` shows links between sensor entities and ipu3-csi2
- [x] `cam --list` reports cameras on Surface Book 2 / Surface Go 2 / Surface Pro 8+