### PR TITLE
fix: suppress background git maintenance during fedora kernel-ark; avoids stale runner

### DIFF
--- a/.github/scripts/package/fedora.sh
+++ b/.github/scripts/package/fedora.sh
@@ -43,6 +43,7 @@ build-packages)
     # setup git
     git config --global user.name "surfacebot"
     git config --global user.email "surfacebot@users.noreply.github.com"
+    git config --global maintenance.auto false #prevent maintenance that exhausts runner resources
 
     # Build source RPM packages
     python3 build-linux-surface.py --mode srpm --ark-dir kernel-ark --outdir srpm


### PR DESCRIPTION
Fedora 43's kernel-ark repository has grown large enough that
git maintenance.auto fires routinely during builds, spawning
parallel commit-graph and pack-objects processes that exhaust
RAM and swap on ubuntu-latest runners, causing the runner to
go stale.

Setting maintenance.auto false before the build removes
this. Since kernel-ark is cloned fresh each run and discarded
afterwards, skipping maintenance should have no net negative effect.

Tested: successful v7.0.7 https://github.com/orthogonaleety/linux-surface/tree/f43-7-0-x , see actions. (NB: package itself not yet tested, only that build can at least complete)