### PR TITLE
patches: Add kernel 7.0 support with Surface Pro 10 camera patches

### DIFF
--- a/contrib/surface-pro-10-cphy/README.md
+++ b/contrib/surface-pro-10-cphy/README.md
@@ -1,0 +1,20 @@
+# Surface Pro 10 Front Camera C-PHY Support
+
+## Status
+BLOCKED ON FIRMWARE - kernel driver is complete but Linux ipu6epmtl_fw.bin
+does not support C-PHY stream processing for Meteor Lake.
+
+## What works
+- C-PHY detection and flag propagation
+- CSI frontend registers correct (FE_MODE=1, PPI_CFG=0x9)  
+- DWC PHY reaches IDLE state
+- IMX681 sensor starts streaming
+- Firmware accepts stream open (src=4)
+
+## What is broken
+Linux firmware never sends FRAME_SOF after stream start.
+Windows firmware uses src=6 (CSI2_3PH_CPHY_PORT0) successfully.
+Linux firmware rejects src=6 with FW_INTERNAL_CONSISTENCY error.
+
+## Required fix
+Intel must release updated ipu6epmtl_fw.bin with C-PHY support.

--- a/contrib/surface-pro-10-cphy/ipu6-cphy.patch
+++ b/contrib/surface-pro-10-cphy/ipu6-cphy.patch
@@ -1,0 +1,163 @@
+--- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-dwc-phy.c	2026-04-12 22:48:06.000000000 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-dwc-phy.c	2026-06-01 09:48:56.292661805 +0200
+@@ -299,6 +299,66 @@
+ 	return DPHY_FREQ_RANGE_INVALID_INDEX;
+ }
+ 
++
++struct dwc_cphy_freq_range {
++	u8 hsfreq;
++	u32 min_msps;
++	u32 max_msps;
++	u32 osc_freq_target;
++};
++
++static const struct dwc_cphy_freq_range cphy_freqranges[] = {
++	{0x00,  80,  149,  335},
++	{0x10, 150,  249,  335},
++	{0x20, 250,  349,  335},
++	{0x30, 350,  449,  335},
++	{0x01, 450,  549,  335},
++	{0x11, 550,  649,  335},
++	{0x21, 650,  749,  335},
++	{0x31, 750,  899,  335},
++	{0x02, 900, 1049,  248},
++	{0x12, 1050, 1249, 248},
++	{0x22, 1250, 1499, 248},
++	{0x32, 1500, 1999, 248},
++	{0x03, 2000, 2500, 248},
++};
++#define CPHY_FREQ_RANGE_NUM ARRAY_SIZE(cphy_freqranges)
++
++static int ipu6_isys_dwc_phy_config_cphy(struct ipu6_isys *isys,
++					 u32 phy_id, u32 msps)
++{
++	struct ipu6_bus_device *adev = isys->adev;
++	struct device *dev = &adev->auxdev.dev;
++	struct ipu6_device *isp = adev->isp;
++	u32 cfg_clk_freqrange;
++	u32 osc_freq_target = 335;
++	u8 hsfreq = 0x00;
++	unsigned int i;
++
++	for (i = 0; i < CPHY_FREQ_RANGE_NUM; i++) {
++		if (msps >= cphy_freqranges[i].min_msps &&
++		    msps <= cphy_freqranges[i].max_msps) {
++			hsfreq = cphy_freqranges[i].hsfreq;
++			osc_freq_target = cphy_freqranges[i].osc_freq_target;
++			break;
++		}
++	}
++
++	dwc_dphy_write_mask(isys, phy_id, IPU6_DWC_DPHY_HSFREQRANGE,
++			    hsfreq, 0, 7);
++	dwc_dphy_ifc_write_mask(isys, phy_id, 0xe4, 0x1, 0, 1);
++	dwc_dphy_ifc_write_mask(isys, phy_id, 0xe2,
++				osc_freq_target & 0xff, 0, 8);
++	dwc_dphy_ifc_write_mask(isys, phy_id, 0xe3,
++				(osc_freq_target >> 8) & 0xf, 0, 4);
++	cfg_clk_freqrange = (isp->buttress.ref_clk - 170) * 4 / 10;
++	dwc_dphy_write_mask(isys, phy_id, IPU6_DWC_DPHY_CFGCLKFREQRANGE,
++			    cfg_clk_freqrange, 0, 8);
++	dwc_dphy_write_mask(isys, phy_id, IPU6_DWC_DPHY_DFT_CTRL2, 0x1, 4, 1);
++	dwc_dphy_write_mask(isys, phy_id, IPU6_DWC_DPHY_DFT_CTRL2, 0x1, 8, 1);
++	return 0;
++}
++
+ static int ipu6_isys_dwc_phy_config(struct ipu6_isys *isys,
+ 				    u32 phy_id, u32 mbps)
+ {
+@@ -464,6 +524,30 @@
+ 	}
+ 
+ 	nlanes = cfg->nlanes;
++
++	dev_info(dev, "PHY setup: port=%u nlanes=%u cphy=%d on=%d mbps=%u\n",
++		 port, nlanes, cfg->cphy, on, mbps);
++
++	if (on && cfg->cphy) {
++		s64 cphy_link_freq;
++		u32 sym_rate;
++		cphy_link_freq = ipu6_isys_csi2_get_link_freq(&isys->csi2[port]);
++		if (cphy_link_freq < 0) {
++			dev_err(dev, "C-PHY get link freq failed: %lld\n", cphy_link_freq);
++			return (int)cphy_link_freq;
++		}
++		do_div(cphy_link_freq, 1000000);
++		sym_rate = (u32)cphy_link_freq;
++		dev_info(dev, "C-PHY: config phy %u with %u trios at %u Msps\n",
++			 port, nlanes, sym_rate);
++		phy_id = port;
++		ipu6_isys_dwc_phy_reset(isys, phy_id);
++		ret = ipu6_isys_dwc_phy_config_cphy(isys, phy_id, sym_rate);
++		if (ret)
++			return ret;
++		return ipu6_isys_dwc_phy_powerup_ack(isys, phy_id);
++	}
++
+ 	/* only port 0, 2 and 4 support 4 lanes */
+ 	if (nlanes == 4 && port % 2) {
+ 		dev_err(dev, "invalid csi-port %u with %u lanes\n", port,
+--- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.h	2026-04-12 22:48:06.000000000 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.h	2026-06-01 09:45:28.991621419 +0200
+@@ -95,6 +95,7 @@
+ struct ipu6_isys_csi2_config {
+ 	u32 nlanes;
+ 	u32 port;
++	bool cphy;
+ };
+ 
+ struct sensor_async_sd {
+--- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.c	2026-04-12 22:48:06.000000000 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.c	2026-06-01 09:46:11.985601108 +0200
+@@ -132,6 +132,7 @@
+ 	}
+ 
+ 	isys->csi2[csi2->port].nlanes = csi2->nlanes;
++	isys->csi2[csi2->port].cphy = csi2->cphy;
+ 
+ 	return 0;
+ 
+@@ -725,7 +726,7 @@
+ 
+ 	for (i = 0; i < ISYS_MAX_PORTS; i++) {
+ 		struct v4l2_fwnode_endpoint vep = {
+-			.bus_type = V4L2_MBUS_CSI2_DPHY
++			.bus_type = V4L2_MBUS_UNKNOWN
+ 		};
+ 		struct sensor_async_sd *s_asd;
+ 		struct fwnode_handle *ep;
+@@ -751,6 +752,13 @@
+ 
+ 		s_asd->csi2.port = vep.base.port;
+ 		s_asd->csi2.nlanes = vep.bus.mipi_csi2.num_data_lanes;
++		s_asd->csi2.cphy = (vep.bus_type == V4L2_MBUS_CSI2_CPHY);
++		/* Fallback: IPU6EP-MTL port 4 is always C-PHY (IMX681/SONY0681) */
++		if (!s_asd->csi2.cphy && is_ipu6ep_mtl(isp->hw_ver) && vep.base.port == 4)
++			s_asd->csi2.cphy = true;
++		dev_info(&isp->pdev->dev, "port %u: bus_type=%d nlanes=%u cphy=%d\n",
++			 vep.base.port, vep.bus_type,
++			 vep.bus.mipi_csi2.num_data_lanes, s_asd->csi2.cphy);
+ 
+ 		dev_dbg(dev, "remote endpoint port %d with %d lanes added\n",
+ 			s_asd->csi2.port, s_asd->csi2.nlanes);
+--- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.h	2026-04-12 22:48:06.000000000 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.h	2026-06-01 09:45:28.992686208 +0200
+@@ -43,6 +43,7 @@
+ 	u32 receiver_errors;
+ 	unsigned int nlanes;
+ 	unsigned int port;
++	bool cphy;
+ };
+ 
+ struct ipu6_isys_csi2_timing {
+--- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c	2026-04-12 22:48:06.000000000 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c	2026-06-01 09:46:11.961944288 +0200
+@@ -247,6 +247,7 @@
+ 
+ 	cfg.port = csi2->port;
+ 	cfg.nlanes = nlanes;
++	cfg.cphy = csi2->cphy;
+ 
+ 	mask = isys->pdata->ipdata->csi2.irq_mask;
+ 	nports = isys->pdata->ipdata->csi2.nports;

--- a/contrib/surface-pro-10-cphy/ipu6-cphy.patch
+++ b/contrib/surface-pro-10-cphy/ipu6-cphy.patch
@@ -1,6 +1,14 @@
 --- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-dwc-phy.c	2026-04-12 22:48:06.000000000 +0200
-+++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-dwc-phy.c	2026-06-01 09:48:56.292661805 +0200
-@@ -299,6 +299,66 @@
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-dwc-phy.c	2026-06-02 23:30:58.630798097 +0200
+@@ -206,6 +206,7 @@
+ 	if (ret)
+ 		dev_err(dev, "Dphy %d power up failed, state 0x%x", phy_id,
+ 			fsm_state);
++	dev_info(dev, "Dphy %d FSM state=0x%x after powerup\n", phy_id, fsm_state);
+ 
+ 	return ret;
+ }
+@@ -299,6 +300,68 @@
  	return DPHY_FREQ_RANGE_INVALID_INDEX;
  }
  
@@ -49,6 +57,8 @@
 +		}
 +	}
 +
++	/* Set C-PHY mode in PHY - IFC reg 0x1f bit 0 selects CPHY vs DPHY */
++	dwc_dphy_ifc_write_mask(isys, phy_id, 0x1f, 0x1, 0, 1);
 +	dwc_dphy_write_mask(isys, phy_id, IPU6_DWC_DPHY_HSFREQRANGE,
 +			    hsfreq, 0, 7);
 +	dwc_dphy_ifc_write_mask(isys, phy_id, 0xe4, 0x1, 0, 1);
@@ -67,7 +77,7 @@
  static int ipu6_isys_dwc_phy_config(struct ipu6_isys *isys,
  				    u32 phy_id, u32 mbps)
  {
-@@ -464,6 +524,30 @@
+@@ -464,6 +527,34 @@
  	}
  
  	nlanes = cfg->nlanes;
@@ -89,10 +99,14 @@
 +			 port, nlanes, sym_rate);
 +		phy_id = port;
 +		ipu6_isys_dwc_phy_reset(isys, phy_id);
++		/* Set C-PHY mode: CORE_DIG_RW_COMMON_7 lower 12 bits = 0x88e */
++		dwc_dphy_ifc_write_mask(isys, phy_id, 0x88e, 0x15, 0, 9);
 +		ret = ipu6_isys_dwc_phy_config_cphy(isys, phy_id, sym_rate);
 +		if (ret)
 +			return ret;
-+		return ipu6_isys_dwc_phy_powerup_ack(isys, phy_id);
++		ret = ipu6_isys_dwc_phy_powerup_ack(isys, phy_id);
++		dev_info(dev, "C-PHY powerup_ack returned %d\n", ret);
++		return ret;
 +	}
 +
  	/* only port 0, 2 and 4 support 4 lanes */
@@ -109,16 +123,17 @@
  
  struct sensor_async_sd {
 --- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.c	2026-04-12 22:48:06.000000000 +0200
-+++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.c	2026-06-01 09:46:11.985601108 +0200
-@@ -132,6 +132,7 @@
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.c	2026-06-03 00:40:18.997545346 +0200
+@@ -132,7 +132,7 @@
  	}
  
  	isys->csi2[csi2->port].nlanes = csi2->nlanes;
+-
 +	isys->csi2[csi2->port].cphy = csi2->cphy;
- 
  	return 0;
  
-@@ -725,7 +726,7 @@
+ unregister_subdev:
+@@ -725,7 +725,7 @@
  
  	for (i = 0; i < ISYS_MAX_PORTS; i++) {
  		struct v4l2_fwnode_endpoint vep = {
@@ -127,7 +142,7 @@
  		};
  		struct sensor_async_sd *s_asd;
  		struct fwnode_handle *ep;
-@@ -751,6 +752,13 @@
+@@ -751,6 +751,13 @@
  
  		s_asd->csi2.port = vep.base.port;
  		s_asd->csi2.nlanes = vep.bus.mipi_csi2.num_data_lanes;
@@ -141,6 +156,28 @@
  
  		dev_dbg(dev, "remote endpoint port %d with %d lanes added\n",
  			s_asd->csi2.port, s_asd->csi2.nlanes);
+@@ -1221,18 +1228,18 @@
+ 	ts = (u64)resp->timestamp[1] << 32 | resp->timestamp[0];
+ 
+ 	index = resp_type_to_index(resp->type);
+-	dev_dbg(&adev->auxdev.dev,
++	dev_info(&adev->auxdev.dev,
+ 		"FW resp %02d %s, stream %u, ts 0x%16.16llx, pin %d\n",
+ 		resp->type, fw_msg[index].msg, resp->stream_handle,
+ 		fw_msg[index].valid_ts ? ts : 0, resp->pin_id);
+ 
+ 	if (resp->error_info.error == IPU6_FW_ISYS_ERROR_STREAM_IN_SUSPENSION)
+ 		/* Suspension is kind of special case: not enough buffers */
+-		dev_dbg(&adev->auxdev.dev,
++		dev_info(&adev->auxdev.dev,
+ 			"FW error resp SUSPENSION, details %d\n",
+ 			resp->error_info.error_details);
+ 	else if (resp->error_info.error)
+-		dev_dbg(&adev->auxdev.dev,
++		dev_info(&adev->auxdev.dev,
+ 			"FW error resp error %d, details %d\n",
+ 			resp->error_info.error, resp->error_info.error_details);
+ 
 --- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.h	2026-04-12 22:48:06.000000000 +0200
 +++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.h	2026-06-01 09:45:28.992686208 +0200
 @@ -43,6 +43,7 @@
@@ -152,7 +189,7 @@
  
  struct ipu6_isys_csi2_timing {
 --- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c	2026-04-12 22:48:06.000000000 +0200
-+++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c	2026-06-01 09:46:11.961944288 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c	2026-06-02 17:46:07.205081860 +0200
 @@ -247,6 +247,7 @@
  
  	cfg.port = csi2->port;
@@ -161,3 +198,35 @@
  
  	mask = isys->pdata->ipdata->csi2.irq_mask;
  	nports = isys->pdata->ipdata->csi2.nports;
+@@ -325,13 +326,16 @@
+ 	       CSI_PORT_REG_BASE_IRQ_ENABLE_OFFSET);
+ 
+ 	/* configure to enable FE and PPI2CSI */
+-	writel(0, csi2->base + CSI_REG_CSI_FE_MODE);
++	writel(cfg.cphy ? CSI_FE_CPHY_MODE : CSI_FE_DPHY_MODE,
++	       csi2->base + CSI_REG_CSI_FE_MODE);
+ 	writel(CSI_SENSOR_INPUT, csi2->base + CSI_REG_CSI_FE_MUX_CTRL);
+ 	writel(CSI_CNTR_SENSOR_LINE_ID | CSI_CNTR_SENSOR_FRAME_ID,
+ 	       csi2->base + CSI_REG_CSI_FE_SYNC_CNTR_SEL);
+-	writel(FIELD_PREP(PPI_INTF_CONFIG_NOF_ENABLED_DLANES_MASK, nlanes - 1),
++	writel(FIELD_PREP(PPI_INTF_CONFIG_NOF_ENABLED_DLANES_MASK, nlanes - 1) |
++	       (cfg.cphy ? PPI_INTF_CONFIG_PHY_TYPE_MASK : 0),
+ 	       csi2->base + CSI_REG_PPI2CSI_CONFIG_PPI_INTF);
+ 
++	writel(0x06, csi2->base + CSI_REG_PPI2CSI_CONFIG_CSI_FEATURE);
+ 	writel(1, csi2->base + CSI_REG_PPI2CSI_ENABLE);
+ 	writel(1, csi2->base + CSI_REG_CSI_FE_ENABLE);
+ 
+@@ -340,6 +344,12 @@
+ 		dev_err(dev, "csi-%d phy power up failed %d\n", csi2->port,
+ 			ret);
+ 
++	dev_info(dev, "CSI%u FE_MODE=0x%x FE_EN=0x%x PPI_CFG=0x%x PPI_EN=0x%x\n",
++		 csi2->port,
++		 readl(csi2->base + CSI_REG_CSI_FE_MODE),
++		 readl(csi2->base + CSI_REG_CSI_FE_ENABLE),
++		 readl(csi2->base + CSI_REG_PPI2CSI_CONFIG_PPI_INTF),
++		 readl(csi2->base + CSI_REG_PPI2CSI_ENABLE));
+ 	return ret;
+ }
+ 

--- a/contrib/surface-pro-10-cphy/ipu6-cphy.patch
+++ b/contrib/surface-pro-10-cphy/ipu6-cphy.patch
@@ -1,4 +1,4 @@
---- /dev/fd/63	2026-06-04 18:17:32.533585838 +0200
+--- /dev/fd/63	2026-06-04 22:53:11.164048188 +0200
 +++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-dwc-phy.c	2026-06-02 23:30:58.630798097 +0200
 @@ -206,6 +206,7 @@
  	if (ret)
@@ -112,7 +112,7 @@
  	/* only port 0, 2 and 4 support 4 lanes */
  	if (nlanes == 4 && port % 2) {
  		dev_err(dev, "invalid csi-port %u with %u lanes\n", port,
---- /dev/fd/63	2026-06-04 18:17:51.754726724 +0200
+--- /dev/fd/63	2026-06-04 22:53:30.385237155 +0200
 +++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.h	2026-06-01 09:45:28.991621419 +0200
 @@ -95,6 +95,7 @@
  struct ipu6_isys_csi2_config {
@@ -122,8 +122,8 @@
  };
  
  struct sensor_async_sd {
---- /dev/fd/63	2026-06-04 18:18:10.664865330 +0200
-+++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.c	2026-06-04 18:13:13.039965481 +0200
+--- /dev/fd/63	2026-06-04 22:53:49.957428850 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.c	2026-06-04 22:35:10.810055685 +0200
 @@ -132,7 +132,7 @@
  	}
  
@@ -179,7 +179,7 @@
  			"FW error resp error %d, details %d\n",
  			resp->error_info.error, resp->error_info.error_details);
  
---- /dev/fd/63	2026-06-04 18:18:32.422024803 +0200
+--- /dev/fd/63	2026-06-04 22:54:08.981611519 +0200
 +++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.h	2026-06-01 09:45:28.992686208 +0200
 @@ -43,6 +43,7 @@
  	u32 receiver_errors;
@@ -189,7 +189,7 @@
  };
  
  struct ipu6_isys_csi2_timing {
---- /dev/fd/63	2026-06-04 18:18:54.622187525 +0200
+--- /dev/fd/63	2026-06-04 22:54:28.061794727 +0200
 +++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c	2026-06-04 18:16:31.280606059 +0200
 @@ -247,6 +247,7 @@
  
@@ -239,7 +239,7 @@
  	return ret;
  }
  
---- /dev/fd/63	2026-06-04 18:19:45.271432345 +0200
+--- /dev/fd/63	2026-06-04 22:54:47.295979413 +0200
 +++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-platform-isys-csi2-reg.h	2026-06-01 22:32:45.079697045 +0200
 @@ -46,6 +46,7 @@
  #define CSI_REG_PPI2CSI_ENABLE				0x200

--- a/contrib/surface-pro-10-cphy/ipu6-cphy.patch
+++ b/contrib/surface-pro-10-cphy/ipu6-cphy.patch
@@ -1,4 +1,4 @@
---- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-dwc-phy.c	2026-04-12 22:48:06.000000000 +0200
+--- /dev/fd/63	2026-06-04 18:17:32.533585838 +0200
 +++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-dwc-phy.c	2026-06-02 23:30:58.630798097 +0200
 @@ -206,6 +206,7 @@
  	if (ret)
@@ -112,7 +112,7 @@
  	/* only port 0, 2 and 4 support 4 lanes */
  	if (nlanes == 4 && port % 2) {
  		dev_err(dev, "invalid csi-port %u with %u lanes\n", port,
---- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.h	2026-04-12 22:48:06.000000000 +0200
+--- /dev/fd/63	2026-06-04 18:17:51.754726724 +0200
 +++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.h	2026-06-01 09:45:28.991621419 +0200
 @@ -95,6 +95,7 @@
  struct ipu6_isys_csi2_config {
@@ -122,8 +122,8 @@
  };
  
  struct sensor_async_sd {
---- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.c	2026-04-12 22:48:06.000000000 +0200
-+++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.c	2026-06-03 00:40:18.997545346 +0200
+--- /dev/fd/63	2026-06-04 18:18:10.664865330 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.c	2026-06-04 18:13:13.039965481 +0200
 @@ -132,7 +132,7 @@
  	}
  
@@ -133,6 +133,15 @@
  	return 0;
  
  unregister_subdev:
+@@ -378,7 +378,7 @@
+ 				if (!isys->csi2[i].base)
+ 					continue;
+ 				if (status_csi & IPU6_ISYS_UNISPART_IRQ_CSI2(i))
+-					ipu6_isys_csi2_isr(&isys->csi2[i]);
++									ipu6_isys_csi2_isr(&isys->csi2[i]);
+ 			}
+ 		}
+ 
 @@ -725,7 +725,7 @@
  
  	for (i = 0; i < ISYS_MAX_PORTS; i++) {
@@ -156,15 +165,7 @@
  
  		dev_dbg(dev, "remote endpoint port %d with %d lanes added\n",
  			s_asd->csi2.port, s_asd->csi2.nlanes);
-@@ -1221,18 +1228,18 @@
- 	ts = (u64)resp->timestamp[1] << 32 | resp->timestamp[0];
- 
- 	index = resp_type_to_index(resp->type);
--	dev_dbg(&adev->auxdev.dev,
-+	dev_info(&adev->auxdev.dev,
- 		"FW resp %02d %s, stream %u, ts 0x%16.16llx, pin %d\n",
- 		resp->type, fw_msg[index].msg, resp->stream_handle,
- 		fw_msg[index].valid_ts ? ts : 0, resp->pin_id);
+@@ -1228,11 +1235,11 @@
  
  	if (resp->error_info.error == IPU6_FW_ISYS_ERROR_STREAM_IN_SUSPENSION)
  		/* Suspension is kind of special case: not enough buffers */
@@ -178,7 +179,7 @@
  			"FW error resp error %d, details %d\n",
  			resp->error_info.error, resp->error_info.error_details);
  
---- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.h	2026-04-12 22:48:06.000000000 +0200
+--- /dev/fd/63	2026-06-04 18:18:32.422024803 +0200
 +++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.h	2026-06-01 09:45:28.992686208 +0200
 @@ -43,6 +43,7 @@
  	u32 receiver_errors;
@@ -188,8 +189,8 @@
  };
  
  struct ipu6_isys_csi2_timing {
---- orig/linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c	2026-04-12 22:48:06.000000000 +0200
-+++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c	2026-06-02 17:46:07.205081860 +0200
+--- /dev/fd/63	2026-06-04 18:18:54.622187525 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c	2026-06-04 18:16:31.280606059 +0200
 @@ -247,6 +247,7 @@
  
  	cfg.port = csi2->port;
@@ -198,7 +199,15 @@
  
  	mask = isys->pdata->ipdata->csi2.irq_mask;
  	nports = isys->pdata->ipdata->csi2.nports;
-@@ -325,13 +326,16 @@
+@@ -291,6 +292,7 @@
+ 		       (isys->pdata->ipdata->csi2.fw_access_port_ofs, i));
+ 	}
+ 
++
+ 	/* enable all error related irq */
+ 	writel(mask,
+ 	       csi2->base + CSI_PORT_REG_BASE_IRQ_CSI +
+@@ -325,13 +327,16 @@
  	       CSI_PORT_REG_BASE_IRQ_ENABLE_OFFSET);
  
  	/* configure to enable FE and PPI2CSI */
@@ -217,7 +226,7 @@
  	writel(1, csi2->base + CSI_REG_PPI2CSI_ENABLE);
  	writel(1, csi2->base + CSI_REG_CSI_FE_ENABLE);
  
-@@ -340,6 +344,12 @@
+@@ -340,6 +345,12 @@
  		dev_err(dev, "csi-%d phy power up failed %d\n", csi2->port,
  			ret);
  
@@ -230,3 +239,13 @@
  	return ret;
  }
  
+--- /dev/fd/63	2026-06-04 18:19:45.271432345 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-platform-isys-csi2-reg.h	2026-06-01 22:32:45.079697045 +0200
+@@ -46,6 +46,7 @@
+ #define CSI_REG_PPI2CSI_ENABLE				0x200
+ #define CSI_REG_PPI2CSI_CONFIG_PPI_INTF			0x204
+ #define PPI_INTF_CONFIG_NOF_ENABLED_DLANES_MASK		GENMASK(4, 3)
++#define PPI_INTF_CONFIG_PHY_TYPE_MASK			BIT(0)
+ #define CSI_REG_PPI2CSI_CONFIG_CSI_FEATURE		0x208
+ 
+ enum CSI_PPI2CSI_CTRL {

--- a/contrib/surface-pro-10-cphy/ipu6-cphy.patch
+++ b/contrib/surface-pro-10-cphy/ipu6-cphy.patch
@@ -1,5 +1,5 @@
---- /dev/fd/63	2026-06-04 22:53:11.164048188 +0200
-+++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-dwc-phy.c	2026-06-02 23:30:58.630798097 +0200
+--- /dev/fd/63	2026-06-05 09:43:44.524639704 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-dwc-phy.c	2026-06-05 09:32:58.950639796 +0200
 @@ -206,6 +206,7 @@
  	if (ret)
  		dev_err(dev, "Dphy %d power up failed, state 0x%x", phy_id,
@@ -112,8 +112,8 @@
  	/* only port 0, 2 and 4 support 4 lanes */
  	if (nlanes == 4 && port % 2) {
  		dev_err(dev, "invalid csi-port %u with %u lanes\n", port,
---- /dev/fd/63	2026-06-04 22:53:30.385237155 +0200
-+++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.h	2026-06-01 09:45:28.991621419 +0200
+--- /dev/fd/63	2026-06-05 09:44:07.149858931 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.h	2026-06-05 09:32:58.950991201 +0200
 @@ -95,6 +95,7 @@
  struct ipu6_isys_csi2_config {
  	u32 nlanes;
@@ -122,8 +122,8 @@
  };
  
  struct sensor_async_sd {
---- /dev/fd/63	2026-06-04 22:53:49.957428850 +0200
-+++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.c	2026-06-04 22:35:10.810055685 +0200
+--- /dev/fd/63	2026-06-05 09:44:33.389352561 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys.c	2026-06-05 09:32:58.951220545 +0200
 @@ -132,7 +132,7 @@
  	}
  
@@ -179,8 +179,8 @@
  			"FW error resp error %d, details %d\n",
  			resp->error_info.error, resp->error_info.error_details);
  
---- /dev/fd/63	2026-06-04 22:54:08.981611519 +0200
-+++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.h	2026-06-01 09:45:28.992686208 +0200
+--- /dev/fd/63	2026-06-05 09:44:56.016024357 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.h	2026-06-05 09:32:58.951438212 +0200
 @@ -43,6 +43,7 @@
  	u32 receiver_errors;
  	unsigned int nlanes;
@@ -189,8 +189,8 @@
  };
  
  struct ipu6_isys_csi2_timing {
---- /dev/fd/63	2026-06-04 22:54:28.061794727 +0200
-+++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c	2026-06-04 18:16:31.280606059 +0200
+--- /dev/fd/63	2026-06-05 09:45:19.635349493 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c	2026-06-05 09:32:58.951580685 +0200
 @@ -247,6 +247,7 @@
  
  	cfg.port = csi2->port;
@@ -239,8 +239,8 @@
  	return ret;
  }
  
---- /dev/fd/63	2026-06-04 22:54:47.295979413 +0200
-+++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-platform-isys-csi2-reg.h	2026-06-01 22:32:45.079697045 +0200
+--- /dev/fd/63	2026-06-05 09:45:40.156582809 +0200
++++ linux-source-7.0.0/drivers/media/pci/intel/ipu6/ipu6-platform-isys-csi2-reg.h	2026-06-05 09:32:58.951753980 +0200
 @@ -46,6 +46,7 @@
  #define CSI_REG_PPI2CSI_ENABLE				0x200
  #define CSI_REG_PPI2CSI_CONFIG_PPI_INTF			0x204

--- a/patches/7.0/0001-secureboot.patch
+++ b/patches/7.0/0001-secureboot.patch
@@ -1,0 +1,112 @@
+From 7d201613b9e598df5b51b9345a54ecadaac3eb20 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Sun, 9 Jun 2024 19:48:58 +0200
+Subject: [PATCH] Revert "efi/x86: Set the PE/COFF header's NX compat flag
+ unconditionally"
+
+This reverts commit 891f8890a4a3663da7056542757022870b499bc1.
+
+Revert because of compatibility issues of MS Surface devices and GRUB
+with NX. In short, these devices get stuck on boot with NX advertised.
+So to not advertise it, add the respective option back in.
+
+Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>
+Patchset: secureboot
+---
+ arch/x86/boot/header.S | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/x86/boot/header.S b/arch/x86/boot/header.S
+index 9bea5a1e2..25848f886 100644
+--- a/arch/x86/boot/header.S
++++ b/arch/x86/boot/header.S
+@@ -111,7 +111,11 @@ extra_header_fields:
+ 	.long	salign				# SizeOfHeaders
+ 	.long	0				# CheckSum
+ 	.word	IMAGE_SUBSYSTEM_EFI_APPLICATION	# Subsystem (EFI application)
++#ifdef CONFIG_EFI_DXE_MEM_ATTRIBUTES
+ 	.word	IMAGE_DLLCHARACTERISTICS_NX_COMPAT	# DllCharacteristics
++#else
++	.word	0				# DllCharacteristics
++#endif
+ #ifdef CONFIG_X86_32
+ 	.long	0				# SizeOfStackReserve
+ 	.long	0				# SizeOfStackCommit
+-- 
+2.53.0
+
+From 68d5a2a32c55afab7aed55f9334f35bff9f7b119 Mon Sep 17 00:00:00 2001
+From: "J. Eduardo" <j.eduardo@gmail.com>
+Date: Sun, 25 Aug 2024 14:17:45 +0200
+Subject: [PATCH] PM: hibernate: Add a lockdown_hibernate parameter
+
+This allows the user to tell the kernel that they know better (namely,
+they secured their swap properly), and that it can enable hibernation.
+
+Signed-off-by: Kelvie Wong <kelvie@kelvie.ca>
+Link: https://github.com/linux-surface/kernel/pull/158
+Link: https://gist.github.com/brknkfr/95d1925ccdbb7a2d18947c168dfabbee
+Patchset: secureboot
+---
+ Documentation/admin-guide/kernel-parameters.txt |  5 +++++
+ kernel/power/hibernate.c                        | 10 +++++++++-
+ 2 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
+index aa0031108..ca92d0e45 100644
+--- a/Documentation/admin-guide/kernel-parameters.txt
++++ b/Documentation/admin-guide/kernel-parameters.txt
+@@ -3500,6 +3500,11 @@ Kernel parameters
+ 			to extract confidential information from the kernel
+ 			are also disabled.
+ 
++	lockdown_hibernate	[HIBERNATION]
++			Enable hibernation even if lockdown is enabled. Enable this only if
++			your swap is encrypted and secured properly, as an attacker can
++			modify the kernel offline during hibernation.
++
+ 	locktorture.acq_writer_lim= [KNL]
+ 			Set the time limit in jiffies for a lock
+ 			acquisition.  Acquisitions exceeding this limit
+diff --git a/kernel/power/hibernate.c b/kernel/power/hibernate.c
+index af8d07baf..9e151554d 100644
+--- a/kernel/power/hibernate.c
++++ b/kernel/power/hibernate.c
+@@ -38,6 +38,7 @@
+ #include "power.h"
+ 
+ 
++static int lockdown_hibernate;
+ static int nocompress;
+ static int noresume;
+ static int nohibernate;
+@@ -109,7 +110,7 @@ bool hibernation_in_progress(void)
+ bool hibernation_available(void)
+ {
+ 	return nohibernate == 0 &&
+-		!security_locked_down(LOCKDOWN_HIBERNATION) &&
++		(lockdown_hibernate || !security_locked_down(LOCKDOWN_HIBERNATION)) &&
+ 		!secretmem_active() && !cxl_mem_active();
+ }
+ 
+@@ -1493,6 +1494,12 @@ static int __init nohibernate_setup(char *str)
+ 	return 1;
+ }
+ 
++static int __init lockdown_hibernate_setup(char *str)
++{
++	lockdown_hibernate = 1;
++	return 1;
++}
++
+ static const char * const comp_alg_enabled[] = {
+ #if IS_ENABLED(CONFIG_CRYPTO_LZO)
+ 	COMPRESSION_ALGO_LZO,
+@@ -1550,3 +1557,4 @@ __setup("hibernate=", hibernate_setup);
+ __setup("resumewait", resumewait_setup);
+ __setup("resumedelay=", resumedelay_setup);
+ __setup("nohibernate", nohibernate_setup);
++__setup("lockdown_hibernate", lockdown_hibernate_setup);
+-- 
+2.53.0
+

--- a/patches/7.0/0002-surface3.patch
+++ b/patches/7.0/0002-surface3.patch
@@ -1,0 +1,234 @@
+From 768f0e265602d98b3c51a39a5a4259937fb795b4 Mon Sep 17 00:00:00 2001
+From: Tsuchiya Yuto <kitakar@gmail.com>
+Date: Sun, 18 Oct 2020 16:42:44 +0900
+Subject: [PATCH] (surface3-oemb) add DMI matches for Surface 3 with broken DMI
+ table
+
+On some Surface 3, the DMI table gets corrupted for unknown reasons
+and breaks existing DMI matching used for device-specific quirks.
+
+This commit adds the (broken) DMI data into dmi_system_id tables used
+for quirks so that each driver can enable quirks even on the affected
+systems.
+
+On affected systems, DMI data will look like this:
+    $ grep . /sys/devices/virtual/dmi/id/{bios_vendor,board_name,board_vendor,\
+    chassis_vendor,product_name,sys_vendor}
+    /sys/devices/virtual/dmi/id/bios_vendor:American Megatrends Inc.
+    /sys/devices/virtual/dmi/id/board_name:OEMB
+    /sys/devices/virtual/dmi/id/board_vendor:OEMB
+    /sys/devices/virtual/dmi/id/chassis_vendor:OEMB
+    /sys/devices/virtual/dmi/id/product_name:OEMB
+    /sys/devices/virtual/dmi/id/sys_vendor:OEMB
+
+Expected:
+    $ grep . /sys/devices/virtual/dmi/id/{bios_vendor,board_name,board_vendor,\
+    chassis_vendor,product_name,sys_vendor}
+    /sys/devices/virtual/dmi/id/bios_vendor:American Megatrends Inc.
+    /sys/devices/virtual/dmi/id/board_name:Surface 3
+    /sys/devices/virtual/dmi/id/board_vendor:Microsoft Corporation
+    /sys/devices/virtual/dmi/id/chassis_vendor:Microsoft Corporation
+    /sys/devices/virtual/dmi/id/product_name:Surface 3
+    /sys/devices/virtual/dmi/id/sys_vendor:Microsoft Corporation
+
+Signed-off-by: Tsuchiya Yuto <kitakar@gmail.com>
+Patchset: surface3
+---
+ drivers/platform/surface/surface3-wmi.c           | 7 +++++++
+ sound/soc/codecs/rt5645.c                         | 9 +++++++++
+ sound/soc/intel/common/soc-acpi-intel-cht-match.c | 8 ++++++++
+ 3 files changed, 24 insertions(+)
+
+diff --git a/drivers/platform/surface/surface3-wmi.c b/drivers/platform/surface/surface3-wmi.c
+index 6c8fb7a4d..22797a53f 100644
+--- a/drivers/platform/surface/surface3-wmi.c
++++ b/drivers/platform/surface/surface3-wmi.c
+@@ -37,6 +37,13 @@ static const struct dmi_system_id surface3_dmi_table[] = {
+ 			DMI_MATCH(DMI_PRODUCT_NAME, "Surface 3"),
+ 		},
+ 	},
++	{
++		.matches = {
++			DMI_MATCH(DMI_BIOS_VENDOR, "American Megatrends Inc."),
++			DMI_MATCH(DMI_SYS_VENDOR, "OEMB"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "OEMB"),
++		},
++	},
+ #endif
+ 	{ }
+ };
+diff --git a/sound/soc/codecs/rt5645.c b/sound/soc/codecs/rt5645.c
+index f7701b8d0..0708c2fe8 100644
+--- a/sound/soc/codecs/rt5645.c
++++ b/sound/soc/codecs/rt5645.c
+@@ -3793,6 +3793,15 @@ static const struct dmi_system_id dmi_platform_data[] = {
+ 		},
+ 		.driver_data = (void *)&intel_braswell_platform_data,
+ 	},
++	{
++		.ident = "Microsoft Surface 3",
++		.matches = {
++			DMI_MATCH(DMI_BIOS_VENDOR, "American Megatrends Inc."),
++			DMI_MATCH(DMI_SYS_VENDOR, "OEMB"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "OEMB"),
++		},
++		.driver_data = (void *)&intel_braswell_platform_data,
++	},
+ 	{
+ 		/*
+ 		 * Match for the GPDwin which unfortunately uses somewhat
+diff --git a/sound/soc/intel/common/soc-acpi-intel-cht-match.c b/sound/soc/intel/common/soc-acpi-intel-cht-match.c
+index e4c3492a0..0b930c91b 100644
+--- a/sound/soc/intel/common/soc-acpi-intel-cht-match.c
++++ b/sound/soc/intel/common/soc-acpi-intel-cht-match.c
+@@ -27,6 +27,14 @@ static const struct dmi_system_id cht_table[] = {
+ 			DMI_MATCH(DMI_PRODUCT_NAME, "Surface 3"),
+ 		},
+ 	},
++	{
++		.callback = cht_surface_quirk_cb,
++		.matches = {
++			DMI_MATCH(DMI_BIOS_VENDOR, "American Megatrends Inc."),
++			DMI_MATCH(DMI_SYS_VENDOR, "OEMB"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "OEMB"),
++		},
++	},
+ 	{ }
+ };
+ 
+-- 
+2.53.0
+
+From 092d2600301127e07e9f0a9376e78453578d30ba Mon Sep 17 00:00:00 2001
+From: kitakar5525 <34676735+kitakar5525@users.noreply.github.com>
+Date: Fri, 6 Dec 2019 23:10:30 +0900
+Subject: [PATCH] surface3-spi: workaround: disable DMA mode to avoid crash by
+ default
+
+On Arch Linux kernel at least after 4.19, touch input is broken after suspend
+(s2idle).
+
+        kern  :err   : [  +0.203408] Surface3-spi spi-MSHW0037:00: SPI transfer timed out
+
+On recent stable Arch Linux kernel (at least after 5.1), touch input will
+crash after the first touch.
+
+        kern  :err   : [  +0.203592] Surface3-spi spi-MSHW0037:00: SPI transfer timed out
+        kern  :err   : [  +0.000173] spi_master spi1: failed to transfer one message from queue
+
+I found on an affected system (Arch Linux kernel, etc.), the touchscreen
+driver uses DMA mode by default. Then, we found some kernels with different
+kernel config (5.1 kernel config from Jakeday [1] or Chromium OS kernel
+chromeos-4.19 [2]) will use PIO mode by default and no such issues there.
+
+So, this commit disables DMA mode on the touchscreen driver side as a quick
+workaround to avoid touch input crash.
+We may need to properly set up DMA mode to use the touchscreen driver with
+DMA mode.
+
+You can still switch DMA/PIO mode if you want:
+
+  switch to DMA mode (maybe broken)
+        echo 1 | sudo tee /sys/module/surface3_spi/parameters/use_dma
+  back to PIO mode
+        echo 0 | sudo tee /sys/module/surface3_spi/parameters/use_dma
+
+Link to issue: https://github.com/jakeday/linux-surface/issues/596
+
+References:
+[1] https://github.com/jakeday/linux-surface/blob/master/configs/5.1/config
+[2] https://chromium.googlesource.com/chromiumos/third_party/kernel/+/refs/heads/chromeos-4.19
+
+Tested on Arch Linux 5.4.1 with Surface 3, which will use DMA by default.
+This commit made the driver use PIO by default and no touch input crash.
+Also tested on chromeos-4.19 4.19.90 with Surface 3, which will use PIO by default
+even without this commit. After this commit, it still uses PIO and confirmed
+no functional changes regarding touch input.
+
+More details:
+  We can confirm which mode the touchscreen driver uses; first, enable
+  debug output:
+
+        echo "file drivers/spi/spi-pxa2xx.c +p" | sudo tee /sys/kernel/debug/dynamic_debug/control
+        echo "file drivers/input/touchscreen/surface3_spi.c +p" | sudo tee /sys/kernel/debug/dynamic_debug/control
+
+  Then, try to make a touch input and see dmesg log
+
+        (On Arch Linux kernel, uses DMA)
+        kern  :debug : [  +0.006383] Surface3-spi spi-MSHW0037:00: 7692307 Hz actual, DMA
+        kern  :debug : [  +0.000495] Surface3-spi spi-MSHW0037:00: surface3_spi_irq_handler received
+	-> ff ff ff ff a5 5a e7 7e 01 d2 00 80 01 03 03 18 00 e4 01 00 04 1a 04 1a e3 0c e3 0c b0 00
+	c5 00 00 00 00 00 ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+
+        (On the kernels I referenced above, uses PIO)
+        kern  :debug : [  +0.009260] Surface3-spi spi-MSHW0037:00: 7692307 Hz actual, PIO
+        kern  :debug : [  +0.001105] Surface3-spi spi-MSHW0037:00: surface3_spi_irq_handler received
+	-> ff ff ff ff a5 5a e7 7e 01 d2 00 80 01 03 03 24 00 e4 01 00 58 0b 58 0b 83 12 83 12 26 01
+	95 01 00 00 00 00 ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+
+Note (2025-03-08): This patch was originally dropped due to the
+comments in [3]. However, according to the commments in [4] it is still
+required.
+
+[3]: https://github.com/linux-surface/kernel/commit/a3421c12bed0e46c28518bcb8c6b22f237c6dc7a
+[4]: https://github.com/linux-surface/linux-surface/issues/1184
+
+Patchset: surface3
+---
+ drivers/input/touchscreen/surface3_spi.c | 26 ++++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/drivers/input/touchscreen/surface3_spi.c b/drivers/input/touchscreen/surface3_spi.c
+index 6074b7730..6aa3e1d6f 100644
+--- a/drivers/input/touchscreen/surface3_spi.c
++++ b/drivers/input/touchscreen/surface3_spi.c
+@@ -25,6 +25,12 @@
+ #define SURFACE3_REPORT_TOUCH	0xd2
+ #define SURFACE3_REPORT_PEN	0x16
+ 
++bool use_dma = false;
++module_param(use_dma, bool, 0644);
++MODULE_PARM_DESC(use_dma,
++				"Disable DMA mode if you encounter touch input crash. "
++				"(default: false, disabled to avoid crash)");
++
+ struct surface3_ts_data {
+ 	struct spi_device *spi;
+ 	struct gpio_desc *gpiod_rst[2];
+@@ -317,6 +323,13 @@ static int surface3_spi_create_pen_input(struct surface3_ts_data *data)
+ 	return 0;
+ }
+ 
++static bool surface3_spi_can_dma(struct spi_controller *ctlr,
++				struct spi_device *spi,
++				struct spi_transfer *tfr)
++{
++	return use_dma;
++}
++
+ static int surface3_spi_probe(struct spi_device *spi)
+ {
+ 	struct surface3_ts_data *data;
+@@ -359,6 +372,19 @@ static int surface3_spi_probe(struct spi_device *spi)
+ 	if (error)
+ 		return error;
+ 
++	/*
++	 * Set up DMA
++	 *
++	 * TODO: Currently, touch input with DMA seems to be broken.
++	 * On 4.19 LTS, touch input will crash after suspend.
++	 * On recent stable kernel (at least after 5.1), touch input will crash after
++	 * the first touch. No problem with PIO on those kernels.
++	 * Maybe we need to configure DMA here.
++	 *
++	 * Link to issue: https://github.com/jakeday/linux-surface/issues/596
++	 */
++	spi->controller->can_dma = surface3_spi_can_dma;
++
+ 	return 0;
+ }
+ 
+-- 
+2.53.0
+

--- a/patches/7.0/0003-mwifiex.patch
+++ b/patches/7.0/0003-mwifiex.patch
@@ -1,0 +1,400 @@
+From 1cb8b0055cccf3a466b21fdbb507cef8425980dd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
+Date: Tue, 3 Nov 2020 13:28:04 +0100
+Subject: [PATCH] mwifiex: Add quirk resetting the PCI bridge on MS Surface
+ devices
+
+The most recent firmware of the 88W8897 card reports a hardcoded LTR
+value to the system during initialization, probably as an (unsuccessful)
+attempt of the developers to fix firmware crashes. This LTR value
+prevents most of the Microsoft Surface devices from entering deep
+powersaving states (either platform C-State 10 or S0ix state), because
+the exit latency of that state would be higher than what the card can
+tolerate.
+
+Turns out the card works just the same (including the firmware crashes)
+no matter if that hardcoded LTR value is reported or not, so it's kind
+of useless and only prevents us from saving power.
+
+To get rid of those hardcoded LTR reports, it's possible to reset the
+PCI bridge device after initializing the cards firmware. I'm not exactly
+sure why that works, maybe the power management subsystem of the PCH
+resets its stored LTR values when doing a function level reset of the
+bridge device. Doing the reset once after starting the wifi firmware
+works very well, probably because the firmware only reports that LTR
+value a single time during firmware startup.
+
+Patchset: mwifiex
+---
+ drivers/net/wireless/marvell/mwifiex/pcie.c   | 12 +++++++++
+ .../wireless/marvell/mwifiex/pcie_quirks.c    | 26 +++++++++++++------
+ .../wireless/marvell/mwifiex/pcie_quirks.h    |  1 +
+ 3 files changed, 31 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/net/wireless/marvell/mwifiex/pcie.c b/drivers/net/wireless/marvell/mwifiex/pcie.c
+index a760de191..db9b20322 100644
+--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
++++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
+@@ -1702,9 +1702,21 @@ mwifiex_pcie_send_boot_cmd(struct mwifiex_adapter *adapter, struct sk_buff *skb)
+ static void mwifiex_pcie_init_fw_port(struct mwifiex_adapter *adapter)
+ {
+ 	struct pcie_service_card *card = adapter->card;
++	struct pci_dev *pdev = card->dev;
++	struct pci_dev *parent_pdev = pci_upstream_bridge(pdev);
+ 	const struct mwifiex_pcie_card_reg *reg = card->pcie.reg;
+ 	int tx_wrap = card->txbd_wrptr & reg->tx_wrap_mask;
+ 
++	/* Trigger a function level reset of the PCI bridge device, this makes
++	 * the firmware of PCIe 88W8897 cards stop reporting a fixed LTR value
++	 * that prevents the system from entering package C10 and S0ix powersaving
++	 * states.
++	 * We need to do it here because it must happen after firmware
++	 * initialization and this function is called after that is done.
++	 */
++	if (card->quirks & QUIRK_DO_FLR_ON_BRIDGE)
++		pci_reset_function(parent_pdev);
++
+ 	/* Write the RX ring read pointer in to reg->rx_rdptr */
+ 	mwifiex_write_reg(adapter, reg->rx_rdptr, card->rxbd_rdptr | tx_wrap);
+ }
+diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
+index dd6d21f1d..f46b06f8d 100644
+--- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
++++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
+@@ -13,7 +13,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Pro 4"),
+ 		},
+-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
++		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
++					QUIRK_DO_FLR_ON_BRIDGE),
+ 	},
+ 	{
+ 		.ident = "Surface Pro 5",
+@@ -22,7 +23,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "Surface_Pro_1796"),
+ 		},
+-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
++		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
++					QUIRK_DO_FLR_ON_BRIDGE),
+ 	},
+ 	{
+ 		.ident = "Surface Pro 5 (LTE)",
+@@ -31,7 +33,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "Surface_Pro_1807"),
+ 		},
+-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
++		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
++					QUIRK_DO_FLR_ON_BRIDGE),
+ 	},
+ 	{
+ 		.ident = "Surface Pro 6",
+@@ -39,7 +42,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Pro 6"),
+ 		},
+-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
++		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
++					QUIRK_DO_FLR_ON_BRIDGE),
+ 	},
+ 	{
+ 		.ident = "Surface Book 1",
+@@ -47,7 +51,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Book"),
+ 		},
+-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
++		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
++					QUIRK_DO_FLR_ON_BRIDGE),
+ 	},
+ 	{
+ 		.ident = "Surface Book 2",
+@@ -55,7 +60,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Book 2"),
+ 		},
+-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
++		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
++					QUIRK_DO_FLR_ON_BRIDGE),
+ 	},
+ 	{
+ 		.ident = "Surface Laptop 1",
+@@ -63,7 +69,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Laptop"),
+ 		},
+-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
++		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
++					QUIRK_DO_FLR_ON_BRIDGE),
+ 	},
+ 	{
+ 		.ident = "Surface Laptop 2",
+@@ -71,7 +78,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Laptop 2"),
+ 		},
+-		.driver_data = (void *)QUIRK_FW_RST_D3COLD,
++		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
++					QUIRK_DO_FLR_ON_BRIDGE),
+ 	},
+ 	{}
+ };
+@@ -89,6 +97,8 @@ void mwifiex_initialize_quirks(struct pcie_service_card *card)
+ 		dev_info(&pdev->dev, "no quirks enabled\n");
+ 	if (card->quirks & QUIRK_FW_RST_D3COLD)
+ 		dev_info(&pdev->dev, "quirk reset_d3cold enabled\n");
++	if (card->quirks & QUIRK_DO_FLR_ON_BRIDGE)
++		dev_info(&pdev->dev, "quirk do_flr_on_bridge enabled\n");
+ }
+ 
+ static void mwifiex_pcie_set_power_d3cold(struct pci_dev *pdev)
+diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
+index d6ff964ae..5d30ae39d 100644
+--- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
++++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
+@@ -4,6 +4,7 @@
+ #include "pcie.h"
+ 
+ #define QUIRK_FW_RST_D3COLD	BIT(0)
++#define QUIRK_DO_FLR_ON_BRIDGE	BIT(1)
+ 
+ void mwifiex_initialize_quirks(struct pcie_service_card *card);
+ int mwifiex_pcie_reset_d3cold_quirk(struct pci_dev *pdev);
+-- 
+2.53.0
+
+From f5454fb0678f6a0a451cf0da228c9b1b993437c2 Mon Sep 17 00:00:00 2001
+From: Tsuchiya Yuto <kitakar@gmail.com>
+Date: Sun, 4 Oct 2020 00:11:49 +0900
+Subject: [PATCH] mwifiex: pcie: disable bridge_d3 for Surface gen4+
+
+Currently, mwifiex fw will crash after suspend on recent kernel series.
+On Windows, it seems that the root port of wifi will never enter D3 state
+(stay on D0 state). And on Linux, disabling the D3 state for the
+bridge fixes fw crashing after suspend.
+
+This commit disables the D3 state of root port on driver initialization
+and fixes fw crashing after suspend.
+
+Signed-off-by: Tsuchiya Yuto <kitakar@gmail.com>
+Patchset: mwifiex
+---
+ drivers/net/wireless/marvell/mwifiex/pcie.c   |  7 +++++
+ .../wireless/marvell/mwifiex/pcie_quirks.c    | 27 +++++++++++++------
+ .../wireless/marvell/mwifiex/pcie_quirks.h    |  1 +
+ 3 files changed, 27 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/net/wireless/marvell/mwifiex/pcie.c b/drivers/net/wireless/marvell/mwifiex/pcie.c
+index db9b20322..ffd0c1fe9 100644
+--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
++++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
+@@ -377,6 +377,7 @@ static int mwifiex_pcie_probe(struct pci_dev *pdev,
+ 					const struct pci_device_id *ent)
+ {
+ 	struct pcie_service_card *card;
++	struct pci_dev *parent_pdev = pci_upstream_bridge(pdev);
+ 	int ret;
+ 
+ 	pr_debug("info: vendor=0x%4.04X device=0x%4.04X rev=%d\n",
+@@ -418,6 +419,12 @@ static int mwifiex_pcie_probe(struct pci_dev *pdev,
+ 		return -1;
+ 	}
+ 
++	/* disable bridge_d3 for Surface gen4+ devices to fix fw crashing
++	 * after suspend
++	 */
++	if (card->quirks & QUIRK_NO_BRIDGE_D3)
++		parent_pdev->bridge_d3 = false;
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
+index f46b06f8d..99b024ecb 100644
+--- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
++++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.c
+@@ -14,7 +14,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Pro 4"),
+ 		},
+ 		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+-					QUIRK_DO_FLR_ON_BRIDGE),
++					QUIRK_DO_FLR_ON_BRIDGE |
++					QUIRK_NO_BRIDGE_D3),
+ 	},
+ 	{
+ 		.ident = "Surface Pro 5",
+@@ -24,7 +25,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "Surface_Pro_1796"),
+ 		},
+ 		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+-					QUIRK_DO_FLR_ON_BRIDGE),
++					QUIRK_DO_FLR_ON_BRIDGE |
++					QUIRK_NO_BRIDGE_D3),
+ 	},
+ 	{
+ 		.ident = "Surface Pro 5 (LTE)",
+@@ -34,7 +36,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "Surface_Pro_1807"),
+ 		},
+ 		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+-					QUIRK_DO_FLR_ON_BRIDGE),
++					QUIRK_DO_FLR_ON_BRIDGE |
++					QUIRK_NO_BRIDGE_D3),
+ 	},
+ 	{
+ 		.ident = "Surface Pro 6",
+@@ -43,7 +46,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Pro 6"),
+ 		},
+ 		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+-					QUIRK_DO_FLR_ON_BRIDGE),
++					QUIRK_DO_FLR_ON_BRIDGE |
++					QUIRK_NO_BRIDGE_D3),
+ 	},
+ 	{
+ 		.ident = "Surface Book 1",
+@@ -52,7 +56,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Book"),
+ 		},
+ 		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+-					QUIRK_DO_FLR_ON_BRIDGE),
++					QUIRK_DO_FLR_ON_BRIDGE |
++					QUIRK_NO_BRIDGE_D3),
+ 	},
+ 	{
+ 		.ident = "Surface Book 2",
+@@ -61,7 +66,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Book 2"),
+ 		},
+ 		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+-					QUIRK_DO_FLR_ON_BRIDGE),
++					QUIRK_DO_FLR_ON_BRIDGE |
++					QUIRK_NO_BRIDGE_D3),
+ 	},
+ 	{
+ 		.ident = "Surface Laptop 1",
+@@ -70,7 +76,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Laptop"),
+ 		},
+ 		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+-					QUIRK_DO_FLR_ON_BRIDGE),
++					QUIRK_DO_FLR_ON_BRIDGE |
++					QUIRK_NO_BRIDGE_D3),
+ 	},
+ 	{
+ 		.ident = "Surface Laptop 2",
+@@ -79,7 +86,8 @@ static const struct dmi_system_id mwifiex_quirk_table[] = {
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Surface Laptop 2"),
+ 		},
+ 		.driver_data = (void *)(QUIRK_FW_RST_D3COLD |
+-					QUIRK_DO_FLR_ON_BRIDGE),
++					QUIRK_DO_FLR_ON_BRIDGE |
++					QUIRK_NO_BRIDGE_D3),
+ 	},
+ 	{}
+ };
+@@ -99,6 +107,9 @@ void mwifiex_initialize_quirks(struct pcie_service_card *card)
+ 		dev_info(&pdev->dev, "quirk reset_d3cold enabled\n");
+ 	if (card->quirks & QUIRK_DO_FLR_ON_BRIDGE)
+ 		dev_info(&pdev->dev, "quirk do_flr_on_bridge enabled\n");
++	if (card->quirks & QUIRK_NO_BRIDGE_D3)
++		dev_info(&pdev->dev,
++			 "quirk no_brigde_d3 enabled\n");
+ }
+ 
+ static void mwifiex_pcie_set_power_d3cold(struct pci_dev *pdev)
+diff --git a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
+index 5d30ae39d..c14eb56eb 100644
+--- a/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
++++ b/drivers/net/wireless/marvell/mwifiex/pcie_quirks.h
+@@ -5,6 +5,7 @@
+ 
+ #define QUIRK_FW_RST_D3COLD	BIT(0)
+ #define QUIRK_DO_FLR_ON_BRIDGE	BIT(1)
++#define QUIRK_NO_BRIDGE_D3	BIT(2)
+ 
+ void mwifiex_initialize_quirks(struct pcie_service_card *card);
+ int mwifiex_pcie_reset_d3cold_quirk(struct pci_dev *pdev);
+-- 
+2.53.0
+
+From 901b2af94faae241a5d8c1b91dd844a4cb6b3ac2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
+Date: Thu, 25 Mar 2021 11:33:02 +0100
+Subject: [PATCH] Bluetooth: btusb: Lower passive lescan interval on Marvell
+ 88W8897
+
+The Marvell 88W8897 combined wifi and bluetooth card (pcie+usb version)
+is used in a lot of Microsoft Surface devices, and all those devices
+suffer from very low 2.4GHz wifi connection speeds while bluetooth is
+enabled. The reason for that is that the default passive scanning
+interval for Bluetooth Low Energy devices is quite high in Linux
+(interval of 60 msec and scan window of 30 msec, see hci_core.c), and
+the Marvell chip is known for its bad bt+wifi coexisting performance.
+
+So decrease that passive scan interval and make the scan window shorter
+on this particular device to allow for spending more time transmitting
+wifi signals: The new scan interval is 250 msec (0x190 * 0.625 msec) and
+the new scan window is 6.25 msec (0xa * 0,625 msec).
+
+This change has a very large impact on the 2.4GHz wifi speeds and gets
+it up to performance comparable with the Windows driver, which seems to
+apply a similar quirk.
+
+The interval and window length were tested and found to work very well
+with a lot of Bluetooth Low Energy devices, including the Surface Pen, a
+Bluetooth Speaker and two modern Bluetooth headphones. All devices were
+discovered immediately after turning them on. Even lower values were
+also tested, but they introduced longer delays until devices get
+discovered.
+
+Patchset: mwifiex
+---
+ drivers/bluetooth/btusb.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
+index a41bb1e2a..572a9bcd2 100644
+--- a/drivers/bluetooth/btusb.c
++++ b/drivers/bluetooth/btusb.c
+@@ -67,6 +67,7 @@ static struct usb_driver btusb_driver;
+ #define BTUSB_INTEL_NO_WBS_SUPPORT	BIT(26)
+ #define BTUSB_ACTIONS_SEMI		BIT(27)
+ #define BTUSB_BARROT			BIT(28)
++#define BTUSB_LOWER_LESCAN_INTERVAL	BIT(29)
+ 
+ static const struct usb_device_id btusb_table[] = {
+ 	/* Generic Bluetooth USB device */
+@@ -472,6 +473,7 @@ static const struct usb_device_id quirks_table[] = {
+ 	{ USB_DEVICE(0x1286, 0x2044), .driver_info = BTUSB_MARVELL },
+ 	{ USB_DEVICE(0x1286, 0x2046), .driver_info = BTUSB_MARVELL },
+ 	{ USB_DEVICE(0x1286, 0x204e), .driver_info = BTUSB_MARVELL },
++	{ USB_DEVICE(0x1286, 0x204c), .driver_info = BTUSB_LOWER_LESCAN_INTERVAL },
+ 
+ 	/* Intel Bluetooth devices */
+ 	{ USB_DEVICE(0x8087, 0x0025), .driver_info = BTUSB_INTEL_COMBINED },
+@@ -4236,6 +4238,19 @@ static int btusb_probe(struct usb_interface *intf,
+ 	if (id->driver_info & BTUSB_MARVELL)
+ 		hdev->set_bdaddr = btusb_set_bdaddr_marvell;
+ 
++	/* The Marvell 88W8897 combined wifi and bluetooth card is known for
++	 * very bad bt+wifi coexisting performance.
++	 *
++	 * Decrease the passive BT Low Energy scan interval a bit
++	 * (0x0190 * 0.625 msec = 250 msec) and make the scan window shorter
++	 * (0x000a * 0,625 msec = 6.25 msec). This allows for significantly
++	 * higher wifi throughput while passively scanning for BT LE devices.
++	 */
++	if (id->driver_info & BTUSB_LOWER_LESCAN_INTERVAL) {
++		hdev->le_scan_interval = 0x0190;
++		hdev->le_scan_window = 0x000a;
++	}
++
+ 	if (IS_ENABLED(CONFIG_BT_HCIBTUSB_MTK) &&
+ 	    (id->driver_info & BTUSB_MEDIATEK)) {
+ 		hdev->setup = btusb_mtk_setup;
+-- 
+2.53.0
+

--- a/patches/7.0/0004-ath10k.patch
+++ b/patches/7.0/0004-ath10k.patch
@@ -1,0 +1,120 @@
+From cfd60c7e9860fe0ff2840433934be98f516c03f7 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Sat, 27 Feb 2021 00:45:52 +0100
+Subject: [PATCH] ath10k: Add module parameters to override board files
+
+Some Surface devices, specifically the Surface Go and AMD version of the
+Surface Laptop 3 (wich both come with QCA6174 WiFi chips), work better
+with a different board file, as it seems that the firmeware included
+upstream is buggy.
+
+As it is generally not a good idea to randomly overwrite files, let
+alone doing so via packages, we add module parameters to override those
+file names in the driver. This allows us to package/deploy the override
+via a modprobe.d config.
+
+Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>
+Patchset: ath10k
+---
+ drivers/net/wireless/ath/ath10k/core.c | 57 ++++++++++++++++++++++++++
+ 1 file changed, 57 insertions(+)
+
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index 7c2939cbd..eb402a3a8 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -41,6 +41,9 @@ static bool fw_diag_log;
+ /* frame mode values are mapped as per enum ath10k_hw_txrx_mode */
+ unsigned int ath10k_frame_mode = ATH10K_HW_TXRX_NATIVE_WIFI;
+ 
++static char *override_board = "";
++static char *override_board2 = "";
++
+ unsigned long ath10k_coredump_mask = BIT(ATH10K_FW_CRASH_DUMP_REGISTERS) |
+ 				     BIT(ATH10K_FW_CRASH_DUMP_CE_DATA);
+ 
+@@ -53,6 +56,9 @@ module_param(fw_diag_log, bool, 0644);
+ module_param_named(frame_mode, ath10k_frame_mode, uint, 0644);
+ module_param_named(coredump_mask, ath10k_coredump_mask, ulong, 0444);
+ 
++module_param(override_board, charp, 0644);
++module_param(override_board2, charp, 0644);
++
+ MODULE_PARM_DESC(debug_mask, "Debugging mask");
+ MODULE_PARM_DESC(uart_print, "Uart target debugging");
+ MODULE_PARM_DESC(skip_otp, "Skip otp failure for calibration in testmode");
+@@ -62,6 +68,9 @@ MODULE_PARM_DESC(frame_mode,
+ MODULE_PARM_DESC(coredump_mask, "Bitfield of what to include in firmware crash file");
+ MODULE_PARM_DESC(fw_diag_log, "Diag based fw log debugging");
+ 
++MODULE_PARM_DESC(override_board, "Override for board.bin file");
++MODULE_PARM_DESC(override_board2, "Override for board-2.bin file");
++
+ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA988X_HW_2_0_VERSION,
+@@ -932,6 +941,42 @@ static int ath10k_init_configure_target(struct ath10k *ar)
+ 	return 0;
+ }
+ 
++static const char *ath10k_override_board_fw_file(struct ath10k *ar,
++						 const char *file)
++{
++	if (strcmp(file, "board.bin") == 0) {
++		if (strcmp(override_board, "") == 0)
++			return file;
++
++		if (strcmp(override_board, "none") == 0) {
++			dev_info(ar->dev, "firmware override: pretending 'board.bin' does not exist\n");
++			return NULL;
++		}
++
++		dev_info(ar->dev, "firmware override: replacing 'board.bin' with '%s'\n",
++			 override_board);
++
++		return override_board;
++	}
++
++	if (strcmp(file, "board-2.bin") == 0) {
++		if (strcmp(override_board2, "") == 0)
++			return file;
++
++		if (strcmp(override_board2, "none") == 0) {
++			dev_info(ar->dev, "firmware override: pretending 'board-2.bin' does not exist\n");
++			return NULL;
++		}
++
++		dev_info(ar->dev, "firmware override: replacing 'board-2.bin' with '%s'\n",
++			 override_board2);
++
++		return override_board2;
++	}
++
++	return file;
++}
++
+ static const struct firmware *ath10k_fetch_fw_file(struct ath10k *ar,
+ 						   const char *dir,
+ 						   const char *file)
+@@ -946,6 +991,18 @@ static const struct firmware *ath10k_fetch_fw_file(struct ath10k *ar,
+ 	if (dir == NULL)
+ 		dir = ".";
+ 
++	/* HACK: Override board.bin and board-2.bin files if specified.
++	 *
++	 * Some Surface devices perform better with a different board
++	 * configuration. To this end, one would need to replace the board.bin
++	 * file with the modified config and remove the board-2.bin file.
++	 * Unfortunately, that's not a solution that we can easily package. So
++	 * we add module options to perform these overrides here.
++	 */
++	file = ath10k_override_board_fw_file(ar, file);
++	if (!file)
++		return ERR_PTR(-ENOENT);
++
+ 	if (ar->board_name) {
+ 		snprintf(filename, sizeof(filename), "%s/%s/%s",
+ 			 dir, ar->board_name, file);
+-- 
+2.53.0
+

--- a/patches/7.0/0005-ipts.patch
+++ b/patches/7.0/0005-ipts.patch
@@ -1,0 +1,3243 @@
+From 28e9cf5ef53f9f3e8da04a85d4928a594ffaf502 Mon Sep 17 00:00:00 2001
+From: Dorian Stoll <dorian.stoll@tmsp.io>
+Date: Thu, 30 Jul 2020 13:21:53 +0200
+Subject: [PATCH] mei: me: Add Icelake device ID for iTouch
+
+Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
+Patchset: ipts
+---
+ drivers/misc/mei/hw-me-regs.h | 1 +
+ drivers/misc/mei/pci-me.c     | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/drivers/misc/mei/hw-me-regs.h b/drivers/misc/mei/hw-me-regs.h
+index fa30899a5..a1864dcb7 100644
+--- a/drivers/misc/mei/hw-me-regs.h
++++ b/drivers/misc/mei/hw-me-regs.h
+@@ -92,6 +92,7 @@
+ #define MEI_DEV_ID_CDF        0x18D3  /* Cedar Fork */
+ 
+ #define MEI_DEV_ID_ICP_LP     0x34E0  /* Ice Lake Point LP */
++#define MEI_DEV_ID_ICP_LP_3   0x34E4  /* Ice Lake Point LP 3 (iTouch) */
+ #define MEI_DEV_ID_ICP_N      0x38E0  /* Ice Lake Point N */
+ 
+ #define MEI_DEV_ID_JSP_N      0x4DE0  /* Jasper Lake Point N */
+diff --git a/drivers/misc/mei/pci-me.c b/drivers/misc/mei/pci-me.c
+index 2a6e56955..c19dfba54 100644
+--- a/drivers/misc/mei/pci-me.c
++++ b/drivers/misc/mei/pci-me.c
+@@ -97,6 +97,7 @@ static const struct pci_device_id mei_me_pci_tbl[] = {
+ 	{MEI_PCI_DEVICE(MEI_DEV_ID_CMP_H_3, MEI_ME_PCH8_ITOUCH_CFG)},
+ 
+ 	{MEI_PCI_DEVICE(MEI_DEV_ID_ICP_LP, MEI_ME_PCH12_CFG)},
++	{MEI_PCI_DEVICE(MEI_DEV_ID_ICP_LP_3, MEI_ME_PCH12_CFG)},
+ 	{MEI_PCI_DEVICE(MEI_DEV_ID_ICP_N, MEI_ME_PCH12_CFG)},
+ 
+ 	{MEI_PCI_DEVICE(MEI_DEV_ID_TGP_LP, MEI_ME_PCH15_CFG)},
+-- 
+2.53.0
+
+From 72740aa77740092fa7f448ac1dd7f2a92af2261a Mon Sep 17 00:00:00 2001
+From: Liban Hannan <liban.p@gmail.com>
+Date: Tue, 12 Apr 2022 23:31:12 +0100
+Subject: [PATCH] iommu: Use IOMMU passthrough mode for IPTS
+
+Adds a quirk so that IOMMU uses passthrough mode for the IPTS device.
+Otherwise, when IOMMU is enabled, IPTS produces DMAR errors like:
+
+DMAR: [DMA Read NO_PASID] Request device [00:16.4] fault addr
+0x104ea3000 [fault reason 0x06] PTE Read access is not set
+
+This is very similar to the bug described at:
+https://bugs.launchpad.net/bugs/1958004
+
+Fixed with the following patch which this patch basically copies:
+https://launchpadlibrarian.net/586396847/43255ca.diff
+
+Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
+Patchset: ipts
+---
+ drivers/iommu/intel/iommu.c | 29 +++++++++++++++++++++++++++++
+ 1 file changed, 29 insertions(+)
+
+diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
+index 705828b06..1400bf283 100644
+--- a/drivers/iommu/intel/iommu.c
++++ b/drivers/iommu/intel/iommu.c
+@@ -39,6 +39,11 @@
+ #define IS_ISA_DEVICE(pdev) ((pdev->class >> 8) == PCI_CLASS_BRIDGE_ISA)
+ #define IS_AZALIA(pdev) ((pdev)->vendor == 0x8086 && (pdev)->device == 0x3a3e)
+ 
++#define IS_IPTS(pdev) ( \
++		((pdev)->vendor == PCI_VENDOR_ID_INTEL && (pdev)->device == 0x9D3E) || \
++		((pdev)->vendor == PCI_VENDOR_ID_INTEL && (pdev)->device == 0x34E4) \
++	)
++
+ #define IOAPIC_RANGE_START	(0xfee00000)
+ #define IOAPIC_RANGE_END	(0xfeefffff)
+ #define IOVA_START_ADDR		(0x1000)
+@@ -202,12 +207,14 @@ int intel_iommu_sm = IS_ENABLED(CONFIG_INTEL_IOMMU_SCALABLE_MODE_DEFAULT_ON);
+ int intel_iommu_enabled = 0;
+ EXPORT_SYMBOL_GPL(intel_iommu_enabled);
+ 
++static int dmar_map_ipts = 1;
+ static int intel_iommu_superpage = 1;
+ static int iommu_identity_mapping;
+ static int iommu_skip_te_disable;
+ static int disable_igfx_iommu;
+ 
+ #define IDENTMAP_AZALIA		4
++#define IDENTMAP_IPTS		16
+ 
+ const struct iommu_ops intel_iommu_ops;
+ 
+@@ -1398,6 +1405,9 @@ static int device_def_domain_type(struct device *dev)
+ 
+ 		if ((iommu_identity_mapping & IDENTMAP_AZALIA) && IS_AZALIA(pdev))
+ 			return IOMMU_DOMAIN_IDENTITY;
++
++		if ((iommu_identity_mapping & IDENTMAP_IPTS) && IS_IPTS(pdev))
++			return IOMMU_DOMAIN_IDENTITY;
+ 	}
+ 
+ 	return 0;
+@@ -1688,6 +1698,9 @@ static int __init init_dmars(void)
+ 		iommu_set_root_entry(iommu);
+ 	}
+ 
++	if (!dmar_map_ipts)
++		iommu_identity_mapping |= IDENTMAP_IPTS;
++
+ 	check_tylersburg_isoch();
+ 
+ 	/*
+@@ -3933,6 +3946,18 @@ static void quirk_iommu_igfx(struct pci_dev *dev)
+ 	disable_igfx_iommu = 1;
+ }
+ 
++static void quirk_iommu_ipts(struct pci_dev *dev)
++{
++	if (!IS_IPTS(dev))
++		return;
++
++	if (risky_device(dev))
++		return;
++
++	pci_info(dev, "Disabling IOMMU for IPTS\n");
++	dmar_map_ipts = 0;
++}
++
+ /* G4x/GM45 integrated gfx dmar support is totally busted. */
+ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x2a40, quirk_iommu_igfx);
+ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x2e00, quirk_iommu_igfx);
+@@ -3971,6 +3996,10 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x1632, quirk_iommu_igfx);
+ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x163A, quirk_iommu_igfx);
+ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x163D, quirk_iommu_igfx);
+ 
++/* disable IPTS dmar support */
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x9D3E, quirk_iommu_ipts);
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x34E4, quirk_iommu_ipts);
++
+ static void quirk_iommu_rwbf(struct pci_dev *dev)
+ {
+ 	if (risky_device(dev))
+-- 
+2.53.0
+
+From aa91547471bf61ae51e3b59a8d122d37c6ce8a93 Mon Sep 17 00:00:00 2001
+From: Dorian Stoll <dorian.stoll@tmsp.io>
+Date: Sun, 11 Dec 2022 12:00:59 +0100
+Subject: [PATCH] hid: Add support for Intel Precise Touch and Stylus
+
+Based on linux-surface/intel-precise-touch@8abe268
+
+Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
+Patchset: ipts
+---
+ drivers/hid/Kconfig            |   2 +
+ drivers/hid/Makefile           |   2 +
+ drivers/hid/ipts/Kconfig       |  14 +
+ drivers/hid/ipts/Makefile      |  16 ++
+ drivers/hid/ipts/cmd.c         |  61 +++++
+ drivers/hid/ipts/cmd.h         |  60 ++++
+ drivers/hid/ipts/context.h     |  52 ++++
+ drivers/hid/ipts/control.c     | 486 +++++++++++++++++++++++++++++++++
+ drivers/hid/ipts/control.h     | 126 +++++++++
+ drivers/hid/ipts/desc.h        |  80 ++++++
+ drivers/hid/ipts/eds1.c        | 104 +++++++
+ drivers/hid/ipts/eds1.h        |  35 +++
+ drivers/hid/ipts/eds2.c        | 145 ++++++++++
+ drivers/hid/ipts/eds2.h        |  35 +++
+ drivers/hid/ipts/hid.c         | 225 +++++++++++++++
+ drivers/hid/ipts/hid.h         |  24 ++
+ drivers/hid/ipts/main.c        | 126 +++++++++
+ drivers/hid/ipts/mei.c         | 188 +++++++++++++
+ drivers/hid/ipts/mei.h         |  66 +++++
+ drivers/hid/ipts/receiver.c    | 251 +++++++++++++++++
+ drivers/hid/ipts/receiver.h    |  16 ++
+ drivers/hid/ipts/resources.c   | 131 +++++++++
+ drivers/hid/ipts/resources.h   |  41 +++
+ drivers/hid/ipts/spec-data.h   | 100 +++++++
+ drivers/hid/ipts/spec-device.h | 290 ++++++++++++++++++++
+ drivers/hid/ipts/spec-hid.h    |  34 +++
+ drivers/hid/ipts/thread.c      |  84 ++++++
+ drivers/hid/ipts/thread.h      |  59 ++++
+ 28 files changed, 2853 insertions(+)
+ create mode 100644 drivers/hid/ipts/Kconfig
+ create mode 100644 drivers/hid/ipts/Makefile
+ create mode 100644 drivers/hid/ipts/cmd.c
+ create mode 100644 drivers/hid/ipts/cmd.h
+ create mode 100644 drivers/hid/ipts/context.h
+ create mode 100644 drivers/hid/ipts/control.c
+ create mode 100644 drivers/hid/ipts/control.h
+ create mode 100644 drivers/hid/ipts/desc.h
+ create mode 100644 drivers/hid/ipts/eds1.c
+ create mode 100644 drivers/hid/ipts/eds1.h
+ create mode 100644 drivers/hid/ipts/eds2.c
+ create mode 100644 drivers/hid/ipts/eds2.h
+ create mode 100644 drivers/hid/ipts/hid.c
+ create mode 100644 drivers/hid/ipts/hid.h
+ create mode 100644 drivers/hid/ipts/main.c
+ create mode 100644 drivers/hid/ipts/mei.c
+ create mode 100644 drivers/hid/ipts/mei.h
+ create mode 100644 drivers/hid/ipts/receiver.c
+ create mode 100644 drivers/hid/ipts/receiver.h
+ create mode 100644 drivers/hid/ipts/resources.c
+ create mode 100644 drivers/hid/ipts/resources.h
+ create mode 100644 drivers/hid/ipts/spec-data.h
+ create mode 100644 drivers/hid/ipts/spec-device.h
+ create mode 100644 drivers/hid/ipts/spec-hid.h
+ create mode 100644 drivers/hid/ipts/thread.c
+ create mode 100644 drivers/hid/ipts/thread.h
+
+diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
+index 6ff4a3ad3..5d41410ac 100644
+--- a/drivers/hid/Kconfig
++++ b/drivers/hid/Kconfig
+@@ -1443,6 +1443,8 @@ source "drivers/hid/surface-hid/Kconfig"
+ 
+ source "drivers/hid/intel-thc-hid/Kconfig"
+ 
++source "drivers/hid/ipts/Kconfig"
++
+ endif # HID
+ 
+ # USB support may be used with HID disabled
+diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
+index 361a7daed..b73a1bbd3 100644
+--- a/drivers/hid/Makefile
++++ b/drivers/hid/Makefile
+@@ -176,3 +176,5 @@ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
+ obj-$(CONFIG_SURFACE_HID_CORE)  += surface-hid/
+ 
+ obj-$(CONFIG_INTEL_THC_HID)     += intel-thc-hid/
++
++obj-$(CONFIG_HID_IPTS)          += ipts/
+diff --git a/drivers/hid/ipts/Kconfig b/drivers/hid/ipts/Kconfig
+new file mode 100644
+index 000000000..297401bd3
+--- /dev/null
++++ b/drivers/hid/ipts/Kconfig
+@@ -0,0 +1,14 @@
++# SPDX-License-Identifier: GPL-2.0-or-later
++
++config HID_IPTS
++	tristate "Intel Precise Touch & Stylus"
++	depends on INTEL_MEI
++	depends on HID
++	help
++	  Say Y here if your system has a touchscreen using Intels
++	  Precise Touch & Stylus (IPTS) technology.
++
++	  If unsure say N.
++
++	  To compile this driver as a module, choose M here: the
++	  module will be called ipts.
+diff --git a/drivers/hid/ipts/Makefile b/drivers/hid/ipts/Makefile
+new file mode 100644
+index 000000000..883896f68
+--- /dev/null
++++ b/drivers/hid/ipts/Makefile
+@@ -0,0 +1,16 @@
++# SPDX-License-Identifier: GPL-2.0-or-later
++#
++# Makefile for the IPTS touchscreen driver
++#
++
++obj-$(CONFIG_HID_IPTS) += ipts.o
++ipts-objs := cmd.o
++ipts-objs += control.o
++ipts-objs += eds1.o
++ipts-objs += eds2.o
++ipts-objs += hid.o
++ipts-objs += main.o
++ipts-objs += mei.o
++ipts-objs += receiver.o
++ipts-objs += resources.o
++ipts-objs += thread.o
+diff --git a/drivers/hid/ipts/cmd.c b/drivers/hid/ipts/cmd.c
+new file mode 100644
+index 000000000..63a4934bb
+--- /dev/null
++++ b/drivers/hid/ipts/cmd.c
+@@ -0,0 +1,61 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (c) 2020-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#include <linux/errno.h>
++#include <linux/types.h>
++
++#include "cmd.h"
++#include "context.h"
++#include "mei.h"
++#include "spec-device.h"
++
++int ipts_cmd_recv_timeout(struct ipts_context *ipts, enum ipts_command_code code,
++			  struct ipts_response *rsp, u64 timeout)
++{
++	int ret = 0;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!rsp)
++		return -EFAULT;
++
++	/*
++	 * In a response, the command code will have the most significant bit flipped to 1.
++	 * If code is passed to ipts_mei_recv as is, no messages will be received.
++	 */
++	ret = ipts_mei_recv(&ipts->mei, code | IPTS_RSP_BIT, rsp, timeout);
++	if (ret < 0)
++		return ret;
++
++	dev_dbg(ipts->dev, "Received 0x%02X with status 0x%02X\n", code, rsp->status);
++
++	/*
++	 * Some devices will always return this error.
++	 * It is allowed to ignore it and to try continuing.
++	 */
++	if (rsp->status == IPTS_STATUS_COMPAT_CHECK_FAIL)
++		rsp->status = IPTS_STATUS_SUCCESS;
++
++	return 0;
++}
++
++int ipts_cmd_send(struct ipts_context *ipts, enum ipts_command_code code, void *data, size_t size)
++{
++	struct ipts_command cmd = { 0 };
++
++	if (!ipts)
++		return -EFAULT;
++
++	cmd.cmd = code;
++
++	if (data && size > 0)
++		memcpy(cmd.payload, data, size);
++
++	dev_dbg(ipts->dev, "Sending 0x%02X with %ld bytes payload\n", code, size);
++	return ipts_mei_send(&ipts->mei, &cmd, sizeof(cmd.cmd) + size);
++}
+diff --git a/drivers/hid/ipts/cmd.h b/drivers/hid/ipts/cmd.h
+new file mode 100644
+index 000000000..2b4079075
+--- /dev/null
++++ b/drivers/hid/ipts/cmd.h
+@@ -0,0 +1,60 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (c) 2020-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#ifndef IPTS_CMD_H
++#define IPTS_CMD_H
++
++#include <linux/types.h>
++
++#include "context.h"
++#include "spec-device.h"
++
++/*
++ * The default timeout for receiving responses
++ */
++#define IPTS_CMD_DEFAULT_TIMEOUT 1000
++
++/**
++ * ipts_cmd_recv_timeout() - Receives a response to a command.
++ * @ipts: The IPTS driver context.
++ * @code: The type of the command / response.
++ * @rsp: The address that the received response will be copied to.
++ * @timeout: How many milliseconds the function will wait at most.
++ *
++ * A negative timeout means to wait forever.
++ *
++ * Returns: 0 on success, <0 on error, -EAGAIN if no response has been received.
++ */
++int ipts_cmd_recv_timeout(struct ipts_context *ipts, enum ipts_command_code code,
++			  struct ipts_response *rsp, u64 timeout);
++
++/**
++ * ipts_cmd_recv() - Receives a response to a command.
++ * @ipts: The IPTS driver context.
++ * @code: The type of the command / response.
++ * @rsp: The address that the received response will be copied to.
++ *
++ * Returns: 0 on success, <0 on error, -EAGAIN if no response has been received.
++ */
++static inline int ipts_cmd_recv(struct ipts_context *ipts, enum ipts_command_code code,
++				struct ipts_response *rsp)
++{
++	return ipts_cmd_recv_timeout(ipts, code, rsp, IPTS_CMD_DEFAULT_TIMEOUT);
++}
++
++/**
++ * ipts_cmd_send() - Executes a command on the device.
++ * @ipts: The IPTS driver context.
++ * @code: The type of the command to execute.
++ * @data: The payload containing parameters for the command.
++ * @size: The size of the payload.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_cmd_send(struct ipts_context *ipts, enum ipts_command_code code, void *data, size_t size);
++
++#endif /* IPTS_CMD_H */
+diff --git a/drivers/hid/ipts/context.h b/drivers/hid/ipts/context.h
+new file mode 100644
+index 000000000..ba33259f1
+--- /dev/null
++++ b/drivers/hid/ipts/context.h
+@@ -0,0 +1,52 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (c) 2020-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#ifndef IPTS_CONTEXT_H
++#define IPTS_CONTEXT_H
++
++#include <linux/completion.h>
++#include <linux/device.h>
++#include <linux/hid.h>
++#include <linux/mei_cl_bus.h>
++#include <linux/mutex.h>
++#include <linux/sched.h>
++#include <linux/types.h>
++
++#include "mei.h"
++#include "resources.h"
++#include "spec-device.h"
++#include "thread.h"
++
++struct ipts_context {
++	struct device *dev;
++	struct ipts_mei mei;
++
++	enum ipts_mode mode;
++
++	/*
++	 * Prevents concurrent GET_FEATURE reports.
++	 */
++	struct mutex feature_lock;
++	struct completion feature_event;
++
++	/*
++	 * These are not inside of struct ipts_resources
++	 * because they don't own the memory they point to.
++	 */
++	struct ipts_buffer feature_report;
++	struct ipts_buffer descriptor;
++
++	bool hid_active;
++	struct hid_device *hid;
++
++	struct ipts_device_info info;
++	struct ipts_resources resources;
++
++	struct ipts_thread receiver_loop;
++};
++
++#endif /* IPTS_CONTEXT_H */
+diff --git a/drivers/hid/ipts/control.c b/drivers/hid/ipts/control.c
+new file mode 100644
+index 000000000..5360842d2
+--- /dev/null
++++ b/drivers/hid/ipts/control.c
+@@ -0,0 +1,486 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (c) 2020-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#include <linux/delay.h>
++#include <linux/dev_printk.h>
++#include <linux/errno.h>
++#include <linux/kernel.h>
++#include <linux/kthread.h>
++#include <linux/types.h>
++
++#include "cmd.h"
++#include "context.h"
++#include "control.h"
++#include "desc.h"
++#include "hid.h"
++#include "receiver.h"
++#include "resources.h"
++#include "spec-data.h"
++#include "spec-device.h"
++
++static int ipts_control_get_device_info(struct ipts_context *ipts, struct ipts_device_info *info)
++{
++	int ret = 0;
++	struct ipts_response rsp = { 0 };
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!info)
++		return -EFAULT;
++
++	ret = ipts_cmd_send(ipts, IPTS_CMD_GET_DEVICE_INFO, NULL, 0);
++	if (ret) {
++		dev_err(ipts->dev, "GET_DEVICE_INFO: send failed: %d\n", ret);
++		return ret;
++	}
++
++	ret = ipts_cmd_recv(ipts, IPTS_CMD_GET_DEVICE_INFO, &rsp);
++	if (ret) {
++		dev_err(ipts->dev, "GET_DEVICE_INFO: recv failed: %d\n", ret);
++		return ret;
++	}
++
++	if (rsp.status != IPTS_STATUS_SUCCESS) {
++		dev_err(ipts->dev, "GET_DEVICE_INFO: cmd failed: %d\n", rsp.status);
++		return -EBADR;
++	}
++
++	memcpy(info, rsp.payload, sizeof(*info));
++	return 0;
++}
++
++static int ipts_control_set_mode(struct ipts_context *ipts, enum ipts_mode mode)
++{
++	int ret = 0;
++	struct ipts_set_mode cmd = { 0 };
++	struct ipts_response rsp = { 0 };
++
++	if (!ipts)
++		return -EFAULT;
++
++	cmd.mode = mode;
++
++	ret = ipts_cmd_send(ipts, IPTS_CMD_SET_MODE, &cmd, sizeof(cmd));
++	if (ret) {
++		dev_err(ipts->dev, "SET_MODE: send failed: %d\n", ret);
++		return ret;
++	}
++
++	ret = ipts_cmd_recv(ipts, IPTS_CMD_SET_MODE, &rsp);
++	if (ret) {
++		dev_err(ipts->dev, "SET_MODE: recv failed: %d\n", ret);
++		return ret;
++	}
++
++	if (rsp.status != IPTS_STATUS_SUCCESS) {
++		dev_err(ipts->dev, "SET_MODE: cmd failed: %d\n", rsp.status);
++		return -EBADR;
++	}
++
++	return 0;
++}
++
++static int ipts_control_set_mem_window(struct ipts_context *ipts, struct ipts_resources *res)
++{
++	int i = 0;
++	int ret = 0;
++	struct ipts_mem_window cmd = { 0 };
++	struct ipts_response rsp = { 0 };
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!res)
++		return -EFAULT;
++
++	for (i = 0; i < IPTS_BUFFERS; i++) {
++		cmd.data_addr_lower[i] = lower_32_bits(res->data[i].dma_address);
++		cmd.data_addr_upper[i] = upper_32_bits(res->data[i].dma_address);
++		cmd.feedback_addr_lower[i] = lower_32_bits(res->feedback[i].dma_address);
++		cmd.feedback_addr_upper[i] = upper_32_bits(res->feedback[i].dma_address);
++	}
++
++	cmd.workqueue_addr_lower = lower_32_bits(res->workqueue.dma_address);
++	cmd.workqueue_addr_upper = upper_32_bits(res->workqueue.dma_address);
++
++	cmd.doorbell_addr_lower = lower_32_bits(res->doorbell.dma_address);
++	cmd.doorbell_addr_upper = upper_32_bits(res->doorbell.dma_address);
++
++	cmd.hid2me_addr_lower = lower_32_bits(res->hid2me.dma_address);
++	cmd.hid2me_addr_upper = upper_32_bits(res->hid2me.dma_address);
++
++	cmd.workqueue_size = IPTS_WORKQUEUE_SIZE;
++	cmd.workqueue_item_size = IPTS_WORKQUEUE_ITEM_SIZE;
++
++	ret = ipts_cmd_send(ipts, IPTS_CMD_SET_MEM_WINDOW, &cmd, sizeof(cmd));
++	if (ret) {
++		dev_err(ipts->dev, "SET_MEM_WINDOW: send failed: %d\n", ret);
++		return ret;
++	}
++
++	ret = ipts_cmd_recv(ipts, IPTS_CMD_SET_MEM_WINDOW, &rsp);
++	if (ret) {
++		dev_err(ipts->dev, "SET_MEM_WINDOW: recv failed: %d\n", ret);
++		return ret;
++	}
++
++	if (rsp.status != IPTS_STATUS_SUCCESS) {
++		dev_err(ipts->dev, "SET_MEM_WINDOW: cmd failed: %d\n", rsp.status);
++		return -EBADR;
++	}
++
++	return 0;
++}
++
++static int ipts_control_get_descriptor(struct ipts_context *ipts)
++{
++	int ret = 0;
++	struct ipts_data_header *header = NULL;
++	struct ipts_get_descriptor cmd = { 0 };
++	struct ipts_response rsp = { 0 };
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!ipts->resources.descriptor.address)
++		return -EFAULT;
++
++	memset(ipts->resources.descriptor.address, 0, ipts->resources.descriptor.size);
++
++	cmd.addr_lower = lower_32_bits(ipts->resources.descriptor.dma_address);
++	cmd.addr_upper = upper_32_bits(ipts->resources.descriptor.dma_address);
++	cmd.magic = 8;
++
++	ret = ipts_cmd_send(ipts, IPTS_CMD_GET_DESCRIPTOR, &cmd, sizeof(cmd));
++	if (ret) {
++		dev_err(ipts->dev, "GET_DESCRIPTOR: send failed: %d\n", ret);
++		return ret;
++	}
++
++	ret = ipts_cmd_recv(ipts, IPTS_CMD_GET_DESCRIPTOR, &rsp);
++	if (ret) {
++		dev_err(ipts->dev, "GET_DESCRIPTOR: recv failed: %d\n", ret);
++		return ret;
++	}
++
++	if (rsp.status != IPTS_STATUS_SUCCESS) {
++		dev_err(ipts->dev, "GET_DESCRIPTOR: cmd failed: %d\n", rsp.status);
++		return -EBADR;
++	}
++
++	header = (struct ipts_data_header *)ipts->resources.descriptor.address;
++
++	if (header->type == IPTS_DATA_TYPE_DESCRIPTOR) {
++		ipts->descriptor.address = &header->data[8];
++		ipts->descriptor.size = header->size - 8;
++
++		return 0;
++	}
++
++	return -ENODATA;
++}
++
++int ipts_control_request_flush(struct ipts_context *ipts)
++{
++	int ret = 0;
++	struct ipts_quiesce_io cmd = { 0 };
++
++	if (!ipts)
++		return -EFAULT;
++
++	ret = ipts_cmd_send(ipts, IPTS_CMD_QUIESCE_IO, &cmd, sizeof(cmd));
++	if (ret)
++		dev_err(ipts->dev, "QUIESCE_IO: send failed: %d\n", ret);
++
++	return ret;
++}
++
++int ipts_control_wait_flush(struct ipts_context *ipts)
++{
++	int ret = 0;
++	struct ipts_response rsp = { 0 };
++
++	if (!ipts)
++		return -EFAULT;
++
++	ret = ipts_cmd_recv(ipts, IPTS_CMD_QUIESCE_IO, &rsp);
++	if (ret) {
++		dev_err(ipts->dev, "QUIESCE_IO: recv failed: %d\n", ret);
++		return ret;
++	}
++
++	if (rsp.status == IPTS_STATUS_TIMEOUT)
++		return -EAGAIN;
++
++	if (rsp.status != IPTS_STATUS_SUCCESS) {
++		dev_err(ipts->dev, "QUIESCE_IO: cmd failed: %d\n", rsp.status);
++		return -EBADR;
++	}
++
++	return 0;
++}
++
++int ipts_control_request_data(struct ipts_context *ipts)
++{
++	int ret = 0;
++
++	if (!ipts)
++		return -EFAULT;
++
++	ret = ipts_cmd_send(ipts, IPTS_CMD_READY_FOR_DATA, NULL, 0);
++	if (ret)
++		dev_err(ipts->dev, "READY_FOR_DATA: send failed: %d\n", ret);
++
++	return ret;
++}
++
++int ipts_control_wait_data(struct ipts_context *ipts, bool shutdown)
++{
++	int ret = 0;
++	struct ipts_response rsp = { 0 };
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!shutdown)
++		ret = ipts_cmd_recv_timeout(ipts, IPTS_CMD_READY_FOR_DATA, &rsp, 0);
++	else
++		ret = ipts_cmd_recv(ipts, IPTS_CMD_READY_FOR_DATA, &rsp);
++
++	if (ret) {
++		if (ret != -EAGAIN)
++			dev_err(ipts->dev, "READY_FOR_DATA: recv failed: %d\n", ret);
++
++		return ret;
++	}
++
++	/*
++	 * During shutdown, it is possible that the sensor has already been disabled.
++	 */
++	if (rsp.status == IPTS_STATUS_SENSOR_DISABLED)
++		return 0;
++
++	if (rsp.status == IPTS_STATUS_TIMEOUT)
++		return -EAGAIN;
++
++	if (rsp.status != IPTS_STATUS_SUCCESS) {
++		dev_err(ipts->dev, "READY_FOR_DATA: cmd failed: %d\n", rsp.status);
++		return -EBADR;
++	}
++
++	return 0;
++}
++
++int ipts_control_send_feedback(struct ipts_context *ipts, u32 buffer)
++{
++	int ret = 0;
++	struct ipts_feedback cmd = { 0 };
++	struct ipts_response rsp = { 0 };
++
++	if (!ipts)
++		return -EFAULT;
++
++	cmd.buffer = buffer;
++
++	ret = ipts_cmd_send(ipts, IPTS_CMD_FEEDBACK, &cmd, sizeof(cmd));
++	if (ret) {
++		dev_err(ipts->dev, "FEEDBACK: send failed: %d\n", ret);
++		return ret;
++	}
++
++	ret = ipts_cmd_recv(ipts, IPTS_CMD_FEEDBACK, &rsp);
++	if (ret) {
++		dev_err(ipts->dev, "FEEDBACK: recv failed: %d\n", ret);
++		return ret;
++	}
++
++	/*
++	 * We don't know what feedback data looks like so we are sending zeros.
++	 * See also ipts_control_refill_buffer.
++	 */
++	if (rsp.status == IPTS_STATUS_INVALID_PARAMS)
++		return 0;
++
++	if (rsp.status != IPTS_STATUS_SUCCESS) {
++		dev_err(ipts->dev, "FEEDBACK: cmd failed: %d\n", rsp.status);
++		return -EBADR;
++	}
++
++	return 0;
++}
++
++int ipts_control_hid2me_feedback(struct ipts_context *ipts, enum ipts_feedback_cmd_type cmd,
++				 enum ipts_feedback_data_type type, void *data, size_t size)
++{
++	struct ipts_feedback_header *header = NULL;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!ipts->resources.hid2me.address)
++		return -EFAULT;
++
++	memset(ipts->resources.hid2me.address, 0, ipts->resources.hid2me.size);
++	header = (struct ipts_feedback_header *)ipts->resources.hid2me.address;
++
++	header->cmd_type = cmd;
++	header->data_type = type;
++	header->size = size;
++	header->buffer = IPTS_HID2ME_BUFFER;
++
++	if (size + sizeof(*header) > ipts->resources.hid2me.size)
++		return -EINVAL;
++
++	if (data && size > 0)
++		memcpy(header->payload, data, size);
++
++	return ipts_control_send_feedback(ipts, IPTS_HID2ME_BUFFER);
++}
++
++int ipts_control_start(struct ipts_context *ipts)
++{
++	int ret = 0;
++	struct ipts_device_info info = { 0 };
++
++	if (!ipts)
++		return -EFAULT;
++
++	dev_info(ipts->dev, "Starting IPTS\n");
++
++	ret = ipts_control_get_device_info(ipts, &info);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to get device info: %d\n", ret);
++		return ret;
++	}
++
++	ipts->info = info;
++
++	ret = ipts_resources_init(&ipts->resources, ipts->dev, info.data_size, info.feedback_size);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to allocate buffers: %d", ret);
++		return ret;
++	}
++
++	dev_info(ipts->dev, "IPTS EDS Version: %d\n", info.intf_eds);
++
++	/*
++	 * Handle newer devices
++	 */
++	if (info.intf_eds > 1) {
++		/*
++		 * Fetching the descriptor will only work on newer devices.
++		 * For older devices, a fallback descriptor will be used.
++		 */
++		ret = ipts_control_get_descriptor(ipts);
++		if (ret) {
++			dev_err(ipts->dev, "Failed to fetch HID descriptor: %d\n", ret);
++			return ret;
++		}
++
++		/*
++		 * Newer devices can be directly initialized in polling mode.
++		 */
++		ipts->mode = IPTS_MODE_POLL;
++	}
++
++	ret = ipts_control_set_mode(ipts, ipts->mode);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to set mode: %d\n", ret);
++		return ret;
++	}
++
++	ret = ipts_control_set_mem_window(ipts, &ipts->resources);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to set memory window: %d\n", ret);
++		return ret;
++	}
++
++	ret = ipts_receiver_start(ipts);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to start receiver: %d\n", ret);
++		return ret;
++	}
++
++	ret = ipts_control_request_data(ipts);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to request data: %d\n", ret);
++		return ret;
++	}
++
++	ipts_hid_enable(ipts);
++
++	ret = ipts_hid_init(ipts, info);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to initialize HID device: %d\n", ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static int _ipts_control_stop(struct ipts_context *ipts)
++{
++	int ret = 0;
++
++	if (!ipts)
++		return -EFAULT;
++
++	ipts_hid_disable(ipts);
++	dev_info(ipts->dev, "Stopping IPTS\n");
++
++	ret = ipts_receiver_stop(ipts);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to stop receiver: %d\n", ret);
++		return ret;
++	}
++
++	ret = ipts_resources_free(&ipts->resources);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to free resources: %d\n", ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++int ipts_control_stop(struct ipts_context *ipts)
++{
++	int ret = 0;
++
++	ret = _ipts_control_stop(ipts);
++	if (ret)
++		return ret;
++
++	ret = ipts_hid_free(ipts);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to free HID device: %d\n", ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++int ipts_control_restart(struct ipts_context *ipts)
++{
++	int ret = 0;
++
++	ret = _ipts_control_stop(ipts);
++	if (ret)
++		return ret;
++
++	/*
++	 * Wait a second to give the sensor time to fully shut down.
++	 */
++	msleep(1000);
++
++	ret = ipts_control_start(ipts);
++	if (ret)
++		return ret;
++
++	return 0;
++}
+diff --git a/drivers/hid/ipts/control.h b/drivers/hid/ipts/control.h
+new file mode 100644
+index 000000000..26629c514
+--- /dev/null
++++ b/drivers/hid/ipts/control.h
+@@ -0,0 +1,126 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (c) 2020-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#ifndef IPTS_CONTROL_H
++#define IPTS_CONTROL_H
++
++#include <linux/types.h>
++
++#include "context.h"
++#include "spec-data.h"
++#include "spec-device.h"
++
++/**
++ * ipts_control_request_flush() - Stop the data flow.
++ * @ipts: The IPTS driver context.
++ *
++ * Runs the command to stop the data flow on the device.
++ * All outstanding data needs to be acknowledged using feedback before the command will return.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_control_request_flush(struct ipts_context *ipts);
++
++/**
++ * ipts_control_wait_flush() - Wait until data flow has been stopped.
++ * @ipts: The IPTS driver context.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_control_wait_flush(struct ipts_context *ipts);
++
++/**
++ * ipts_control_wait_flush() - Notify the device that the driver can receive new data.
++ * @ipts: The IPTS driver context.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_control_request_data(struct ipts_context *ipts);
++
++/**
++ * ipts_control_wait_data() - Wait until new data is available.
++ * @ipts: The IPTS driver context.
++ * @block: Whether to block execution until data is available.
++ *
++ * In poll mode, this function will never return while the data flow is active. Instead,
++ * the poll will be incremented when new data is available.
++ *
++ * Returns: 0 on success, <0 on error, -EAGAIN if no data is available.
++ */
++int ipts_control_wait_data(struct ipts_context *ipts, bool block);
++
++/**
++ * ipts_control_send_feedback() - Submits a feedback buffer to the device.
++ * @ipts: The IPTS driver context.
++ * @buffer: The ID of the buffer containing feedback data.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_control_send_feedback(struct ipts_context *ipts, u32 buffer);
++
++/**
++ * ipts_control_hid2me_feedback() - Sends HID2ME feedback, a special type of feedback.
++ * @ipts: The IPTS driver context.
++ * @cmd: The command that will be run on the device.
++ * @type: The type of the payload that is sent to the device.
++ * @data: The payload of the feedback command.
++ * @size: The size of the payload.
++ *
++ * HID2ME feedback is a special type of feedback, because it allows interfacing with
++ * the HID API of the device at any moment, without requiring a buffer that has to
++ * be acknowledged.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_control_hid2me_feedback(struct ipts_context *ipts, enum ipts_feedback_cmd_type cmd,
++				 enum ipts_feedback_data_type type, void *data, size_t size);
++
++/**
++ * ipts_control_refill_buffer() - Acknowledges that data in a buffer has been processed.
++ * @ipts: The IPTS driver context.
++ * @buffer: The buffer that has been processed and can be refilled.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++static inline int ipts_control_refill_buffer(struct ipts_context *ipts, u32 buffer)
++{
++	/*
++	 * IPTS expects structured data in the feedback buffer matching the buffer that will be
++	 * refilled. We don't know what that data looks like, so we just keep the buffer empty.
++	 * This results in an INVALID_PARAMS error, but the buffer gets refilled without an issue.
++	 * Sending a minimal structure with the buffer ID fixes the error, but breaks refilling
++	 * the buffers on some devices.
++	 */
++
++	return ipts_control_send_feedback(ipts, buffer);
++}
++
++/**
++ * ipts_control_start() - Initialized the device and starts the data flow.
++ * @ipts: The IPTS driver context.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_control_start(struct ipts_context *ipts);
++
++/**
++ * ipts_control_stop() - Stops the data flow and resets the device.
++ * @ipts: The IPTS driver context.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_control_stop(struct ipts_context *ipts);
++
++/**
++ * ipts_control_restart() - Stops the device and starts it again.
++ * @ipts: The IPTS driver context.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_control_restart(struct ipts_context *ipts);
++
++#endif /* IPTS_CONTROL_H */
+diff --git a/drivers/hid/ipts/desc.h b/drivers/hid/ipts/desc.h
+new file mode 100644
+index 000000000..307438c7c
+--- /dev/null
++++ b/drivers/hid/ipts/desc.h
+@@ -0,0 +1,80 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (c) 2022-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#ifndef IPTS_DESC_H
++#define IPTS_DESC_H
++
++#include <linux/types.h>
++
++#define IPTS_HID_REPORT_SINGLETOUCH 64
++#define IPTS_HID_REPORT_DATA	    65
++#define IPTS_HID_REPORT_SET_MODE    66
++
++#define IPTS_HID_REPORT_DATA_SIZE 7485
++
++/*
++ * HID descriptor for singletouch data.
++ * This descriptor should be present on all IPTS devices.
++ */
++static const u8 ipts_singletouch_descriptor[] = {
++	0x05, 0x0D,	  /*  Usage Page (Digitizer),            */
++	0x09, 0x04,	  /*  Usage (Touchscreen),               */
++	0xA1, 0x01,	  /*  Collection (Application),          */
++	0x85, 0x40,	  /*      Report ID (64),                */
++	0x09, 0x42,	  /*      Usage (Tip Switch),            */
++	0x15, 0x00,	  /*      Logical Minimum (0),           */
++	0x25, 0x01,	  /*      Logical Maximum (1),           */
++	0x75, 0x01,	  /*      Report Size (1),               */
++	0x95, 0x01,	  /*      Report Count (1),              */
++	0x81, 0x02,	  /*      Input (Variable),              */
++	0x95, 0x07,	  /*      Report Count (7),              */
++	0x81, 0x03,	  /*      Input (Constant, Variable),    */
++	0x05, 0x01,	  /*      Usage Page (Desktop),          */
++	0x09, 0x30,	  /*      Usage (X),                     */
++	0x75, 0x10,	  /*      Report Size (16),              */
++	0x95, 0x01,	  /*      Report Count (1),              */
++	0xA4,		  /*      Push,                          */
++	0x55, 0x0E,	  /*      Unit Exponent (14),            */
++	0x65, 0x11,	  /*      Unit (Centimeter),             */
++	0x46, 0x76, 0x0B, /*      Physical Maximum (2934),       */
++	0x26, 0xFF, 0x7F, /*      Logical Maximum (32767),       */
++	0x81, 0x02,	  /*      Input (Variable),              */
++	0x09, 0x31,	  /*      Usage (Y),                     */
++	0x46, 0x74, 0x06, /*      Physical Maximum (1652),       */
++	0x26, 0xFF, 0x7F, /*      Logical Maximum (32767),       */
++	0x81, 0x02,	  /*      Input (Variable),              */
++	0xB4,		  /*      Pop,                           */
++	0xC0,		  /*  End Collection                     */
++};
++
++/*
++ * Fallback HID descriptor for older devices that do not have
++ * the ability to query their HID descriptor.
++ */
++static const u8 ipts_fallback_descriptor[] = {
++	0x05, 0x0D,	  /*  Usage Page (Digitizer),            */
++	0x09, 0x0F,	  /*  Usage (Capacitive Hm Digitizer),   */
++	0xA1, 0x01,	  /*  Collection (Application),          */
++	0x85, 0x41,	  /*      Report ID (65),                */
++	0x09, 0x56,	  /*      Usage (Scan Time),             */
++	0x95, 0x01,	  /*      Report Count (1),              */
++	0x75, 0x10,	  /*      Report Size (16),              */
++	0x81, 0x02,	  /*      Input (Variable),              */
++	0x09, 0x61,	  /*      Usage (Gesture Char Quality),  */
++	0x75, 0x08,	  /*      Report Size (8),               */
++	0x96, 0x3D, 0x1D, /*      Report Count (7485),           */
++	0x81, 0x03,	  /*      Input (Constant, Variable),    */
++	0x85, 0x42,	  /*      Report ID (66),                */
++	0x06, 0x00, 0xFF, /*      Usage Page (FF00h),            */
++	0x09, 0xC8,	  /*      Usage (C8h),                   */
++	0x75, 0x08,	  /*      Report Size (8),               */
++	0x95, 0x01,	  /*      Report Count (1),              */
++	0xB1, 0x02,	  /*      Feature (Variable),            */
++	0xC0,		  /*  End Collection,                    */
++};
++
++#endif /* IPTS_DESC_H */
+diff --git a/drivers/hid/ipts/eds1.c b/drivers/hid/ipts/eds1.c
+new file mode 100644
+index 000000000..7b9f54388
+--- /dev/null
++++ b/drivers/hid/ipts/eds1.c
+@@ -0,0 +1,104 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (c) 2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#include <linux/err.h>
++#include <linux/gfp.h>
++#include <linux/hid.h>
++#include <linux/slab.h>
++#include <linux/types.h>
++
++#include "context.h"
++#include "control.h"
++#include "desc.h"
++#include "eds1.h"
++#include "spec-device.h"
++
++int ipts_eds1_get_descriptor(struct ipts_context *ipts, u8 **desc_buffer, size_t *desc_size)
++{
++	size_t size = 0;
++	u8 *buffer = NULL;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!desc_buffer)
++		return -EFAULT;
++
++	if (!desc_size)
++		return -EFAULT;
++
++	size = sizeof(ipts_singletouch_descriptor) + sizeof(ipts_fallback_descriptor);
++
++	buffer = kzalloc(size, GFP_KERNEL);
++	if (!buffer)
++		return -ENOMEM;
++
++	memcpy(buffer, ipts_singletouch_descriptor, sizeof(ipts_singletouch_descriptor));
++	memcpy(&buffer[sizeof(ipts_singletouch_descriptor)], ipts_fallback_descriptor,
++	       sizeof(ipts_fallback_descriptor));
++
++	*desc_size = size;
++	*desc_buffer = buffer;
++
++	return 0;
++}
++
++static int ipts_eds1_switch_mode(struct ipts_context *ipts, enum ipts_mode mode)
++{
++	int ret = 0;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (ipts->mode == mode)
++		return 0;
++
++	ipts->mode = mode;
++
++	ret = ipts_control_restart(ipts);
++	if (ret)
++		dev_err(ipts->dev, "Failed to switch modes: %d\n", ret);
++
++	return ret;
++}
++
++int ipts_eds1_raw_request(struct ipts_context *ipts, u8 *buffer, size_t size, u8 report_id,
++			  enum hid_report_type report_type, enum hid_class_request request_type)
++{
++	int ret = 0;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!buffer)
++		return -EFAULT;
++
++	if (report_id != IPTS_HID_REPORT_SET_MODE)
++		return -EIO;
++
++	if (report_type != HID_FEATURE_REPORT)
++		return -EIO;
++
++	if (size != 2)
++		return -EINVAL;
++
++	/*
++	 * Implement mode switching report for older devices without native HID support.
++	 */
++
++	if (request_type == HID_REQ_GET_REPORT) {
++		memset(buffer, 0, size);
++		buffer[0] = report_id;
++		buffer[1] = ipts->mode;
++	} else if (request_type == HID_REQ_SET_REPORT) {
++		return ipts_eds1_switch_mode(ipts, buffer[1]);
++	} else {
++		return -EIO;
++	}
++
++	return ret;
++}
+diff --git a/drivers/hid/ipts/eds1.h b/drivers/hid/ipts/eds1.h
+new file mode 100644
+index 000000000..eeeb6575e
+--- /dev/null
++++ b/drivers/hid/ipts/eds1.h
+@@ -0,0 +1,35 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (c) 2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#include <linux/hid.h>
++#include <linux/types.h>
++
++#include "context.h"
++
++/**
++ * ipts_eds1_get_descriptor() - Assembles the HID descriptor of the device.
++ * @ipts: The IPTS driver context.
++ * @desc_buffer: A pointer to the location where the address of the allocated buffer is stored.
++ * @desc_size: A pointer to the location where the size of the allocated buffer is stored.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_eds1_get_descriptor(struct ipts_context *ipts, u8 **desc_buffer, size_t *desc_size);
++
++/**
++ * ipts_eds1_raw_request() - Executes an output or feature report on the device.
++ * @ipts: The IPTS driver context.
++ * @buffer: The buffer containing the report.
++ * @size: The size of the buffer.
++ * @report_id: The HID report ID.
++ * @report_type: Whether this report is an output or a feature report.
++ * @request_type: Whether this report requests or sends data.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_eds1_raw_request(struct ipts_context *ipts, u8 *buffer, size_t size, u8 report_id,
++			  enum hid_report_type report_type, enum hid_class_request request_type);
+diff --git a/drivers/hid/ipts/eds2.c b/drivers/hid/ipts/eds2.c
+new file mode 100644
+index 000000000..639940794
+--- /dev/null
++++ b/drivers/hid/ipts/eds2.c
+@@ -0,0 +1,145 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (c) 2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#include <linux/completion.h>
++#include <linux/err.h>
++#include <linux/gfp.h>
++#include <linux/mutex.h>
++#include <linux/slab.h>
++#include <linux/types.h>
++
++#include "context.h"
++#include "control.h"
++#include "desc.h"
++#include "eds2.h"
++#include "spec-data.h"
++
++int ipts_eds2_get_descriptor(struct ipts_context *ipts, u8 **desc_buffer, size_t *desc_size)
++{
++	size_t size = 0;
++	u8 *buffer = NULL;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!desc_buffer)
++		return -EFAULT;
++
++	if (!desc_size)
++		return -EFAULT;
++
++	size = sizeof(ipts_singletouch_descriptor) + ipts->descriptor.size;
++
++	buffer = kzalloc(size, GFP_KERNEL);
++	if (!buffer)
++		return -ENOMEM;
++
++	memcpy(buffer, ipts_singletouch_descriptor, sizeof(ipts_singletouch_descriptor));
++	memcpy(&buffer[sizeof(ipts_singletouch_descriptor)], ipts->descriptor.address,
++	       ipts->descriptor.size);
++
++	*desc_size = size;
++	*desc_buffer = buffer;
++
++	return 0;
++}
++
++static int ipts_eds2_get_feature(struct ipts_context *ipts, u8 *buffer, size_t size, u8 report_id,
++				 enum ipts_feedback_data_type type)
++{
++	int ret = 0;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!buffer)
++		return -EFAULT;
++
++	mutex_lock(&ipts->feature_lock);
++
++	memset(buffer, 0, size);
++	buffer[0] = report_id;
++
++	memset(&ipts->feature_report, 0, sizeof(ipts->feature_report));
++	reinit_completion(&ipts->feature_event);
++
++	ret = ipts_control_hid2me_feedback(ipts, IPTS_FEEDBACK_CMD_TYPE_NONE, type, buffer, size);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to send hid2me feedback: %d\n", ret);
++		goto out;
++	}
++
++	ret = wait_for_completion_timeout(&ipts->feature_event, msecs_to_jiffies(5000));
++	if (ret == 0) {
++		dev_warn(ipts->dev, "GET_FEATURES timed out!\n");
++		ret = -EIO;
++		goto out;
++	}
++
++	if (!ipts->feature_report.address) {
++		ret = -EFAULT;
++		goto out;
++	}
++
++	if (ipts->feature_report.size > size) {
++		ret = -ETOOSMALL;
++		goto out;
++	}
++
++	ret = ipts->feature_report.size;
++	memcpy(buffer, ipts->feature_report.address, ipts->feature_report.size);
++
++out:
++	mutex_unlock(&ipts->feature_lock);
++	return ret;
++}
++
++static int ipts_eds2_set_feature(struct ipts_context *ipts, u8 *buffer, size_t size, u8 report_id,
++				 enum ipts_feedback_data_type type)
++{
++	int ret = 0;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!buffer)
++		return -EFAULT;
++
++	buffer[0] = report_id;
++
++	ret = ipts_control_hid2me_feedback(ipts, IPTS_FEEDBACK_CMD_TYPE_NONE, type, buffer, size);
++	if (ret)
++		dev_err(ipts->dev, "Failed to send hid2me feedback: %d\n", ret);
++
++	return ret;
++}
++
++int ipts_eds2_raw_request(struct ipts_context *ipts, u8 *buffer, size_t size, u8 report_id,
++			  enum hid_report_type report_type, enum hid_class_request request_type)
++{
++	enum ipts_feedback_data_type feedback_type = IPTS_FEEDBACK_DATA_TYPE_VENDOR;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!buffer)
++		return -EFAULT;
++
++	if (report_type == HID_OUTPUT_REPORT && request_type == HID_REQ_SET_REPORT)
++		feedback_type = IPTS_FEEDBACK_DATA_TYPE_OUTPUT_REPORT;
++	else if (report_type == HID_FEATURE_REPORT && request_type == HID_REQ_GET_REPORT)
++		feedback_type = IPTS_FEEDBACK_DATA_TYPE_GET_FEATURES;
++	else if (report_type == HID_FEATURE_REPORT && request_type == HID_REQ_SET_REPORT)
++		feedback_type = IPTS_FEEDBACK_DATA_TYPE_SET_FEATURES;
++	else
++		return -EIO;
++
++	if (request_type == HID_REQ_GET_REPORT)
++		return ipts_eds2_get_feature(ipts, buffer, size, report_id, feedback_type);
++	else
++		return ipts_eds2_set_feature(ipts, buffer, size, report_id, feedback_type);
++}
+diff --git a/drivers/hid/ipts/eds2.h b/drivers/hid/ipts/eds2.h
+new file mode 100644
+index 000000000..064e37169
+--- /dev/null
++++ b/drivers/hid/ipts/eds2.h
+@@ -0,0 +1,35 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (c) 2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#include <linux/hid.h>
++#include <linux/types.h>
++
++#include "context.h"
++
++/**
++ * ipts_eds2_get_descriptor() - Assembles the HID descriptor of the device.
++ * @ipts: The IPTS driver context.
++ * @desc_buffer: A pointer to the location where the address of the allocated buffer is stored.
++ * @desc_size: A pointer to the location where the size of the allocated buffer is stored.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_eds2_get_descriptor(struct ipts_context *ipts, u8 **desc_buffer, size_t *desc_size);
++
++/**
++ * ipts_eds2_raw_request() - Executes an output or feature report on the device.
++ * @ipts: The IPTS driver context.
++ * @buffer: The buffer containing the report.
++ * @size: The size of the buffer.
++ * @report_id: The HID report ID.
++ * @report_type: Whether this report is an output or a feature report.
++ * @request_type: Whether this report requests or sends data.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_eds2_raw_request(struct ipts_context *ipts, u8 *buffer, size_t size, u8 report_id,
++			  enum hid_report_type report_type, enum hid_class_request request_type);
+diff --git a/drivers/hid/ipts/hid.c b/drivers/hid/ipts/hid.c
+new file mode 100644
+index 000000000..e34a1a4f9
+--- /dev/null
++++ b/drivers/hid/ipts/hid.c
+@@ -0,0 +1,225 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (c) 2022-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#include <linux/completion.h>
++#include <linux/err.h>
++#include <linux/gfp.h>
++#include <linux/hid.h>
++#include <linux/mutex.h>
++#include <linux/slab.h>
++#include <linux/types.h>
++
++#include "context.h"
++#include "desc.h"
++#include "eds1.h"
++#include "eds2.h"
++#include "hid.h"
++#include "spec-data.h"
++#include "spec-hid.h"
++
++void ipts_hid_enable(struct ipts_context *ipts)
++{
++	WRITE_ONCE(ipts->hid_active, true);
++}
++
++void ipts_hid_disable(struct ipts_context *ipts)
++{
++	WRITE_ONCE(ipts->hid_active, false);
++}
++
++static int ipts_hid_start(struct hid_device *hid)
++{
++	return 0;
++}
++
++static void ipts_hid_stop(struct hid_device *hid)
++{
++}
++
++static int ipts_hid_parse(struct hid_device *hid)
++{
++	int ret = 0;
++	struct ipts_context *ipts = NULL;
++
++	u8 *buffer = NULL;
++	size_t size = 0;
++
++	if (!hid)
++		return -ENODEV;
++
++	ipts = hid->driver_data;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!READ_ONCE(ipts->hid_active))
++		return -ENODEV;
++
++	if (ipts->info.intf_eds == 1)
++		ret = ipts_eds1_get_descriptor(ipts, &buffer, &size);
++	else
++		ret = ipts_eds2_get_descriptor(ipts, &buffer, &size);
++
++	if (ret) {
++		dev_err(ipts->dev, "Failed to allocate HID descriptor: %d\n", ret);
++		return ret;
++	}
++
++	ret = hid_parse_report(hid, buffer, size);
++	kfree(buffer);
++
++	if (ret) {
++		dev_err(ipts->dev, "Failed to parse HID descriptor: %d\n", ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static int ipts_hid_raw_request(struct hid_device *hid, unsigned char report_id, __u8 *buffer,
++				size_t size, unsigned char report_type, int request_type)
++{
++	struct ipts_context *ipts = NULL;
++
++	if (!hid)
++		return -ENODEV;
++
++	ipts = hid->driver_data;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!READ_ONCE(ipts->hid_active))
++		return -ENODEV;
++
++	if (ipts->info.intf_eds == 1) {
++		return ipts_eds1_raw_request(ipts, buffer, size, report_id, report_type,
++					     request_type);
++	} else {
++		return ipts_eds2_raw_request(ipts, buffer, size, report_id, report_type,
++					     request_type);
++	}
++}
++
++static struct hid_ll_driver ipts_hid_driver = {
++	.start = ipts_hid_start,
++	.stop = ipts_hid_stop,
++	.open = ipts_hid_start,
++	.close = ipts_hid_stop,
++	.parse = ipts_hid_parse,
++	.raw_request = ipts_hid_raw_request,
++};
++
++int ipts_hid_input_data(struct ipts_context *ipts, u32 buffer)
++{
++	u8 *temp = NULL;
++	struct ipts_hid_header *frame = NULL;
++	struct ipts_data_header *header = NULL;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (!ipts->hid)
++		return -ENODEV;
++
++	if (!READ_ONCE(ipts->hid_active))
++		return -ENODEV;
++
++	header = (struct ipts_data_header *)ipts->resources.data[buffer].address;
++
++	temp = ipts->resources.report.address;
++	memset(temp, 0, ipts->resources.report.size);
++
++	if (!header)
++		return -EFAULT;
++
++	if (header->size == 0)
++		return 0;
++
++	if (header->type == IPTS_DATA_TYPE_HID)
++		return hid_input_report(ipts->hid, HID_INPUT_REPORT, header->data, header->size, 1);
++
++	if (header->type == IPTS_DATA_TYPE_GET_FEATURES) {
++		ipts->feature_report.address = header->data;
++		ipts->feature_report.size = header->size;
++
++		complete_all(&ipts->feature_event);
++		return 0;
++	}
++
++	if (header->type != IPTS_DATA_TYPE_FRAME)
++		return 0;
++
++	if (header->size + 3 + sizeof(struct ipts_hid_header) > IPTS_HID_REPORT_DATA_SIZE)
++		return -ERANGE;
++
++	/*
++	 * Synthesize a HID report matching the devices that natively send HID reports
++	 */
++	temp[0] = IPTS_HID_REPORT_DATA;
++
++	frame = (struct ipts_hid_header *)&temp[3];
++	frame->type = IPTS_HID_FRAME_TYPE_RAW;
++	frame->size = header->size + sizeof(*frame);
++
++	memcpy(frame->data, header->data, header->size);
++
++	return hid_input_report(ipts->hid, HID_INPUT_REPORT, temp, IPTS_HID_REPORT_DATA_SIZE, 1);
++}
++
++int ipts_hid_init(struct ipts_context *ipts, struct ipts_device_info info)
++{
++	int ret = 0;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (ipts->hid)
++		return 0;
++
++	ipts->hid = hid_allocate_device();
++	if (IS_ERR(ipts->hid)) {
++		int err = PTR_ERR(ipts->hid);
++
++		dev_err(ipts->dev, "Failed to allocate HID device: %d\n", err);
++		return err;
++	}
++
++	ipts->hid->driver_data = ipts;
++	ipts->hid->dev.parent = ipts->dev;
++	ipts->hid->ll_driver = &ipts_hid_driver;
++
++	ipts->hid->vendor = info.vendor;
++	ipts->hid->product = info.product;
++	ipts->hid->group = HID_GROUP_GENERIC;
++
++	snprintf(ipts->hid->name, sizeof(ipts->hid->name), "IPTS %04X:%04X", info.vendor,
++		 info.product);
++
++	ret = hid_add_device(ipts->hid);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to add HID device: %d\n", ret);
++		ipts_hid_free(ipts);
++		return ret;
++	}
++
++	return 0;
++}
++
++int ipts_hid_free(struct ipts_context *ipts)
++{
++	if (!ipts)
++		return -EFAULT;
++
++	if (!ipts->hid)
++		return 0;
++
++	hid_destroy_device(ipts->hid);
++	ipts->hid = NULL;
++
++	return 0;
++}
+diff --git a/drivers/hid/ipts/hid.h b/drivers/hid/ipts/hid.h
+new file mode 100644
+index 000000000..1ebe77447
+--- /dev/null
++++ b/drivers/hid/ipts/hid.h
+@@ -0,0 +1,24 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (c) 2022-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#ifndef IPTS_HID_H
++#define IPTS_HID_H
++
++#include <linux/types.h>
++
++#include "context.h"
++#include "spec-device.h"
++
++void ipts_hid_enable(struct ipts_context *ipts);
++void ipts_hid_disable(struct ipts_context *ipts);
++
++int ipts_hid_input_data(struct ipts_context *ipts, u32 buffer);
++
++int ipts_hid_init(struct ipts_context *ipts, struct ipts_device_info info);
++int ipts_hid_free(struct ipts_context *ipts);
++
++#endif /* IPTS_HID_H */
+diff --git a/drivers/hid/ipts/main.c b/drivers/hid/ipts/main.c
+new file mode 100644
+index 000000000..fb5b5c13e
+--- /dev/null
++++ b/drivers/hid/ipts/main.c
+@@ -0,0 +1,126 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (c) 2020-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#include <linux/completion.h>
++#include <linux/delay.h>
++#include <linux/device.h>
++#include <linux/dma-mapping.h>
++#include <linux/mei_cl_bus.h>
++#include <linux/mod_devicetable.h>
++#include <linux/module.h>
++#include <linux/mutex.h>
++#include <linux/slab.h>
++#include <linux/stddef.h>
++#include <linux/types.h>
++
++#include "context.h"
++#include "control.h"
++#include "mei.h"
++#include "receiver.h"
++#include "spec-device.h"
++
++/*
++ * The MEI client ID for IPTS functionality.
++ */
++#define IPTS_ID UUID_LE(0x3e8d0870, 0x271a, 0x4208, 0x8e, 0xb5, 0x9a, 0xcb, 0x94, 0x02, 0xae, 0x04)
++
++static int ipts_set_dma_mask(struct mei_cl_device *cldev)
++{
++	if (!cldev)
++		return -EFAULT;
++
++	if (!dma_coerce_mask_and_coherent(&cldev->dev, DMA_BIT_MASK(64)))
++		return 0;
++
++	return dma_coerce_mask_and_coherent(&cldev->dev, DMA_BIT_MASK(32));
++}
++
++static int ipts_probe(struct mei_cl_device *cldev, const struct mei_cl_device_id *id)
++{
++	int ret = 0;
++	struct ipts_context *ipts = NULL;
++
++	if (!cldev)
++		return -EFAULT;
++
++	ret = ipts_set_dma_mask(cldev);
++	if (ret) {
++		dev_err(&cldev->dev, "Failed to set DMA mask for IPTS: %d\n", ret);
++		return ret;
++	}
++
++	ret = mei_cldev_enable(cldev);
++	if (ret) {
++		dev_err(&cldev->dev, "Failed to enable MEI device: %d\n", ret);
++		return ret;
++	}
++
++	ipts = devm_kzalloc(&cldev->dev, sizeof(*ipts), GFP_KERNEL);
++	if (!ipts) {
++		mei_cldev_disable(cldev);
++		return -ENOMEM;
++	}
++
++	ret = ipts_mei_init(&ipts->mei, cldev);
++	if (ret) {
++		dev_err(&cldev->dev, "Failed to init MEI bus logic: %d\n", ret);
++		return ret;
++	}
++
++	ipts->dev = &cldev->dev;
++	ipts->mode = IPTS_MODE_EVENT;
++
++	mutex_init(&ipts->feature_lock);
++	init_completion(&ipts->feature_event);
++
++	mei_cldev_set_drvdata(cldev, ipts);
++
++	ret = ipts_control_start(ipts);
++	if (ret) {
++		dev_err(&cldev->dev, "Failed to start IPTS: %d\n", ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++static void ipts_remove(struct mei_cl_device *cldev)
++{
++	int ret = 0;
++	struct ipts_context *ipts = NULL;
++
++	if (!cldev) {
++		pr_err("MEI device is NULL!");
++		return;
++	}
++
++	ipts = mei_cldev_get_drvdata(cldev);
++
++	ret = ipts_control_stop(ipts);
++	if (ret)
++		dev_err(&cldev->dev, "Failed to stop IPTS: %d\n", ret);
++
++	mei_cldev_disable(cldev);
++}
++
++static struct mei_cl_device_id ipts_device_id_table[] = {
++	{ .uuid = IPTS_ID, .version = MEI_CL_VERSION_ANY },
++	{},
++};
++MODULE_DEVICE_TABLE(mei, ipts_device_id_table);
++
++static struct mei_cl_driver ipts_driver = {
++	.id_table = ipts_device_id_table,
++	.name = "ipts",
++	.probe = ipts_probe,
++	.remove = ipts_remove,
++};
++module_mei_cl_driver(ipts_driver);
++
++MODULE_DESCRIPTION("IPTS touchscreen driver");
++MODULE_AUTHOR("Dorian Stoll <dorian.stoll@tmsp.io>");
++MODULE_LICENSE("GPL");
+diff --git a/drivers/hid/ipts/mei.c b/drivers/hid/ipts/mei.c
+new file mode 100644
+index 000000000..1e0395cea
+--- /dev/null
++++ b/drivers/hid/ipts/mei.c
+@@ -0,0 +1,188 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (c) 2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#include <linux/device.h>
++#include <linux/errno.h>
++#include <linux/jiffies.h>
++#include <linux/list.h>
++#include <linux/mei_cl_bus.h>
++#include <linux/printk.h>
++#include <linux/rwsem.h>
++#include <linux/types.h>
++#include <linux/wait.h>
++
++#include "context.h"
++#include "mei.h"
++
++static void locked_list_add(struct list_head *new, struct list_head *head,
++			    struct rw_semaphore *lock)
++{
++	down_write(lock);
++	list_add(new, head);
++	up_write(lock);
++}
++
++static void locked_list_del(struct list_head *entry, struct rw_semaphore *lock)
++{
++	down_write(lock);
++	list_del(entry);
++	up_write(lock);
++}
++
++static void ipts_mei_incoming(struct mei_cl_device *cldev)
++{
++	ssize_t ret = 0;
++	struct ipts_mei_message *entry = NULL;
++	struct ipts_context *ipts = NULL;
++
++	if (!cldev) {
++		pr_err("MEI device is NULL!");
++		return;
++	}
++
++	ipts = mei_cldev_get_drvdata(cldev);
++	if (!ipts) {
++		pr_err("IPTS driver context is NULL!");
++		return;
++	}
++
++	entry = devm_kzalloc(ipts->dev, sizeof(*entry), GFP_KERNEL);
++	if (!entry)
++		return;
++
++	INIT_LIST_HEAD(&entry->list);
++
++	do {
++		ret = mei_cldev_recv(cldev, (u8 *)&entry->rsp, sizeof(entry->rsp));
++	} while (ret == -EINTR);
++
++	if (ret < 0) {
++		dev_err(ipts->dev, "Error while reading response: %ld\n", ret);
++		return;
++	}
++
++	if (ret == 0) {
++		dev_err(ipts->dev, "Received empty response\n");
++		return;
++	}
++
++	locked_list_add(&entry->list, &ipts->mei.messages, &ipts->mei.message_lock);
++	wake_up_all(&ipts->mei.message_queue);
++}
++
++static int ipts_mei_search(struct ipts_mei *mei, enum ipts_command_code code,
++			   struct ipts_response *rsp)
++{
++	struct ipts_mei_message *entry = NULL;
++
++	if (!mei)
++		return -EFAULT;
++
++	if (!rsp)
++		return -EFAULT;
++
++	down_read(&mei->message_lock);
++
++	/*
++	 * Iterate over the list of received messages, and check if there is one
++	 * matching the requested command code.
++	 */
++	list_for_each_entry(entry, &mei->messages, list) {
++		if (entry->rsp.cmd == code)
++			break;
++	}
++
++	up_read(&mei->message_lock);
++
++	/*
++	 * If entry is not the list head, this means that the loop above has been stopped early,
++	 * and that we found a matching element. We drop the message from the list and return it.
++	 */
++	if (!list_entry_is_head(entry, &mei->messages, list)) {
++		locked_list_del(&entry->list, &mei->message_lock);
++
++		*rsp = entry->rsp;
++		devm_kfree(&mei->cldev->dev, entry);
++
++		return 0;
++	}
++
++	return -EAGAIN;
++}
++
++int ipts_mei_recv(struct ipts_mei *mei, enum ipts_command_code code, struct ipts_response *rsp,
++		  u64 timeout)
++{
++	int ret = 0;
++
++	if (!mei)
++		return -EFAULT;
++
++	/*
++	 * A timeout of 0 means check and return immideately.
++	 */
++	if (timeout == 0)
++		return ipts_mei_search(mei, code, rsp);
++
++	/*
++	 * A timeout of less than 0 means to wait forever.
++	 */
++	if (timeout < 0) {
++		wait_event(mei->message_queue, ipts_mei_search(mei, code, rsp) == 0);
++		return 0;
++	}
++
++	ret = wait_event_timeout(mei->message_queue, ipts_mei_search(mei, code, rsp) == 0,
++				 msecs_to_jiffies(timeout));
++
++	if (ret > 0)
++		return 0;
++
++	return -EAGAIN;
++}
++
++int ipts_mei_send(struct ipts_mei *mei, void *data, size_t length)
++{
++	int ret = 0;
++
++	if (!mei)
++		return -EFAULT;
++
++	if (!mei->cldev)
++		return -EFAULT;
++
++	if (!data)
++		return -EFAULT;
++
++	do {
++		ret = mei_cldev_send(mei->cldev, (u8 *)data, length);
++	} while (ret == -EINTR);
++
++	if (ret < 0)
++		return ret;
++
++	return 0;
++}
++
++int ipts_mei_init(struct ipts_mei *mei, struct mei_cl_device *cldev)
++{
++	if (!mei)
++		return -EFAULT;
++
++	if (!cldev)
++		return -EFAULT;
++
++	mei->cldev = cldev;
++
++	INIT_LIST_HEAD(&mei->messages);
++	init_waitqueue_head(&mei->message_queue);
++	init_rwsem(&mei->message_lock);
++
++	mei_cldev_register_rx_cb(cldev, ipts_mei_incoming);
++
++	return 0;
++}
+diff --git a/drivers/hid/ipts/mei.h b/drivers/hid/ipts/mei.h
+new file mode 100644
+index 000000000..973bade6b
+--- /dev/null
++++ b/drivers/hid/ipts/mei.h
+@@ -0,0 +1,66 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (c) 2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#ifndef IPTS_MEI_H
++#define IPTS_MEI_H
++
++#include <linux/list.h>
++#include <linux/mei_cl_bus.h>
++#include <linux/rwsem.h>
++#include <linux/types.h>
++#include <linux/wait.h>
++
++#include "spec-device.h"
++
++struct ipts_mei_message {
++	struct list_head list;
++	struct ipts_response rsp;
++};
++
++struct ipts_mei {
++	struct mei_cl_device *cldev;
++
++	struct list_head messages;
++
++	wait_queue_head_t message_queue;
++	struct rw_semaphore message_lock;
++};
++
++/**
++ * ipts_mei_recv() - Receive data from a MEI device.
++ * @mei: The IPTS MEI device context.
++ * @code: The IPTS command code to look for.
++ * @rsp: The address that the received data will be copied to.
++ * @timeout: How many milliseconds the function will wait at most.
++ *
++ * A negative timeout means to wait forever.
++ *
++ * Returns: 0 on success, <0 on error, -EAGAIN if no response has been received.
++ */
++int ipts_mei_recv(struct ipts_mei *mei, enum ipts_command_code code, struct ipts_response *rsp,
++		  u64 timeout);
++
++/**
++ * ipts_mei_send() - Send data to a MEI device.
++ * @ipts: The IPTS MEI device context.
++ * @data: The data to send.
++ * @size: The size of the data.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_mei_send(struct ipts_mei *mei, void *data, size_t length);
++
++/**
++ * ipts_mei_init() - Initialize the MEI device context.
++ * @mei: The MEI device context to initialize.
++ * @cldev: The MEI device the context will be bound to.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_mei_init(struct ipts_mei *mei, struct mei_cl_device *cldev);
++
++#endif /* IPTS_MEI_H */
+diff --git a/drivers/hid/ipts/receiver.c b/drivers/hid/ipts/receiver.c
+new file mode 100644
+index 000000000..977724c72
+--- /dev/null
++++ b/drivers/hid/ipts/receiver.c
+@@ -0,0 +1,251 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (c) 2020-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#include <linux/delay.h>
++#include <linux/err.h>
++#include <linux/kthread.h>
++#include <linux/time64.h>
++#include <linux/timekeeping.h>
++#include <linux/types.h>
++
++#include "cmd.h"
++#include "context.h"
++#include "control.h"
++#include "hid.h"
++#include "receiver.h"
++#include "resources.h"
++#include "spec-device.h"
++#include "thread.h"
++
++static void ipts_receiver_next_doorbell(struct ipts_context *ipts)
++{
++	u32 *doorbell = (u32 *)ipts->resources.doorbell.address;
++	*doorbell = *doorbell + 1;
++}
++
++static u32 ipts_receiver_current_doorbell(struct ipts_context *ipts)
++{
++	u32 *doorbell = (u32 *)ipts->resources.doorbell.address;
++	return *doorbell;
++}
++
++static void ipts_receiver_backoff(time64_t last, u32 n)
++{
++	/*
++	 * If the last change was less than n seconds ago,
++	 * sleep for a shorter period so that new data can be
++	 * processed quickly. If there was no change for more than
++	 * n seconds, sleep longer to avoid wasting CPU cycles.
++	 */
++	if (last + n > ktime_get_seconds())
++		usleep_range(1 * USEC_PER_MSEC, 5 * USEC_PER_MSEC);
++	else
++		msleep(200);
++}
++
++static int ipts_receiver_event_loop(struct ipts_thread *thread)
++{
++	int ret = 0;
++	u32 buffer = 0;
++
++	struct ipts_context *ipts = NULL;
++	time64_t last = ktime_get_seconds();
++
++	if (!thread)
++		return -EFAULT;
++
++	ipts = thread->data;
++
++	if (!ipts)
++		return -EFAULT;
++
++	dev_info(ipts->dev, "IPTS running in event mode\n");
++
++	while (!ipts_thread_should_stop(thread)) {
++		int i = 0;
++
++		for (i = 0; i < IPTS_BUFFERS; i++) {
++			ret = ipts_control_wait_data(ipts, false);
++			if (ret == -EAGAIN)
++				break;
++
++			if (ret) {
++				dev_err(ipts->dev, "Failed to wait for data: %d\n", ret);
++				continue;
++			}
++
++			buffer = ipts_receiver_current_doorbell(ipts) % IPTS_BUFFERS;
++			ipts_receiver_next_doorbell(ipts);
++
++			ret = ipts_hid_input_data(ipts, buffer);
++			if (ret)
++				dev_err(ipts->dev, "Failed to process buffer: %d\n", ret);
++
++			ret = ipts_control_refill_buffer(ipts, buffer);
++			if (ret)
++				dev_err(ipts->dev, "Failed to send feedback: %d\n", ret);
++
++			ret = ipts_control_request_data(ipts);
++			if (ret)
++				dev_err(ipts->dev, "Failed to request data: %d\n", ret);
++
++			last = ktime_get_seconds();
++		}
++
++		ipts_receiver_backoff(last, 5);
++	}
++
++	ret = ipts_control_request_flush(ipts);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to request flush: %d\n", ret);
++		return ret;
++	}
++
++	ret = ipts_control_wait_data(ipts, true);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to wait for data: %d\n", ret);
++
++		if (ret != -EAGAIN)
++			return ret;
++		else
++			return 0;
++	}
++
++	ret = ipts_control_wait_flush(ipts);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to wait for flush: %d\n", ret);
++
++		if (ret != -EAGAIN)
++			return ret;
++		else
++			return 0;
++	}
++
++	return 0;
++}
++
++static int ipts_receiver_poll_loop(struct ipts_thread *thread)
++{
++	int ret = 0;
++	u32 buffer = 0;
++
++	u32 doorbell = 0;
++	u32 lastdb = 0;
++
++	struct ipts_context *ipts = NULL;
++	time64_t last = ktime_get_seconds();
++
++	if (!thread)
++		return -EFAULT;
++
++	ipts = thread->data;
++
++	if (!ipts)
++		return -EFAULT;
++
++	dev_info(ipts->dev, "IPTS running in poll mode\n");
++
++	while (true) {
++		if (ipts_thread_should_stop(thread)) {
++			ret = ipts_control_request_flush(ipts);
++			if (ret) {
++				dev_err(ipts->dev, "Failed to request flush: %d\n", ret);
++				return ret;
++			}
++		}
++
++		doorbell = ipts_receiver_current_doorbell(ipts);
++
++		/*
++		 * After filling up one of the data buffers, IPTS will increment
++		 * the doorbell. The value of the doorbell stands for the *next*
++		 * buffer that IPTS is going to fill.
++		 */
++		while (lastdb != doorbell) {
++			buffer = lastdb % IPTS_BUFFERS;
++
++			ret = ipts_hid_input_data(ipts, buffer);
++			if (ret)
++				dev_err(ipts->dev, "Failed to process buffer: %d\n", ret);
++
++			ret = ipts_control_refill_buffer(ipts, buffer);
++			if (ret)
++				dev_err(ipts->dev, "Failed to send feedback: %d\n", ret);
++
++			last = ktime_get_seconds();
++			lastdb++;
++		}
++
++		if (ipts_thread_should_stop(thread))
++			break;
++
++		ipts_receiver_backoff(last, 5);
++	}
++
++	ret = ipts_control_wait_data(ipts, true);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to wait for data: %d\n", ret);
++
++		if (ret != -EAGAIN)
++			return ret;
++		else
++			return 0;
++	}
++
++	ret = ipts_control_wait_flush(ipts);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to wait for flush: %d\n", ret);
++
++		if (ret != -EAGAIN)
++			return ret;
++		else
++			return 0;
++	}
++
++	return 0;
++}
++
++int ipts_receiver_start(struct ipts_context *ipts)
++{
++	int ret = 0;
++
++	if (!ipts)
++		return -EFAULT;
++
++	if (ipts->mode == IPTS_MODE_EVENT) {
++		ret = ipts_thread_start(&ipts->receiver_loop, ipts_receiver_event_loop, ipts,
++					"ipts_event");
++	} else if (ipts->mode == IPTS_MODE_POLL) {
++		ret = ipts_thread_start(&ipts->receiver_loop, ipts_receiver_poll_loop, ipts,
++					"ipts_poll");
++	} else {
++		ret = -EINVAL;
++	}
++
++	if (ret) {
++		dev_err(ipts->dev, "Failed to start receiver loop: %d\n", ret);
++		return ret;
++	}
++
++	return 0;
++}
++
++int ipts_receiver_stop(struct ipts_context *ipts)
++{
++	int ret = 0;
++
++	if (!ipts)
++		return -EFAULT;
++
++	ret = ipts_thread_stop(&ipts->receiver_loop);
++	if (ret) {
++		dev_err(ipts->dev, "Failed to stop receiver loop: %d\n", ret);
++		return ret;
++	}
++
++	return 0;
++}
+diff --git a/drivers/hid/ipts/receiver.h b/drivers/hid/ipts/receiver.h
+new file mode 100644
+index 000000000..3de7da62d
+--- /dev/null
++++ b/drivers/hid/ipts/receiver.h
+@@ -0,0 +1,16 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (c) 2020-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#ifndef IPTS_RECEIVER_H
++#define IPTS_RECEIVER_H
++
++#include "context.h"
++
++int ipts_receiver_start(struct ipts_context *ipts);
++int ipts_receiver_stop(struct ipts_context *ipts);
++
++#endif /* IPTS_RECEIVER_H */
+diff --git a/drivers/hid/ipts/resources.c b/drivers/hid/ipts/resources.c
+new file mode 100644
+index 000000000..cc14653b2
+--- /dev/null
++++ b/drivers/hid/ipts/resources.c
+@@ -0,0 +1,131 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (c) 2020-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#include <linux/dma-mapping.h>
++#include <linux/slab.h>
++#include <linux/types.h>
++
++#include "desc.h"
++#include "resources.h"
++#include "spec-device.h"
++
++static int ipts_resources_alloc_buffer(struct ipts_buffer *buffer, struct device *dev, size_t size)
++{
++	if (!buffer)
++		return -EFAULT;
++
++	if (buffer->address)
++		return 0;
++
++	buffer->address = dma_alloc_coherent(dev, size, &buffer->dma_address, GFP_KERNEL);
++
++	if (!buffer->address)
++		return -ENOMEM;
++
++	buffer->size = size;
++	buffer->device = dev;
++
++	return 0;
++}
++
++static void ipts_resources_free_buffer(struct ipts_buffer *buffer)
++{
++	if (!buffer->address)
++		return;
++
++	dma_free_coherent(buffer->device, buffer->size, buffer->address, buffer->dma_address);
++
++	buffer->address = NULL;
++	buffer->size = 0;
++
++	buffer->dma_address = 0;
++	buffer->device = NULL;
++}
++
++int ipts_resources_init(struct ipts_resources *res, struct device *dev, size_t ds, size_t fs)
++{
++	int ret = 0;
++
++	/*
++	 * Some compilers (AOSP clang) complain about a redefined
++	 * variable when this is declared inside of the for loop.
++	 */
++	int i = 0;
++
++	if (!res)
++		return -EFAULT;
++
++	for (i = 0; i < IPTS_BUFFERS; i++) {
++		ret = ipts_resources_alloc_buffer(&res->data[i], dev, ds);
++		if (ret)
++			goto err;
++	}
++
++	for (i = 0; i < IPTS_BUFFERS; i++) {
++		ret = ipts_resources_alloc_buffer(&res->feedback[i], dev, fs);
++		if (ret)
++			goto err;
++	}
++
++	ret = ipts_resources_alloc_buffer(&res->doorbell, dev, sizeof(u32));
++	if (ret)
++		goto err;
++
++	ret = ipts_resources_alloc_buffer(&res->workqueue, dev, sizeof(u32));
++	if (ret)
++		goto err;
++
++	ret = ipts_resources_alloc_buffer(&res->hid2me, dev, fs);
++	if (ret)
++		goto err;
++
++	ret = ipts_resources_alloc_buffer(&res->descriptor, dev, ds + 8);
++	if (ret)
++		goto err;
++
++	if (!res->report.address) {
++		res->report.size = IPTS_HID_REPORT_DATA_SIZE;
++		res->report.address = kzalloc(res->report.size, GFP_KERNEL);
++
++		if (!res->report.address) {
++			ret = -ENOMEM;
++			goto err;
++		}
++	}
++
++	return 0;
++
++err:
++
++	ipts_resources_free(res);
++	return ret;
++}
++
++int ipts_resources_free(struct ipts_resources *res)
++{
++	int i = 0;
++
++	if (!res)
++		return -EFAULT;
++
++	for (i = 0; i < IPTS_BUFFERS; i++)
++		ipts_resources_free_buffer(&res->data[i]);
++
++	for (i = 0; i < IPTS_BUFFERS; i++)
++		ipts_resources_free_buffer(&res->feedback[i]);
++
++	ipts_resources_free_buffer(&res->doorbell);
++	ipts_resources_free_buffer(&res->workqueue);
++	ipts_resources_free_buffer(&res->hid2me);
++	ipts_resources_free_buffer(&res->descriptor);
++
++	kfree(res->report.address);
++	res->report.address = NULL;
++	res->report.size = 0;
++
++	return 0;
++}
+diff --git a/drivers/hid/ipts/resources.h b/drivers/hid/ipts/resources.h
+new file mode 100644
+index 000000000..2068e1328
+--- /dev/null
++++ b/drivers/hid/ipts/resources.h
+@@ -0,0 +1,41 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (c) 2020-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#ifndef IPTS_RESOURCES_H
++#define IPTS_RESOURCES_H
++
++#include <linux/device.h>
++#include <linux/types.h>
++
++#include "spec-device.h"
++
++struct ipts_buffer {
++	u8 *address;
++	size_t size;
++
++	dma_addr_t dma_address;
++	struct device *device;
++};
++
++struct ipts_resources {
++	struct ipts_buffer data[IPTS_BUFFERS];
++	struct ipts_buffer feedback[IPTS_BUFFERS];
++
++	struct ipts_buffer doorbell;
++	struct ipts_buffer workqueue;
++	struct ipts_buffer hid2me;
++
++	struct ipts_buffer descriptor;
++
++	// Buffer for synthesizing HID reports
++	struct ipts_buffer report;
++};
++
++int ipts_resources_init(struct ipts_resources *res, struct device *dev, size_t ds, size_t fs);
++int ipts_resources_free(struct ipts_resources *res);
++
++#endif /* IPTS_RESOURCES_H */
+diff --git a/drivers/hid/ipts/spec-data.h b/drivers/hid/ipts/spec-data.h
+new file mode 100644
+index 000000000..e8dd98895
+--- /dev/null
++++ b/drivers/hid/ipts/spec-data.h
+@@ -0,0 +1,100 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (c) 2016 Intel Corporation
++ * Copyright (c) 2020-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#ifndef IPTS_SPEC_DATA_H
++#define IPTS_SPEC_DATA_H
++
++#include <linux/build_bug.h>
++#include <linux/types.h>
++
++/**
++ * enum ipts_feedback_cmd_type - Commands that can be executed on the sensor through feedback.
++ */
++enum ipts_feedback_cmd_type {
++	IPTS_FEEDBACK_CMD_TYPE_NONE = 0,
++	IPTS_FEEDBACK_CMD_TYPE_SOFT_RESET = 1,
++	IPTS_FEEDBACK_CMD_TYPE_GOTO_ARMED = 2,
++	IPTS_FEEDBACK_CMD_TYPE_GOTO_SENSING = 3,
++	IPTS_FEEDBACK_CMD_TYPE_GOTO_SLEEP = 4,
++	IPTS_FEEDBACK_CMD_TYPE_GOTO_DOZE = 5,
++	IPTS_FEEDBACK_CMD_TYPE_HARD_RESET = 6,
++};
++
++/**
++ * enum ipts_feedback_data_type - Defines what data a feedback buffer contains.
++ * @IPTS_FEEDBACK_DATA_TYPE_VENDOR:        The buffer contains vendor specific feedback.
++ * @IPTS_FEEDBACK_DATA_TYPE_SET_FEATURES:  The buffer contains a HID set features report.
++ * @IPTS_FEEDBACK_DATA_TYPE_GET_FEATURES:  The buffer contains a HID get features report.
++ * @IPTS_FEEDBACK_DATA_TYPE_OUTPUT_REPORT: The buffer contains a HID output report.
++ * @IPTS_FEEDBACK_DATA_TYPE_STORE_DATA:    The buffer contains calibration data for the sensor.
++ */
++enum ipts_feedback_data_type {
++	IPTS_FEEDBACK_DATA_TYPE_VENDOR = 0,
++	IPTS_FEEDBACK_DATA_TYPE_SET_FEATURES = 1,
++	IPTS_FEEDBACK_DATA_TYPE_GET_FEATURES = 2,
++	IPTS_FEEDBACK_DATA_TYPE_OUTPUT_REPORT = 3,
++	IPTS_FEEDBACK_DATA_TYPE_STORE_DATA = 4,
++};
++
++/**
++ * struct ipts_feedback_header - Header that is prefixed to the data in a feedback buffer.
++ * @cmd_type:   A command that should be executed on the sensor.
++ * @size:       The size of the payload to be written.
++ * @buffer:     The ID of the buffer that contains this feedback data.
++ * @protocol:   The protocol version of the EDS.
++ * @data_type:  The type of data that the buffer contains.
++ * @spi_offset: The offset at which to write the payload data to the sensor.
++ * @payload:    Payload for the feedback command, or 0 if no payload is sent.
++ */
++struct ipts_feedback_header {
++	enum ipts_feedback_cmd_type cmd_type;
++	u32 size;
++	u32 buffer;
++	u32 protocol;
++	enum ipts_feedback_data_type data_type;
++	u32 spi_offset;
++	u8 reserved[40];
++	u8 payload[];
++} __packed;
++
++static_assert(sizeof(struct ipts_feedback_header) == 64);
++
++/**
++ * enum ipts_data_type - Defines what type of data a buffer contains.
++ * @IPTS_DATA_TYPE_FRAME:        Raw data frame.
++ * @IPTS_DATA_TYPE_ERROR:        Error data.
++ * @IPTS_DATA_TYPE_VENDOR:       Vendor specific data.
++ * @IPTS_DATA_TYPE_HID:          A HID report.
++ * @IPTS_DATA_TYPE_GET_FEATURES: The response to a GET_FEATURES HID2ME command.
++ */
++enum ipts_data_type {
++	IPTS_DATA_TYPE_FRAME = 0x00,
++	IPTS_DATA_TYPE_ERROR = 0x01,
++	IPTS_DATA_TYPE_VENDOR = 0x02,
++	IPTS_DATA_TYPE_HID = 0x03,
++	IPTS_DATA_TYPE_GET_FEATURES = 0x04,
++	IPTS_DATA_TYPE_DESCRIPTOR = 0x05,
++};
++
++/**
++ * struct ipts_data_header - Header that is prefixed to the data in a data buffer.
++ * @type: What data the buffer contains.
++ * @size: How much data the buffer contains.
++ * @buffer: Which buffer the data is in.
++ */
++struct ipts_data_header {
++	enum ipts_data_type type;
++	u32 size;
++	u32 buffer;
++	u8 reserved[52];
++	u8 data[];
++} __packed;
++
++static_assert(sizeof(struct ipts_data_header) == 64);
++
++#endif /* IPTS_SPEC_DATA_H */
+diff --git a/drivers/hid/ipts/spec-device.h b/drivers/hid/ipts/spec-device.h
+new file mode 100644
+index 000000000..41845f9d9
+--- /dev/null
++++ b/drivers/hid/ipts/spec-device.h
+@@ -0,0 +1,290 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (c) 2016 Intel Corporation
++ * Copyright (c) 2020-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#ifndef IPTS_SPEC_DEVICE_H
++#define IPTS_SPEC_DEVICE_H
++
++#include <linux/build_bug.h>
++#include <linux/types.h>
++
++/*
++ * The amount of buffers that IPTS can use for data transfer.
++ */
++#define IPTS_BUFFERS 16
++
++/*
++ * The buffer ID that is used for HID2ME feedback
++ */
++#define IPTS_HID2ME_BUFFER IPTS_BUFFERS
++
++/**
++ * enum ipts_command - Commands that can be sent to the IPTS hardware.
++ * @IPTS_CMD_GET_DEVICE_INFO:  Retrieves vendor information from the device.
++ * @IPTS_CMD_SET_MODE:         Changes the mode that the device will operate in.
++ * @IPTS_CMD_SET_MEM_WINDOW:   Configures memory buffers for passing data between device and driver.
++ * @IPTS_CMD_QUIESCE_IO:       Stops the data flow from the device to the driver.
++ * @IPTS_CMD_READY_FOR_DATA:   Informs the device that the driver is ready to receive data.
++ * @IPTS_CMD_FEEDBACK:         Informs the device that a buffer was processed and can be refilled.
++ * @IPTS_CMD_CLEAR_MEM_WINDOW: Stops the data flow and clears the buffer addresses on the device.
++ * @IPTS_CMD_RESET_SENSOR:     Resets the sensor to its default state.
++ * @IPTS_CMD_GET_DESCRIPTOR:   Retrieves the HID descriptor of the device.
++ */
++enum ipts_command_code {
++	IPTS_CMD_GET_DEVICE_INFO = 0x01,
++	IPTS_CMD_SET_MODE = 0x02,
++	IPTS_CMD_SET_MEM_WINDOW = 0x03,
++	IPTS_CMD_QUIESCE_IO = 0x04,
++	IPTS_CMD_READY_FOR_DATA = 0x05,
++	IPTS_CMD_FEEDBACK = 0x06,
++	IPTS_CMD_CLEAR_MEM_WINDOW = 0x07,
++	IPTS_CMD_RESET_SENSOR = 0x0B,
++	IPTS_CMD_GET_DESCRIPTOR = 0x0F,
++};
++
++/**
++ * enum ipts_status - Possible status codes returned by the IPTS device.
++ * @IPTS_STATUS_SUCCESS:                 Operation completed successfully.
++ * @IPTS_STATUS_INVALID_PARAMS:          Command contained an invalid payload.
++ * @IPTS_STATUS_ACCESS_DENIED:           ME could not validate a buffer address.
++ * @IPTS_STATUS_CMD_SIZE_ERROR:          Command contains an invalid payload.
++ * @IPTS_STATUS_NOT_READY:               Buffer addresses have not been set.
++ * @IPTS_STATUS_REQUEST_OUTSTANDING:     There is an outstanding command of the same type.
++ * @IPTS_STATUS_NO_SENSOR_FOUND:         No sensor could be found.
++ * @IPTS_STATUS_OUT_OF_MEMORY:           Not enough free memory for requested operation.
++ * @IPTS_STATUS_INTERNAL_ERROR:          An unexpected error occurred.
++ * @IPTS_STATUS_SENSOR_DISABLED:         The sensor has been disabled and must be reinitialized.
++ * @IPTS_STATUS_COMPAT_CHECK_FAIL:       Compatibility revision check between sensor and ME failed.
++ *                                       The host can ignore this error and attempt to continue.
++ * @IPTS_STATUS_SENSOR_EXPECTED_RESET:   The sensor went through a reset initiated by the driver.
++ * @IPTS_STATUS_SENSOR_UNEXPECTED_RESET: The sensor went through an unexpected reset.
++ * @IPTS_STATUS_RESET_FAILED:            Requested sensor reset failed to complete.
++ * @IPTS_STATUS_TIMEOUT:                 The operation timed out.
++ * @IPTS_STATUS_TEST_MODE_FAIL:          Test mode pattern did not match expected values.
++ * @IPTS_STATUS_SENSOR_FAIL_FATAL:       The sensor reported an error during reset sequence.
++ *                                       Further progress is not possible.
++ * @IPTS_STATUS_SENSOR_FAIL_NONFATAL:    The sensor reported an error during reset sequence.
++ *                                       The driver can attempt to continue.
++ * @IPTS_STATUS_INVALID_DEVICE_CAPS:     The device reported invalid capabilities.
++ * @IPTS_STATUS_QUIESCE_IO_IN_PROGRESS:  Command cannot be completed until Quiesce IO is done.
++ */
++enum ipts_status {
++	IPTS_STATUS_SUCCESS = 0x00,
++	IPTS_STATUS_INVALID_PARAMS = 0x01,
++	IPTS_STATUS_ACCESS_DENIED = 0x02,
++	IPTS_STATUS_CMD_SIZE_ERROR = 0x03,
++	IPTS_STATUS_NOT_READY = 0x04,
++	IPTS_STATUS_REQUEST_OUTSTANDING = 0x05,
++	IPTS_STATUS_NO_SENSOR_FOUND = 0x06,
++	IPTS_STATUS_OUT_OF_MEMORY = 0x07,
++	IPTS_STATUS_INTERNAL_ERROR = 0x08,
++	IPTS_STATUS_SENSOR_DISABLED = 0x09,
++	IPTS_STATUS_COMPAT_CHECK_FAIL = 0x0A,
++	IPTS_STATUS_SENSOR_EXPECTED_RESET = 0x0B,
++	IPTS_STATUS_SENSOR_UNEXPECTED_RESET = 0x0C,
++	IPTS_STATUS_RESET_FAILED = 0x0D,
++	IPTS_STATUS_TIMEOUT = 0x0E,
++	IPTS_STATUS_TEST_MODE_FAIL = 0x0F,
++	IPTS_STATUS_SENSOR_FAIL_FATAL = 0x10,
++	IPTS_STATUS_SENSOR_FAIL_NONFATAL = 0x11,
++	IPTS_STATUS_INVALID_DEVICE_CAPS = 0x12,
++	IPTS_STATUS_QUIESCE_IO_IN_PROGRESS = 0x13,
++};
++
++/**
++ * struct ipts_command - Message that is sent to the device for calling a command.
++ * @cmd:     The command that will be called.
++ * @payload: Payload containing parameters for the called command.
++ */
++struct ipts_command {
++	enum ipts_command_code cmd;
++	u8 payload[320];
++} __packed;
++
++static_assert(sizeof(struct ipts_command) == 324);
++
++/**
++ * enum ipts_mode - Configures what data the device produces and how its sent.
++ * @IPTS_MODE_EVENT: The device will send an event once a buffer was filled.
++ *                   Older devices will return singletouch data in this mode.
++ * @IPTS_MODE_POLL:  The device will notify the driver by incrementing the doorbell value.
++ *                   Older devices will return multitouch data in this mode.
++ */
++enum ipts_mode {
++	IPTS_MODE_EVENT = 0x00,
++	IPTS_MODE_POLL = 0x01,
++};
++
++/**
++ * struct ipts_set_mode - Payload for the SET_MODE command.
++ * @mode: Changes the mode that IPTS will operate in.
++ */
++struct ipts_set_mode {
++	enum ipts_mode mode;
++	u8 reserved[12];
++} __packed;
++
++static_assert(sizeof(struct ipts_set_mode) == 16);
++
++#define IPTS_WORKQUEUE_SIZE	 8192
++#define IPTS_WORKQUEUE_ITEM_SIZE 16
++
++/**
++ * struct ipts_mem_window - Payload for the SET_MEM_WINDOW command.
++ * @data_addr_lower:      Lower 32 bits of the data buffer addresses.
++ * @data_addr_upper:      Upper 32 bits of the data buffer addresses.
++ * @workqueue_addr_lower: Lower 32 bits of the workqueue buffer address.
++ * @workqueue_addr_upper: Upper 32 bits of the workqueue buffer address.
++ * @doorbell_addr_lower:  Lower 32 bits of the doorbell buffer address.
++ * @doorbell_addr_upper:  Upper 32 bits of the doorbell buffer address.
++ * @feedbackaddr_lower:   Lower 32 bits of the feedback buffer addresses.
++ * @feedbackaddr_upper:   Upper 32 bits of the feedback buffer addresses.
++ * @hid2me_addr_lower:    Lower 32 bits of the hid2me buffer address.
++ * @hid2me_addr_upper:    Upper 32 bits of the hid2me buffer address.
++ * @hid2me_size:          Size of the hid2me feedback buffer.
++ * @workqueue_item_size:  Magic value. Must be 16.
++ * @workqueue_size:       Magic value. Must be 8192.
++ *
++ * The workqueue related items in this struct are required for using
++ * GuC submission with binary processing firmware. Since this driver does
++ * not use GuC submission and instead exports raw data to userspace, these
++ * items are not actually used, but they need to be allocated and passed
++ * to the device, otherwise initialization will fail.
++ */
++struct ipts_mem_window {
++	u32 data_addr_lower[IPTS_BUFFERS];
++	u32 data_addr_upper[IPTS_BUFFERS];
++	u32 workqueue_addr_lower;
++	u32 workqueue_addr_upper;
++	u32 doorbell_addr_lower;
++	u32 doorbell_addr_upper;
++	u32 feedback_addr_lower[IPTS_BUFFERS];
++	u32 feedback_addr_upper[IPTS_BUFFERS];
++	u32 hid2me_addr_lower;
++	u32 hid2me_addr_upper;
++	u32 hid2me_size;
++	u8 reserved1;
++	u8 workqueue_item_size;
++	u16 workqueue_size;
++	u8 reserved[32];
++} __packed;
++
++static_assert(sizeof(struct ipts_mem_window) == 320);
++
++/**
++ * struct ipts_quiesce_io - Payload for the QUIESCE_IO command.
++ */
++struct ipts_quiesce_io {
++	u8 reserved[12];
++} __packed;
++
++static_assert(sizeof(struct ipts_quiesce_io) == 12);
++
++/**
++ * struct ipts_feedback - Payload for the FEEDBACK command.
++ * @buffer: The buffer that the device should refill.
++ */
++struct ipts_feedback {
++	u32 buffer;
++	u8 reserved[12];
++} __packed;
++
++static_assert(sizeof(struct ipts_feedback) == 16);
++
++/**
++ * enum ipts_reset_type - Possible ways of resetting the device.
++ * @IPTS_RESET_TYPE_HARD: Perform hardware reset using GPIO pin.
++ * @IPTS_RESET_TYPE_SOFT: Perform software reset using SPI command.
++ */
++enum ipts_reset_type {
++	IPTS_RESET_TYPE_HARD = 0x00,
++	IPTS_RESET_TYPE_SOFT = 0x01,
++};
++
++/**
++ * struct ipts_reset - Payload for the RESET_SENSOR command.
++ * @type: How the device should get reset.
++ */
++struct ipts_reset_sensor {
++	enum ipts_reset_type type;
++	u8 reserved[4];
++} __packed;
++
++static_assert(sizeof(struct ipts_reset_sensor) == 8);
++
++/**
++ * struct ipts_get_descriptor - Payload for the GET_DESCRIPTOR command.
++ * @addr_lower: The lower 32 bits of the descriptor buffer address.
++ * @addr_upper: The upper 32 bits of the descriptor buffer address.
++ * @magic:      A magic value. Must be 8.
++ */
++struct ipts_get_descriptor {
++	u32 addr_lower;
++	u32 addr_upper;
++	u32 magic;
++	u8 reserved[12];
++} __packed;
++
++static_assert(sizeof(struct ipts_get_descriptor) == 24);
++
++/*
++ * The type of a response is indicated by a
++ * command code, with the most significant bit flipped to 1.
++ */
++#define IPTS_RSP_BIT BIT(31)
++
++/**
++ * struct ipts_response - Data returned from the device in response to a command.
++ * @cmd:     The command that this response answers (IPTS_RSP_BIT will be 1).
++ * @status:  The return code of the command.
++ * @payload: The data that was produced by the command.
++ */
++struct ipts_response {
++	enum ipts_command_code cmd;
++	enum ipts_status status;
++	u8 payload[80];
++} __packed;
++
++static_assert(sizeof(struct ipts_response) == 88);
++
++/**
++ * struct ipts_device_info - Vendor information of the IPTS device.
++ * @vendor:         Vendor ID of this device.
++ * @product:        Product ID of this device.
++ * @hw_version:     Hardware revision of this device.
++ * @fw_version:     Firmware revision of this device.
++ * @data_size:      Requested size for a data buffer.
++ * @feedback_size:  Requested size for a feedback buffer.
++ * @mode:           Mode that the device currently operates in.
++ * @max_contacts:   Maximum amount of concurrent touches the sensor can process.
++ * @sensor_min_eds: The minimum EDS version supported by the sensor.
++ * @sensor_max_eds: The maximum EDS version supported by the sensor.
++ * @me_min_eds:     The minimum EDS version supported by the ME for communicating with the sensor.
++ * @me_max_eds:     The maximum EDS version supported by the ME for communicating with the sensor.
++ * @intf_eds:       The EDS version implemented by the interface between ME and host.
++ */
++struct ipts_device_info {
++	u16 vendor;
++	u16 product;
++	u32 hw_version;
++	u32 fw_version;
++	u32 data_size;
++	u32 feedback_size;
++	enum ipts_mode mode;
++	u8 max_contacts;
++	u8 reserved1[3];
++	u8 sensor_min_eds;
++	u8 sensor_maj_eds;
++	u8 me_min_eds;
++	u8 me_maj_eds;
++	u8 intf_eds;
++	u8 reserved2[11];
++} __packed;
++
++static_assert(sizeof(struct ipts_device_info) == 44);
++
++#endif /* IPTS_SPEC_DEVICE_H */
+diff --git a/drivers/hid/ipts/spec-hid.h b/drivers/hid/ipts/spec-hid.h
+new file mode 100644
+index 000000000..5a58d4a0a
+--- /dev/null
++++ b/drivers/hid/ipts/spec-hid.h
+@@ -0,0 +1,34 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (c) 2020-2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#ifndef IPTS_SPEC_HID_H
++#define IPTS_SPEC_HID_H
++
++#include <linux/build_bug.h>
++#include <linux/types.h>
++
++/*
++ * Made-up type for passing raw IPTS data in a HID report.
++ */
++#define IPTS_HID_FRAME_TYPE_RAW 0xEE
++
++/**
++ * struct ipts_hid_frame - Header that is prefixed to raw IPTS data wrapped in a HID report.
++ * @size: Size of the data inside the report, including this header.
++ * @type: What type of data does this report contain.
++ */
++struct ipts_hid_header {
++	u32 size;
++	u8 reserved1;
++	u8 type;
++	u8 reserved2;
++	u8 data[];
++} __packed;
++
++static_assert(sizeof(struct ipts_hid_header) == 7);
++
++#endif /* IPTS_SPEC_HID_H */
+diff --git a/drivers/hid/ipts/thread.c b/drivers/hid/ipts/thread.c
+new file mode 100644
+index 000000000..355e92bea
+--- /dev/null
++++ b/drivers/hid/ipts/thread.c
+@@ -0,0 +1,84 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (c) 2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#include <linux/completion.h>
++#include <linux/err.h>
++#include <linux/kthread.h>
++#include <linux/mutex.h>
++
++#include "thread.h"
++
++bool ipts_thread_should_stop(struct ipts_thread *thread)
++{
++	if (!thread)
++		return false;
++
++	return READ_ONCE(thread->should_stop);
++}
++
++static int ipts_thread_runner(void *data)
++{
++	int ret = 0;
++	struct ipts_thread *thread = data;
++
++	if (!thread)
++		return -EFAULT;
++
++	if (!thread->threadfn)
++		return -EFAULT;
++
++	ret = thread->threadfn(thread);
++	complete_all(&thread->done);
++
++	return ret;
++}
++
++int ipts_thread_start(struct ipts_thread *thread, int (*threadfn)(struct ipts_thread *thread),
++		      void *data, const char *name)
++{
++	if (!thread)
++		return -EFAULT;
++
++	if (!threadfn)
++		return -EFAULT;
++
++	init_completion(&thread->done);
++
++	thread->data = data;
++	thread->should_stop = false;
++	thread->threadfn = threadfn;
++
++	thread->thread = kthread_run(ipts_thread_runner, thread, name);
++	return PTR_ERR_OR_ZERO(thread->thread);
++}
++
++int ipts_thread_stop(struct ipts_thread *thread)
++{
++	int ret = 0;
++
++	if (!thread)
++		return -EFAULT;
++
++	if (!thread->thread)
++		return 0;
++
++	WRITE_ONCE(thread->should_stop, true);
++
++	/*
++	 * Make sure that the write has gone through before waiting.
++	 */
++	wmb();
++
++	wait_for_completion(&thread->done);
++	ret = kthread_stop(thread->thread);
++
++	thread->thread = NULL;
++	thread->data = NULL;
++	thread->threadfn = NULL;
++
++	return ret;
++}
+diff --git a/drivers/hid/ipts/thread.h b/drivers/hid/ipts/thread.h
+new file mode 100644
+index 000000000..1f966b8b3
+--- /dev/null
++++ b/drivers/hid/ipts/thread.h
+@@ -0,0 +1,59 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (c) 2023 Dorian Stoll
++ *
++ * Linux driver for Intel Precise Touch & Stylus
++ */
++
++#ifndef IPTS_THREAD_H
++#define IPTS_THREAD_H
++
++#include <linux/completion.h>
++#include <linux/mutex.h>
++#include <linux/sched.h>
++
++/*
++ * This wrapper over kthread is necessary, because calling kthread_stop makes it impossible
++ * to issue MEI commands from that thread while it shuts itself down. By using a custom
++ * boolean variable and a completion object, we can call kthread_stop only when the thread
++ * already finished all of its work and has returned.
++ */
++struct ipts_thread {
++	struct task_struct *thread;
++
++	bool should_stop;
++	struct completion done;
++
++	void *data;
++	int (*threadfn)(struct ipts_thread *thread);
++};
++
++/**
++ * ipts_thread_should_stop() - Returns true if the thread is asked to terminate.
++ * @thread: The current thread.
++ *
++ * Returns: true if the thread should stop, false if not.
++ */
++bool ipts_thread_should_stop(struct ipts_thread *thread);
++
++/**
++ * ipts_thread_start() - Starts an IPTS thread.
++ * @thread: The thread to initialize and start.
++ * @threadfn: The function to execute.
++ * @data: An argument that will be passed to threadfn.
++ * @name: The name of the new thread.
++ *
++ * Returns: 0 on success, <0 on error.
++ */
++int ipts_thread_start(struct ipts_thread *thread, int (*threadfn)(struct ipts_thread *thread),
++		      void *data, const char name[]);
++
++/**
++ * ipts_thread_stop() - Asks the thread to terminate and waits until it has finished.
++ * @thread: The thread that should stop.
++ *
++ * Returns: The return value of the thread function.
++ */
++int ipts_thread_stop(struct ipts_thread *thread);
++
++#endif /* IPTS_THREAD_H */
+-- 
+2.53.0
+

--- a/patches/7.0/0006-ithc.patch
+++ b/patches/7.0/0006-ithc.patch
@@ -1,0 +1,2780 @@
+From 55e86797e434d35ad49d5fc5ffbc8c17f4bc1404 Mon Sep 17 00:00:00 2001
+From: Dorian Stoll <dorian.stoll@tmsp.io>
+Date: Sun, 11 Dec 2022 12:03:38 +0100
+Subject: [PATCH] iommu: intel: Disable source id verification for ITHC
+
+Signed-off-by: Dorian Stoll <dorian.stoll@tmsp.io>
+Patchset: ithc
+---
+ drivers/iommu/intel/irq_remapping.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/drivers/iommu/intel/irq_remapping.c b/drivers/iommu/intel/irq_remapping.c
+index 8bcbfe3d9..c78806d35 100644
+--- a/drivers/iommu/intel/irq_remapping.c
++++ b/drivers/iommu/intel/irq_remapping.c
+@@ -381,6 +381,22 @@ static int set_msi_sid(struct irte *irte, struct pci_dev *dev)
+ 	data.busmatch_count = 0;
+ 	pci_for_each_dma_alias(dev, set_msi_sid_cb, &data);
+ 
++	/*
++	 * The Intel Touch Host Controller is at 00:10.6, but for some reason
++	 * the MSI interrupts have request id 01:05.0.
++	 * Disable id verification to work around this.
++	 * FIXME Find proper fix or turn this into a quirk.
++	 */
++	if (dev->vendor == PCI_VENDOR_ID_INTEL && (dev->class >> 8) == PCI_CLASS_INPUT_PEN) {
++		switch(dev->device) {
++		case 0x98d0: case 0x98d1: // LKF
++		case 0xa0d0: case 0xa0d1: // TGL LP
++		case 0x43d0: case 0x43d1: // TGL H
++			set_irte_sid(irte, SVT_NO_VERIFY, SQ_ALL_16, 0);
++			return 0;
++		}
++	}
++
+ 	/*
+ 	 * DMA alias provides us with a PCI device and alias.  The only case
+ 	 * where the it will return an alias on a different bus than the
+-- 
+2.53.0
+
+From 1cf2103b5e8668521b74da4136e06ee5a17144f3 Mon Sep 17 00:00:00 2001
+From: quo <tuple@list.ru>
+Date: Sun, 11 Dec 2022 12:10:54 +0100
+Subject: [PATCH] hid: Add support for Intel Touch Host Controller
+
+Based on quo/ithc-linux@34539af4726d.
+
+Signed-off-by: Maximilian Stoll <luzmaximilian@gmail.com>
+Patchset: ithc
+---
+ drivers/hid/Kconfig              |   2 +
+ drivers/hid/Makefile             |   1 +
+ drivers/hid/ithc/Kbuild          |   6 +
+ drivers/hid/ithc/Kconfig         |  12 +
+ drivers/hid/ithc/ithc-debug.c    | 149 ++++++++
+ drivers/hid/ithc/ithc-debug.h    |   7 +
+ drivers/hid/ithc/ithc-dma.c      | 312 ++++++++++++++++
+ drivers/hid/ithc/ithc-dma.h      |  47 +++
+ drivers/hid/ithc/ithc-hid.c      | 207 +++++++++++
+ drivers/hid/ithc/ithc-hid.h      |  32 ++
+ drivers/hid/ithc/ithc-legacy.c   | 254 +++++++++++++
+ drivers/hid/ithc/ithc-legacy.h   |   8 +
+ drivers/hid/ithc/ithc-main.c     | 438 ++++++++++++++++++++++
+ drivers/hid/ithc/ithc-quickspi.c | 607 +++++++++++++++++++++++++++++++
+ drivers/hid/ithc/ithc-quickspi.h |  39 ++
+ drivers/hid/ithc/ithc-regs.c     | 154 ++++++++
+ drivers/hid/ithc/ithc-regs.h     | 211 +++++++++++
+ drivers/hid/ithc/ithc.h          |  89 +++++
+ 18 files changed, 2575 insertions(+)
+ create mode 100644 drivers/hid/ithc/Kbuild
+ create mode 100644 drivers/hid/ithc/Kconfig
+ create mode 100644 drivers/hid/ithc/ithc-debug.c
+ create mode 100644 drivers/hid/ithc/ithc-debug.h
+ create mode 100644 drivers/hid/ithc/ithc-dma.c
+ create mode 100644 drivers/hid/ithc/ithc-dma.h
+ create mode 100644 drivers/hid/ithc/ithc-hid.c
+ create mode 100644 drivers/hid/ithc/ithc-hid.h
+ create mode 100644 drivers/hid/ithc/ithc-legacy.c
+ create mode 100644 drivers/hid/ithc/ithc-legacy.h
+ create mode 100644 drivers/hid/ithc/ithc-main.c
+ create mode 100644 drivers/hid/ithc/ithc-quickspi.c
+ create mode 100644 drivers/hid/ithc/ithc-quickspi.h
+ create mode 100644 drivers/hid/ithc/ithc-regs.c
+ create mode 100644 drivers/hid/ithc/ithc-regs.h
+ create mode 100644 drivers/hid/ithc/ithc.h
+
+diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
+index 5d41410ac..fb65f49b5 100644
+--- a/drivers/hid/Kconfig
++++ b/drivers/hid/Kconfig
+@@ -1445,6 +1445,8 @@ source "drivers/hid/intel-thc-hid/Kconfig"
+ 
+ source "drivers/hid/ipts/Kconfig"
+ 
++source "drivers/hid/ithc/Kconfig"
++
+ endif # HID
+ 
+ # USB support may be used with HID disabled
+diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
+index b73a1bbd3..3190ece25 100644
+--- a/drivers/hid/Makefile
++++ b/drivers/hid/Makefile
+@@ -178,3 +178,4 @@ obj-$(CONFIG_SURFACE_HID_CORE)  += surface-hid/
+ obj-$(CONFIG_INTEL_THC_HID)     += intel-thc-hid/
+ 
+ obj-$(CONFIG_HID_IPTS)          += ipts/
++obj-$(CONFIG_HID_ITHC)          += ithc/
+diff --git a/drivers/hid/ithc/Kbuild b/drivers/hid/ithc/Kbuild
+new file mode 100644
+index 000000000..4937ba131
+--- /dev/null
++++ b/drivers/hid/ithc/Kbuild
+@@ -0,0 +1,6 @@
++obj-$(CONFIG_HID_ITHC) := ithc.o
++
++ithc-objs := ithc-main.o ithc-regs.o ithc-dma.o ithc-hid.o ithc-legacy.o ithc-quickspi.o ithc-debug.o
++
++ccflags-y := -std=gnu11 -Wno-declaration-after-statement
++
+diff --git a/drivers/hid/ithc/Kconfig b/drivers/hid/ithc/Kconfig
+new file mode 100644
+index 000000000..ede713023
+--- /dev/null
++++ b/drivers/hid/ithc/Kconfig
+@@ -0,0 +1,12 @@
++config HID_ITHC
++	tristate "Intel Touch Host Controller"
++	depends on PCI
++	depends on HID
++	help
++	  Say Y here if your system has a touchscreen using Intels
++	  Touch Host Controller (ITHC / IPTS) technology.
++
++	  If unsure say N.
++
++	  To compile this driver as a module, choose M here: the
++	  module will be called ithc.
+diff --git a/drivers/hid/ithc/ithc-debug.c b/drivers/hid/ithc/ithc-debug.c
+new file mode 100644
+index 000000000..2d8c6afe9
+--- /dev/null
++++ b/drivers/hid/ithc/ithc-debug.c
+@@ -0,0 +1,149 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
++
++#include "ithc.h"
++
++void ithc_log_regs(struct ithc *ithc)
++{
++	if (!ithc->prev_regs)
++		return;
++	u32 __iomem *cur = (__iomem void *)ithc->regs;
++	u32 *prev = (void *)ithc->prev_regs;
++	for (int i = 1024; i < sizeof(*ithc->regs) / 4; i++) {
++		u32 x = readl(cur + i);
++		if (x != prev[i]) {
++			pci_info(ithc->pci, "reg %04x: %08x -> %08x\n", i * 4, prev[i], x);
++			prev[i] = x;
++		}
++	}
++}
++
++static ssize_t ithc_debugfs_cmd_write(struct file *f, const char __user *buf, size_t len,
++	loff_t *offset)
++{
++	// Debug commands consist of a single letter followed by a list of numbers (decimal or
++	// hexadecimal, space-separated).
++	struct ithc *ithc = file_inode(f)->i_private;
++	char cmd[256];
++	if (!ithc || !ithc->pci)
++		return -ENODEV;
++	if (!len)
++		return -EINVAL;
++	if (len >= sizeof(cmd))
++		return -EINVAL;
++	if (copy_from_user(cmd, buf, len))
++		return -EFAULT;
++	cmd[len] = 0;
++	if (cmd[len-1] == '\n')
++		cmd[len-1] = 0;
++	pci_info(ithc->pci, "debug command: %s\n", cmd);
++
++	// Parse the list of arguments into a u32 array.
++	u32 n = 0;
++	const char *s = cmd + 1;
++	u32 a[32];
++	while (*s && *s != '\n') {
++		if (n >= ARRAY_SIZE(a))
++			return -EINVAL;
++		if (*s++ != ' ')
++			return -EINVAL;
++		char *e;
++		a[n++] = simple_strtoul(s, &e, 0);
++		if (e == s)
++			return -EINVAL;
++		s = e;
++	}
++	ithc_log_regs(ithc);
++
++	// Execute the command.
++	switch (cmd[0]) {
++	case 'x': // reset
++		ithc_reset(ithc);
++		break;
++	case 'w': // write register: offset mask value
++		if (n != 3 || (a[0] & 3))
++			return -EINVAL;
++		pci_info(ithc->pci, "debug write 0x%04x = 0x%08x (mask 0x%08x)\n",
++			a[0], a[2], a[1]);
++		bitsl(((__iomem u32 *)ithc->regs) + a[0] / 4, a[1], a[2]);
++		break;
++	case 'r': // read register: offset
++		if (n != 1 || (a[0] & 3))
++			return -EINVAL;
++		pci_info(ithc->pci, "debug read 0x%04x = 0x%08x\n", a[0],
++			readl(((__iomem u32 *)ithc->regs) + a[0] / 4));
++		break;
++	case 's': // spi command: cmd offset len data...
++		// read config: s 4 0 64 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
++		// set touch cfg: s 6 12 4 XX
++		if (n < 3 || a[2] > (n - 3) * 4)
++			return -EINVAL;
++		pci_info(ithc->pci, "debug spi command %u with %u bytes of data\n", a[0], a[2]);
++		if (!CHECK(ithc_spi_command, ithc, a[0], a[1], a[2], a + 3))
++			for (u32 i = 0; i < (a[2] + 3) / 4; i++)
++				pci_info(ithc->pci, "resp %u = 0x%08x\n", i, a[3+i]);
++		break;
++	case 'd': // dma command: cmd len data...
++		// get report descriptor: d 7 8 0 0
++		// enable multitouch: d 3 2 0x0105
++		if (n < 1)
++			return -EINVAL;
++		pci_info(ithc->pci, "debug dma command with %u bytes of data\n", n * 4);
++		struct ithc_data data = { .type = ITHC_DATA_RAW, .size = n * 4, .data = a };
++		if (ithc_dma_tx(ithc, &data))
++			pci_err(ithc->pci, "dma tx failed\n");
++		break;
++	default:
++		return -EINVAL;
++	}
++	ithc_log_regs(ithc);
++	return len;
++}
++
++static struct dentry *dbg_dir;
++
++void __init ithc_debug_init_module(void)
++{
++	struct dentry *d = debugfs_create_dir(DEVNAME, NULL);
++	if (IS_ERR(d))
++		pr_warn("failed to create debugfs dir (%li)\n", PTR_ERR(d));
++	else
++		dbg_dir = d;
++}
++
++void __exit ithc_debug_exit_module(void)
++{
++	debugfs_remove_recursive(dbg_dir);
++	dbg_dir = NULL;
++}
++
++static const struct file_operations ithc_debugfops_cmd = {
++	.owner = THIS_MODULE,
++	.write = ithc_debugfs_cmd_write,
++};
++
++static void ithc_debugfs_devres_release(struct device *dev, void *res)
++{
++	struct dentry **dbgm = res;
++	debugfs_remove_recursive(*dbgm);
++}
++
++int ithc_debug_init_device(struct ithc *ithc)
++{
++	if (!dbg_dir)
++		return -ENOENT;
++	struct dentry **dbgm = devres_alloc(ithc_debugfs_devres_release, sizeof(*dbgm), GFP_KERNEL);
++	if (!dbgm)
++		return -ENOMEM;
++	devres_add(&ithc->pci->dev, dbgm);
++	struct dentry *dbg = debugfs_create_dir(pci_name(ithc->pci), dbg_dir);
++	if (IS_ERR(dbg))
++		return PTR_ERR(dbg);
++	*dbgm = dbg;
++
++	struct dentry *cmd = debugfs_create_file("cmd", 0220, dbg, ithc, &ithc_debugfops_cmd);
++	if (IS_ERR(cmd))
++		return PTR_ERR(cmd);
++
++	return 0;
++}
++
+diff --git a/drivers/hid/ithc/ithc-debug.h b/drivers/hid/ithc/ithc-debug.h
+new file mode 100644
+index 000000000..38c53d916
+--- /dev/null
++++ b/drivers/hid/ithc/ithc-debug.h
+@@ -0,0 +1,7 @@
++/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
++
++void ithc_debug_init_module(void);
++void ithc_debug_exit_module(void);
++int ithc_debug_init_device(struct ithc *ithc);
++void ithc_log_regs(struct ithc *ithc);
++
+diff --git a/drivers/hid/ithc/ithc-dma.c b/drivers/hid/ithc/ithc-dma.c
+new file mode 100644
+index 000000000..bf4eab330
+--- /dev/null
++++ b/drivers/hid/ithc/ithc-dma.c
+@@ -0,0 +1,312 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
++
++#include "ithc.h"
++
++// The THC uses tables of PRDs (physical region descriptors) to describe the TX and RX data buffers.
++// Each PRD contains the DMA address and size of a block of DMA memory, and some status flags.
++// This allows each data buffer to consist of multiple non-contiguous blocks of memory.
++
++static int ithc_dma_prd_alloc(struct ithc *ithc, struct ithc_dma_prd_buffer *p,
++	unsigned int num_buffers, unsigned int num_pages, enum dma_data_direction dir)
++{
++	p->num_pages = num_pages;
++	p->dir = dir;
++	// We allocate enough space to have one PRD per data buffer page, however if the data
++	// buffer pages happen to be contiguous, we can describe the buffer using fewer PRDs, so
++	// some will remain unused (which is fine).
++	p->size = round_up(num_buffers * num_pages * sizeof(struct ithc_phys_region_desc), PAGE_SIZE);
++	p->addr = dmam_alloc_coherent(&ithc->pci->dev, p->size, &p->dma_addr, GFP_KERNEL);
++	if (!p->addr)
++		return -ENOMEM;
++	if (p->dma_addr & (PAGE_SIZE - 1))
++		return -EFAULT;
++	return 0;
++}
++
++// Devres managed sg_table wrapper.
++struct ithc_sg_table {
++	void *addr;
++	struct sg_table sgt;
++	enum dma_data_direction dir;
++};
++static void ithc_dma_sgtable_free(struct sg_table *sgt)
++{
++	struct scatterlist *sg;
++	int i;
++	for_each_sgtable_sg(sgt, sg, i) {
++		struct page *p = sg_page(sg);
++		if (p)
++			__free_page(p);
++	}
++	sg_free_table(sgt);
++}
++static void ithc_dma_data_devres_release(struct device *dev, void *res)
++{
++	struct ithc_sg_table *sgt = res;
++	if (sgt->addr)
++		vunmap(sgt->addr);
++	dma_unmap_sgtable(dev, &sgt->sgt, sgt->dir, 0);
++	ithc_dma_sgtable_free(&sgt->sgt);
++}
++
++static int ithc_dma_data_alloc(struct ithc *ithc, struct ithc_dma_prd_buffer *prds,
++	struct ithc_dma_data_buffer *b)
++{
++	// We don't use dma_alloc_coherent() for data buffers, because they don't have to be
++	// coherent (they are unidirectional) or contiguous (we can use one PRD per page).
++	// We could use dma_alloc_noncontiguous(), however this still always allocates a single
++	// DMA mapped segment, which is more restrictive than what we need.
++	// Instead we use an sg_table of individually allocated pages.
++	struct page *pages[16];
++	if (prds->num_pages == 0 || prds->num_pages > ARRAY_SIZE(pages))
++		return -EINVAL;
++	b->active_idx = -1;
++	struct ithc_sg_table *sgt = devres_alloc(
++		ithc_dma_data_devres_release, sizeof(*sgt), GFP_KERNEL);
++	if (!sgt)
++		return -ENOMEM;
++	sgt->dir = prds->dir;
++
++	if (!sg_alloc_table(&sgt->sgt, prds->num_pages, GFP_KERNEL)) {
++		struct scatterlist *sg;
++		int i;
++		bool ok = true;
++		for_each_sgtable_sg(&sgt->sgt, sg, i) {
++			// NOTE: don't need __GFP_DMA for PCI DMA
++			struct page *p = pages[i] = alloc_page(GFP_KERNEL | __GFP_ZERO);
++			if (!p) {
++				ok = false;
++				break;
++			}
++			sg_set_page(sg, p, PAGE_SIZE, 0);
++		}
++		if (ok && !dma_map_sgtable(&ithc->pci->dev, &sgt->sgt, prds->dir, 0)) {
++			devres_add(&ithc->pci->dev, sgt);
++			b->sgt = &sgt->sgt;
++			b->addr = sgt->addr = vmap(pages, prds->num_pages, 0, PAGE_KERNEL);
++			if (!b->addr)
++				return -ENOMEM;
++			return 0;
++		}
++		ithc_dma_sgtable_free(&sgt->sgt);
++	}
++	devres_free(sgt);
++	return -ENOMEM;
++}
++
++static int ithc_dma_data_buffer_put(struct ithc *ithc, struct ithc_dma_prd_buffer *prds,
++	struct ithc_dma_data_buffer *b, unsigned int idx)
++{
++	// Give a buffer to the THC.
++	struct ithc_phys_region_desc *prd = prds->addr;
++	prd += idx * prds->num_pages;
++	if (b->active_idx >= 0) {
++		pci_err(ithc->pci, "buffer already active\n");
++		return -EINVAL;
++	}
++	b->active_idx = idx;
++	if (prds->dir == DMA_TO_DEVICE) {
++		// TX buffer: Caller should have already filled the data buffer, so just fill
++		// the PRD and flush.
++		// (TODO: Support multi-page TX buffers. So far no device seems to use or need
++		// these though.)
++		if (b->data_size > PAGE_SIZE)
++			return -EINVAL;
++		prd->addr = sg_dma_address(b->sgt->sgl) >> 10;
++		prd->size = b->data_size | PRD_FLAG_END;
++		flush_kernel_vmap_range(b->addr, b->data_size);
++	} else if (prds->dir == DMA_FROM_DEVICE) {
++		// RX buffer: Reset PRDs.
++		struct scatterlist *sg;
++		int i;
++		for_each_sgtable_dma_sg(b->sgt, sg, i) {
++			prd->addr = sg_dma_address(sg) >> 10;
++			prd->size = sg_dma_len(sg);
++			prd++;
++		}
++		prd[-1].size |= PRD_FLAG_END;
++	}
++	dma_wmb(); // for the prds
++	dma_sync_sgtable_for_device(&ithc->pci->dev, b->sgt, prds->dir);
++	return 0;
++}
++
++static int ithc_dma_data_buffer_get(struct ithc *ithc, struct ithc_dma_prd_buffer *prds,
++	struct ithc_dma_data_buffer *b, unsigned int idx)
++{
++	// Take a buffer from the THC.
++	struct ithc_phys_region_desc *prd = prds->addr;
++	prd += idx * prds->num_pages;
++	// This is purely a sanity check. We don't strictly need the idx parameter for this
++	// function, because it should always be the same as active_idx, unless we have a bug.
++	if (b->active_idx != idx) {
++		pci_err(ithc->pci, "wrong buffer index\n");
++		return -EINVAL;
++	}
++	b->active_idx = -1;
++	if (prds->dir == DMA_FROM_DEVICE) {
++		// RX buffer: Calculate actual received data size from PRDs.
++		dma_rmb(); // for the prds
++		b->data_size = 0;
++		struct scatterlist *sg;
++		int i;
++		for_each_sgtable_dma_sg(b->sgt, sg, i) {
++			unsigned int size = prd->size;
++			b->data_size += size & PRD_SIZE_MASK;
++			if (size & PRD_FLAG_END)
++				break;
++			if ((size & PRD_SIZE_MASK) != sg_dma_len(sg)) {
++				pci_err(ithc->pci, "truncated prd\n");
++				break;
++			}
++			prd++;
++		}
++		invalidate_kernel_vmap_range(b->addr, b->data_size);
++	}
++	dma_sync_sgtable_for_cpu(&ithc->pci->dev, b->sgt, prds->dir);
++	return 0;
++}
++
++int ithc_dma_rx_init(struct ithc *ithc, u8 channel)
++{
++	struct ithc_dma_rx *rx = &ithc->dma_rx[channel];
++	mutex_init(&rx->mutex);
++
++	// Allocate buffers.
++	unsigned int num_pages = (ithc->max_rx_size + PAGE_SIZE - 1) / PAGE_SIZE;
++	pci_dbg(ithc->pci, "allocating rx buffers: num = %u, size = %u, pages = %u\n",
++		NUM_RX_BUF, ithc->max_rx_size, num_pages);
++	CHECK_RET(ithc_dma_prd_alloc, ithc, &rx->prds, NUM_RX_BUF, num_pages, DMA_FROM_DEVICE);
++	for (unsigned int i = 0; i < NUM_RX_BUF; i++)
++		CHECK_RET(ithc_dma_data_alloc, ithc, &rx->prds, &rx->bufs[i]);
++
++	// Init registers.
++	writeb(DMA_RX_CONTROL2_RESET, &ithc->regs->dma_rx[channel].control2);
++	lo_hi_writeq(rx->prds.dma_addr, &ithc->regs->dma_rx[channel].addr);
++	writeb(NUM_RX_BUF - 1, &ithc->regs->dma_rx[channel].num_bufs);
++	writeb(num_pages - 1, &ithc->regs->dma_rx[channel].num_prds);
++	u8 head = readb(&ithc->regs->dma_rx[channel].head);
++	if (head) {
++		pci_err(ithc->pci, "head is nonzero (%u)\n", head);
++		return -EIO;
++	}
++
++	// Init buffers.
++	for (unsigned int i = 0; i < NUM_RX_BUF; i++)
++		CHECK_RET(ithc_dma_data_buffer_put, ithc, &rx->prds, &rx->bufs[i], i);
++
++	writeb(head ^ DMA_RX_WRAP_FLAG, &ithc->regs->dma_rx[channel].tail);
++	return 0;
++}
++
++void ithc_dma_rx_enable(struct ithc *ithc, u8 channel)
++{
++	bitsb_set(&ithc->regs->dma_rx[channel].control,
++		DMA_RX_CONTROL_ENABLE | DMA_RX_CONTROL_IRQ_ERROR | DMA_RX_CONTROL_IRQ_DATA);
++	CHECK(waitl, ithc, &ithc->regs->dma_rx[channel].status,
++		DMA_RX_STATUS_ENABLED, DMA_RX_STATUS_ENABLED);
++}
++
++int ithc_dma_tx_init(struct ithc *ithc)
++{
++	struct ithc_dma_tx *tx = &ithc->dma_tx;
++	mutex_init(&tx->mutex);
++
++	// Allocate buffers.
++	unsigned int num_pages = (ithc->max_tx_size + PAGE_SIZE - 1) / PAGE_SIZE;
++	pci_dbg(ithc->pci, "allocating tx buffers: size = %u, pages = %u\n",
++		ithc->max_tx_size, num_pages);
++	CHECK_RET(ithc_dma_prd_alloc, ithc, &tx->prds, 1, num_pages, DMA_TO_DEVICE);
++	CHECK_RET(ithc_dma_data_alloc, ithc, &tx->prds, &tx->buf);
++
++	// Init registers.
++	lo_hi_writeq(tx->prds.dma_addr, &ithc->regs->dma_tx.addr);
++	writeb(num_pages - 1, &ithc->regs->dma_tx.num_prds);
++
++	// Init buffers.
++	CHECK_RET(ithc_dma_data_buffer_put, ithc, &ithc->dma_tx.prds, &ithc->dma_tx.buf, 0);
++	return 0;
++}
++
++static int ithc_dma_rx_unlocked(struct ithc *ithc, u8 channel)
++{
++	// Process all filled RX buffers from the ringbuffer.
++	struct ithc_dma_rx *rx = &ithc->dma_rx[channel];
++	unsigned int n = rx->num_received;
++	u8 head_wrap = readb(&ithc->regs->dma_rx[channel].head);
++	while (1) {
++		u8 tail = n % NUM_RX_BUF;
++		u8 tail_wrap = tail | ((n / NUM_RX_BUF) & 1 ? 0 : DMA_RX_WRAP_FLAG);
++		writeb(tail_wrap, &ithc->regs->dma_rx[channel].tail);
++		// ringbuffer is full if tail_wrap == head_wrap
++		// ringbuffer is empty if tail_wrap == head_wrap ^ WRAP_FLAG
++		if (tail_wrap == (head_wrap ^ DMA_RX_WRAP_FLAG))
++			return 0;
++
++		// take the buffer that the device just filled
++		struct ithc_dma_data_buffer *b = &rx->bufs[n % NUM_RX_BUF];
++		CHECK_RET(ithc_dma_data_buffer_get, ithc, &rx->prds, b, tail);
++		rx->num_received = ++n;
++
++		// process data
++		struct ithc_data d;
++		if ((ithc->use_quickspi ? ithc_quickspi_decode_rx : ithc_legacy_decode_rx)
++			(ithc, b->addr, b->data_size, &d) < 0) {
++			pci_err(ithc->pci, "invalid dma rx data! channel %u, buffer %u, size %u: %*ph\n",
++				channel, tail, b->data_size, min((int)b->data_size, 64), b->addr);
++			print_hex_dump_debug(DEVNAME " data: ", DUMP_PREFIX_OFFSET, 32, 1,
++				b->addr, min(b->data_size, 0x400u), 0);
++		} else {
++			ithc_hid_process_data(ithc, &d);
++		}
++
++		// give the buffer back to the device
++		CHECK_RET(ithc_dma_data_buffer_put, ithc, &rx->prds, b, tail);
++	}
++}
++int ithc_dma_rx(struct ithc *ithc, u8 channel)
++{
++	struct ithc_dma_rx *rx = &ithc->dma_rx[channel];
++	mutex_lock(&rx->mutex);
++	int ret = ithc_dma_rx_unlocked(ithc, channel);
++	mutex_unlock(&rx->mutex);
++	return ret;
++}
++
++static int ithc_dma_tx_unlocked(struct ithc *ithc, const struct ithc_data *data)
++{
++	// Send a single TX buffer to the THC.
++	pci_dbg(ithc->pci, "dma tx data type %u, size %u\n", data->type, data->size);
++	CHECK_RET(ithc_dma_data_buffer_get, ithc, &ithc->dma_tx.prds, &ithc->dma_tx.buf, 0);
++
++	// Fill the TX buffer with header and data.
++	ssize_t sz;
++	if (data->type == ITHC_DATA_RAW) {
++		sz = min(data->size, ithc->max_tx_size);
++		memcpy(ithc->dma_tx.buf.addr, data->data, sz);
++	} else {
++		sz = (ithc->use_quickspi ? ithc_quickspi_encode_tx : ithc_legacy_encode_tx)
++			(ithc, data, ithc->dma_tx.buf.addr, ithc->max_tx_size);
++	}
++	ithc->dma_tx.buf.data_size = sz < 0 ? 0 : sz;
++	CHECK_RET(ithc_dma_data_buffer_put, ithc, &ithc->dma_tx.prds, &ithc->dma_tx.buf, 0);
++	if (sz < 0) {
++		pci_err(ithc->pci, "failed to encode tx data type %i, size %u, error %i\n",
++			data->type, data->size, (int)sz);
++		return -EINVAL;
++	}
++
++	// Let the THC process the buffer.
++	bitsb_set(&ithc->regs->dma_tx.control, DMA_TX_CONTROL_SEND);
++	CHECK_RET(waitb, ithc, &ithc->regs->dma_tx.control, DMA_TX_CONTROL_SEND, 0);
++	writel(DMA_TX_STATUS_DONE, &ithc->regs->dma_tx.status);
++	return 0;
++}
++int ithc_dma_tx(struct ithc *ithc, const struct ithc_data *data)
++{
++	mutex_lock(&ithc->dma_tx.mutex);
++	int ret = ithc_dma_tx_unlocked(ithc, data);
++	mutex_unlock(&ithc->dma_tx.mutex);
++	return ret;
++}
++
+diff --git a/drivers/hid/ithc/ithc-dma.h b/drivers/hid/ithc/ithc-dma.h
+new file mode 100644
+index 000000000..1749a5819
+--- /dev/null
++++ b/drivers/hid/ithc/ithc-dma.h
+@@ -0,0 +1,47 @@
++/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
++
++#define PRD_SIZE_MASK            0xffffff
++#define PRD_FLAG_END             0x1000000
++#define PRD_FLAG_SUCCESS         0x2000000
++#define PRD_FLAG_ERROR           0x4000000
++
++struct ithc_phys_region_desc {
++	u64 addr; // physical addr/1024
++	u32 size; // num bytes, PRD_FLAG_END marks last prd for data split over multiple prds
++	u32 unused;
++};
++
++struct ithc_dma_prd_buffer {
++	void *addr;
++	dma_addr_t dma_addr;
++	u32 size;
++	u32 num_pages; // per data buffer
++	enum dma_data_direction dir;
++};
++
++struct ithc_dma_data_buffer {
++	void *addr;
++	struct sg_table *sgt;
++	int active_idx;
++	u32 data_size;
++};
++
++struct ithc_dma_tx {
++	struct mutex mutex;
++	struct ithc_dma_prd_buffer prds;
++	struct ithc_dma_data_buffer buf;
++};
++
++struct ithc_dma_rx {
++	struct mutex mutex;
++	u32 num_received;
++	struct ithc_dma_prd_buffer prds;
++	struct ithc_dma_data_buffer bufs[NUM_RX_BUF];
++};
++
++int ithc_dma_rx_init(struct ithc *ithc, u8 channel);
++void ithc_dma_rx_enable(struct ithc *ithc, u8 channel);
++int ithc_dma_tx_init(struct ithc *ithc);
++int ithc_dma_rx(struct ithc *ithc, u8 channel);
++int ithc_dma_tx(struct ithc *ithc, const struct ithc_data *data);
++
+diff --git a/drivers/hid/ithc/ithc-hid.c b/drivers/hid/ithc/ithc-hid.c
+new file mode 100644
+index 000000000..065646ab4
+--- /dev/null
++++ b/drivers/hid/ithc/ithc-hid.c
+@@ -0,0 +1,207 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
++
++#include "ithc.h"
++
++static int ithc_hid_start(struct hid_device *hdev) { return 0; }
++static void ithc_hid_stop(struct hid_device *hdev) { }
++static int ithc_hid_open(struct hid_device *hdev) { return 0; }
++static void ithc_hid_close(struct hid_device *hdev) { }
++
++static int ithc_hid_parse(struct hid_device *hdev)
++{
++	struct ithc *ithc = hdev->driver_data;
++	const struct ithc_data get_report_desc = { .type = ITHC_DATA_REPORT_DESCRIPTOR };
++	WRITE_ONCE(ithc->hid.parse_done, false);
++	for (int retries = 0; ; retries++) {
++		ithc_log_regs(ithc);
++		CHECK_RET(ithc_dma_tx, ithc, &get_report_desc);
++		if (wait_event_timeout(ithc->hid.wait_parse, READ_ONCE(ithc->hid.parse_done),
++				msecs_to_jiffies(200))) {
++			ithc_log_regs(ithc);
++			return 0;
++		}
++		if (retries > 5) {
++			ithc_log_regs(ithc);
++			pci_err(ithc->pci, "failed to read report descriptor\n");
++			return -ETIMEDOUT;
++		}
++		pci_warn(ithc->pci, "failed to read report descriptor, retrying\n");
++	}
++}
++
++static int ithc_hid_raw_request(struct hid_device *hdev, unsigned char reportnum, __u8 *buf,
++	size_t len, unsigned char rtype, int reqtype)
++{
++	struct ithc *ithc = hdev->driver_data;
++	if (!buf || !len)
++		return -EINVAL;
++
++	struct ithc_data d = { .size = len, .data = buf };
++	buf[0] = reportnum;
++
++	if (rtype == HID_OUTPUT_REPORT && reqtype == HID_REQ_SET_REPORT) {
++		d.type = ITHC_DATA_OUTPUT_REPORT;
++		CHECK_RET(ithc_dma_tx, ithc, &d);
++		return 0;
++	}
++
++	if (rtype == HID_FEATURE_REPORT && reqtype == HID_REQ_SET_REPORT) {
++		d.type = ITHC_DATA_SET_FEATURE;
++		CHECK_RET(ithc_dma_tx, ithc, &d);
++		return 0;
++	}
++
++	if (rtype == HID_FEATURE_REPORT && reqtype == HID_REQ_GET_REPORT) {
++		d.type = ITHC_DATA_GET_FEATURE;
++		d.data = &reportnum;
++		d.size = 1;
++
++		// Prepare for response.
++		mutex_lock(&ithc->hid.get_feature_mutex);
++		ithc->hid.get_feature_buf = buf;
++		ithc->hid.get_feature_size = len;
++		mutex_unlock(&ithc->hid.get_feature_mutex);
++
++		// Transmit 'get feature' request.
++		int r = CHECK(ithc_dma_tx, ithc, &d);
++		if (!r) {
++			r = wait_event_interruptible_timeout(ithc->hid.wait_get_feature,
++				!ithc->hid.get_feature_buf, msecs_to_jiffies(1000));
++			if (!r)
++				r = -ETIMEDOUT;
++			else if (r < 0)
++				r = -EINTR;
++			else
++				r = 0;
++		}
++
++		// If everything went ok, the buffer has been filled with the response data.
++		// Return the response size.
++		mutex_lock(&ithc->hid.get_feature_mutex);
++		ithc->hid.get_feature_buf = NULL;
++		if (!r)
++			r = ithc->hid.get_feature_size;
++		mutex_unlock(&ithc->hid.get_feature_mutex);
++		return r;
++	}
++
++	pci_err(ithc->pci, "unhandled hid request %i %i for report id %i\n",
++		rtype, reqtype, reportnum);
++	return -EINVAL;
++}
++
++// FIXME hid_input_report()/hid_parse_report() currently don't take const buffers, so we have to
++// cast away the const to avoid a compiler warning...
++#define NOCONST(x) ((void *)x)
++
++void ithc_hid_process_data(struct ithc *ithc, struct ithc_data *d)
++{
++	WARN_ON(!ithc->hid.dev);
++	if (!ithc->hid.dev)
++		return;
++
++	switch (d->type) {
++
++	case ITHC_DATA_IGNORE:
++		return;
++
++	case ITHC_DATA_ERROR:
++		CHECK(ithc_reset, ithc);
++		return;
++
++	case ITHC_DATA_REPORT_DESCRIPTOR:
++		// Response to the report descriptor request sent by ithc_hid_parse().
++		CHECK(hid_parse_report, ithc->hid.dev, NOCONST(d->data), d->size);
++		WRITE_ONCE(ithc->hid.parse_done, true);
++		wake_up(&ithc->hid.wait_parse);
++		return;
++
++	case ITHC_DATA_INPUT_REPORT:
++	{
++		// Standard HID input report.
++		int r = hid_input_report(ithc->hid.dev, HID_INPUT_REPORT, NOCONST(d->data), d->size, 1);
++		if (r < 0) {
++			pci_warn(ithc->pci, "hid_input_report failed with %i (size %u, report ID 0x%02x)\n",
++				r, d->size, d->size ? *(u8 *)d->data : 0);
++			print_hex_dump_debug(DEVNAME " report: ", DUMP_PREFIX_OFFSET, 32, 1,
++				d->data, min(d->size, 0x400u), 0);
++		}
++		return;
++	}
++
++	case ITHC_DATA_GET_FEATURE:
++	{
++		// Response to a 'get feature' request sent by ithc_hid_raw_request().
++		bool done = false;
++		mutex_lock(&ithc->hid.get_feature_mutex);
++		if (ithc->hid.get_feature_buf) {
++			if (d->size < ithc->hid.get_feature_size)
++				ithc->hid.get_feature_size = d->size;
++			memcpy(ithc->hid.get_feature_buf, d->data, ithc->hid.get_feature_size);
++			ithc->hid.get_feature_buf = NULL;
++			done = true;
++		}
++		mutex_unlock(&ithc->hid.get_feature_mutex);
++		if (done) {
++			wake_up(&ithc->hid.wait_get_feature);
++		} else {
++			// Received data without a matching request, or the request already
++			// timed out. (XXX What's the correct thing to do here?)
++			CHECK(hid_input_report, ithc->hid.dev, HID_FEATURE_REPORT,
++				NOCONST(d->data), d->size, 1);
++		}
++		return;
++	}
++
++	default:
++		pci_err(ithc->pci, "unhandled data type %i\n", d->type);
++		return;
++	}
++}
++
++static struct hid_ll_driver ithc_ll_driver = {
++	.start = ithc_hid_start,
++	.stop = ithc_hid_stop,
++	.open = ithc_hid_open,
++	.close = ithc_hid_close,
++	.parse = ithc_hid_parse,
++	.raw_request = ithc_hid_raw_request,
++};
++
++static void ithc_hid_devres_release(struct device *dev, void *res)
++{
++	struct hid_device **hidm = res;
++	if (*hidm)
++		hid_destroy_device(*hidm);
++}
++
++int ithc_hid_init(struct ithc *ithc)
++{
++	struct hid_device **hidm = devres_alloc(ithc_hid_devres_release, sizeof(*hidm), GFP_KERNEL);
++	if (!hidm)
++		return -ENOMEM;
++	devres_add(&ithc->pci->dev, hidm);
++	struct hid_device *hid = hid_allocate_device();
++	if (IS_ERR(hid))
++		return PTR_ERR(hid);
++	*hidm = hid;
++
++	strscpy(hid->name, DEVFULLNAME, sizeof(hid->name));
++	strscpy(hid->phys, ithc->phys, sizeof(hid->phys));
++	hid->ll_driver = &ithc_ll_driver;
++	hid->bus = BUS_PCI;
++	hid->vendor = ithc->vendor_id;
++	hid->product = ithc->product_id;
++	hid->version = 0x100;
++	hid->dev.parent = &ithc->pci->dev;
++	hid->driver_data = ithc;
++
++	ithc->hid.dev = hid;
++
++	init_waitqueue_head(&ithc->hid.wait_parse);
++	init_waitqueue_head(&ithc->hid.wait_get_feature);
++	mutex_init(&ithc->hid.get_feature_mutex);
++
++	return 0;
++}
++
+diff --git a/drivers/hid/ithc/ithc-hid.h b/drivers/hid/ithc/ithc-hid.h
+new file mode 100644
+index 000000000..599eb912c
+--- /dev/null
++++ b/drivers/hid/ithc/ithc-hid.h
+@@ -0,0 +1,32 @@
++/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
++
++enum ithc_data_type {
++	ITHC_DATA_IGNORE,
++	ITHC_DATA_RAW,
++	ITHC_DATA_ERROR,
++	ITHC_DATA_REPORT_DESCRIPTOR,
++	ITHC_DATA_INPUT_REPORT,
++	ITHC_DATA_OUTPUT_REPORT,
++	ITHC_DATA_GET_FEATURE,
++	ITHC_DATA_SET_FEATURE,
++};
++
++struct ithc_data {
++	enum ithc_data_type type;
++	u32 size;
++	const void *data;
++};
++
++struct ithc_hid {
++	struct hid_device *dev;
++	bool parse_done;
++	wait_queue_head_t wait_parse;
++	wait_queue_head_t wait_get_feature;
++	struct mutex get_feature_mutex;
++	void *get_feature_buf;
++	size_t get_feature_size;
++};
++
++int ithc_hid_init(struct ithc *ithc);
++void ithc_hid_process_data(struct ithc *ithc, struct ithc_data *d);
++
+diff --git a/drivers/hid/ithc/ithc-legacy.c b/drivers/hid/ithc/ithc-legacy.c
+new file mode 100644
+index 000000000..8883987fb
+--- /dev/null
++++ b/drivers/hid/ithc/ithc-legacy.c
+@@ -0,0 +1,254 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
++
++#include "ithc.h"
++
++#define DEVCFG_DMA_RX_SIZE(x)          ((((x) & 0x3fff) + 1) << 6)
++#define DEVCFG_DMA_TX_SIZE(x)          (((((x) >> 14) & 0x3ff) + 1) << 6)
++
++#define DEVCFG_TOUCH_MASK              0x3f
++#define DEVCFG_TOUCH_ENABLE            BIT(0)
++#define DEVCFG_TOUCH_PROP_DATA_ENABLE  BIT(1)
++#define DEVCFG_TOUCH_HID_REPORT_ENABLE BIT(2)
++#define DEVCFG_TOUCH_POWER_STATE(x)    (((x) & 7) << 3)
++#define DEVCFG_TOUCH_UNKNOWN_6         BIT(6)
++
++#define DEVCFG_DEVICE_ID_TIC           0x43495424 // "$TIC"
++
++#define DEVCFG_SPI_CLKDIV(x)           (((x) >> 1) & 7)
++#define DEVCFG_SPI_CLKDIV_8            BIT(4)
++#define DEVCFG_SPI_SUPPORTS_SINGLE     BIT(5)
++#define DEVCFG_SPI_SUPPORTS_DUAL       BIT(6)
++#define DEVCFG_SPI_SUPPORTS_QUAD       BIT(7)
++#define DEVCFG_SPI_MAX_TOUCH_POINTS(x) (((x) >> 8) & 0x3f)
++#define DEVCFG_SPI_MIN_RESET_TIME(x)   (((x) >> 16) & 0xf)
++#define DEVCFG_SPI_NEEDS_HEARTBEAT     BIT(20) // TODO implement heartbeat
++#define DEVCFG_SPI_HEARTBEAT_INTERVAL(x) (((x) >> 21) & 7)
++#define DEVCFG_SPI_UNKNOWN_25          BIT(25)
++#define DEVCFG_SPI_UNKNOWN_26          BIT(26)
++#define DEVCFG_SPI_UNKNOWN_27          BIT(27)
++#define DEVCFG_SPI_DELAY(x)            (((x) >> 28) & 7) // TODO use this
++#define DEVCFG_SPI_USE_EXT_READ_CFG    BIT(31) // TODO use this?
++
++struct ithc_device_config { // (Example values are from an SP7+.)
++	u32 irq_cause;        // 00 = 0xe0000402 (0xe0000401 after DMA_RX_CODE_RESET)
++	u32 error;            // 04 = 0x00000000
++	u32 dma_buf_sizes;    // 08 = 0x000a00ff
++	u32 touch_cfg;        // 0c = 0x0000001c
++	u32 touch_state;      // 10 = 0x0000001c
++	u32 device_id;        // 14 = 0x43495424 = "$TIC"
++	u32 spi_config;       // 18 = 0xfda00a2e
++	u16 vendor_id;        // 1c = 0x045e = Microsoft Corp.
++	u16 product_id;       // 1e = 0x0c1a
++	u32 revision;         // 20 = 0x00000001
++	u32 fw_version;       // 24 = 0x05008a8b = 5.0.138.139 (this value looks more random on newer devices)
++	u32 command;          // 28 = 0x00000000
++	u32 fw_mode;          // 2c = 0x00000000 (for fw update?)
++	u32 _unknown_30;      // 30 = 0x00000000
++	u8 eds_minor_ver;     // 34 = 0x5e
++	u8 eds_major_ver;     // 35 = 0x03
++	u8 interface_rev;     // 36 = 0x04
++	u8 eu_kernel_ver;     // 37 = 0x04
++	u32 _unknown_38;      // 38 = 0x000001c0 (0x000001c1 after DMA_RX_CODE_RESET)
++	u32 _unknown_3c;      // 3c = 0x00000002
++};
++static_assert(sizeof(struct ithc_device_config) == 64);
++
++#define RX_CODE_INPUT_REPORT          3
++#define RX_CODE_FEATURE_REPORT        4
++#define RX_CODE_REPORT_DESCRIPTOR     5
++#define RX_CODE_RESET                 7
++
++#define TX_CODE_SET_FEATURE           3
++#define TX_CODE_GET_FEATURE           4
++#define TX_CODE_OUTPUT_REPORT         5
++#define TX_CODE_GET_REPORT_DESCRIPTOR 7
++
++static int ithc_set_device_enabled(struct ithc *ithc, bool enable)
++{
++	u32 x = ithc->legacy_touch_cfg =
++		(ithc->legacy_touch_cfg & ~(u32)DEVCFG_TOUCH_MASK) |
++		DEVCFG_TOUCH_HID_REPORT_ENABLE |
++		(enable ? DEVCFG_TOUCH_ENABLE | DEVCFG_TOUCH_POWER_STATE(3) : 0);
++	return ithc_spi_command(ithc, SPI_CMD_CODE_WRITE,
++		offsetof(struct ithc_device_config, touch_cfg), sizeof(x), &x);
++}
++
++int ithc_legacy_init(struct ithc *ithc)
++{
++	// Since we don't yet know which SPI config the device wants, use default speed and mode
++	// initially for reading config data.
++	CHECK(ithc_set_spi_config, ithc, 2, true, SPI_MODE_SINGLE, SPI_MODE_SINGLE);
++
++	// Setting the following bit seems to make reading the config more reliable.
++	bitsl_set(&ithc->regs->dma_rx[0].init_unknown, INIT_UNKNOWN_31);
++
++	// Setting this bit may be necessary on ADL devices.
++	switch (ithc->pci->device) {
++	case PCI_DEVICE_ID_INTEL_THC_ADL_S_PORT1:
++	case PCI_DEVICE_ID_INTEL_THC_ADL_S_PORT2:
++	case PCI_DEVICE_ID_INTEL_THC_ADL_P_PORT1:
++	case PCI_DEVICE_ID_INTEL_THC_ADL_P_PORT2:
++	case PCI_DEVICE_ID_INTEL_THC_ADL_M_PORT1:
++	case PCI_DEVICE_ID_INTEL_THC_ADL_M_PORT2:
++		bitsl_set(&ithc->regs->dma_rx[0].init_unknown, INIT_UNKNOWN_5);
++		break;
++	}
++
++	// Take the touch device out of reset.
++	bitsl(&ithc->regs->control_bits, CONTROL_QUIESCE, 0);
++	CHECK_RET(waitl, ithc, &ithc->regs->control_bits, CONTROL_IS_QUIESCED, 0);
++	for (int retries = 0; ; retries++) {
++		ithc_log_regs(ithc);
++		bitsl_set(&ithc->regs->control_bits, CONTROL_NRESET);
++		if (!waitl(ithc, &ithc->regs->irq_cause, 0xf, 2))
++			break;
++		if (retries > 5) {
++			pci_err(ithc->pci, "failed to reset device, irq_cause = 0x%08x\n",
++				readl(&ithc->regs->irq_cause));
++			return -ETIMEDOUT;
++		}
++		pci_warn(ithc->pci, "invalid irq_cause, retrying reset\n");
++		bitsl(&ithc->regs->control_bits, CONTROL_NRESET, 0);
++		if (msleep_interruptible(1000))
++			return -EINTR;
++	}
++	ithc_log_regs(ithc);
++
++	CHECK(waitl, ithc, &ithc->regs->dma_rx[0].status, DMA_RX_STATUS_READY, DMA_RX_STATUS_READY);
++
++	// Read configuration data.
++	u32 spi_cfg;
++	for (int retries = 0; ; retries++) {
++		ithc_log_regs(ithc);
++		struct ithc_device_config config = { 0 };
++		CHECK_RET(ithc_spi_command, ithc, SPI_CMD_CODE_READ, 0, sizeof(config), &config);
++		u32 *p = (void *)&config;
++		pci_info(ithc->pci, "config: %08x %08x %08x %08x %08x %08x %08x %08x %08x %08x %08x %08x %08x %08x %08x %08x\n",
++			p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15]);
++		if (config.device_id == DEVCFG_DEVICE_ID_TIC) {
++			spi_cfg = config.spi_config;
++			ithc->vendor_id = config.vendor_id;
++			ithc->product_id = config.product_id;
++			ithc->product_rev = config.revision;
++			ithc->max_rx_size = DEVCFG_DMA_RX_SIZE(config.dma_buf_sizes);
++			ithc->max_tx_size = DEVCFG_DMA_TX_SIZE(config.dma_buf_sizes);
++			ithc->legacy_touch_cfg = config.touch_cfg;
++			ithc->have_config = true;
++			break;
++		}
++		if (retries > 10) {
++			pci_err(ithc->pci, "failed to read config, unknown device ID 0x%08x\n",
++				config.device_id);
++			return -EIO;
++		}
++		pci_warn(ithc->pci, "failed to read config, retrying\n");
++		if (msleep_interruptible(100))
++			return -EINTR;
++	}
++	ithc_log_regs(ithc);
++
++	// Apply SPI config and enable touch device.
++	CHECK_RET(ithc_set_spi_config, ithc,
++		DEVCFG_SPI_CLKDIV(spi_cfg), (spi_cfg & DEVCFG_SPI_CLKDIV_8) != 0,
++		spi_cfg & DEVCFG_SPI_SUPPORTS_QUAD ? SPI_MODE_QUAD :
++		spi_cfg & DEVCFG_SPI_SUPPORTS_DUAL ? SPI_MODE_DUAL :
++		SPI_MODE_SINGLE,
++		SPI_MODE_SINGLE);
++	CHECK_RET(ithc_set_device_enabled, ithc, true);
++	ithc_log_regs(ithc);
++	return 0;
++}
++
++void ithc_legacy_exit(struct ithc *ithc)
++{
++	CHECK(ithc_set_device_enabled, ithc, false);
++}
++
++int ithc_legacy_decode_rx(struct ithc *ithc, const void *src, size_t len, struct ithc_data *dest)
++{
++	const struct {
++		u32 code;
++		u32 data_size;
++		u32 _unknown[14];
++	} *hdr = src;
++
++	if (len < sizeof(*hdr))
++		return -ENODATA;
++	// Note: RX data is not padded, even though TX data must be padded.
++	if (len != sizeof(*hdr) + hdr->data_size)
++		return -EMSGSIZE;
++
++	dest->data = hdr + 1;
++	dest->size = hdr->data_size;
++
++	switch (hdr->code) {
++	case RX_CODE_RESET:
++		// The THC sends a reset request when we need to reinitialize the device.
++		// This usually only happens if we send an invalid command or put the device
++		// in a bad state.
++		dest->type = ITHC_DATA_ERROR;
++		return 0;
++	case RX_CODE_REPORT_DESCRIPTOR:
++		// The descriptor is preceded by 8 nul bytes.
++		if (hdr->data_size < 8)
++			return -ENODATA;
++		dest->type = ITHC_DATA_REPORT_DESCRIPTOR;
++		dest->data = (char *)(hdr + 1) + 8;
++		dest->size = hdr->data_size - 8;
++		return 0;
++	case RX_CODE_INPUT_REPORT:
++		dest->type = ITHC_DATA_INPUT_REPORT;
++		return 0;
++	case RX_CODE_FEATURE_REPORT:
++		dest->type = ITHC_DATA_GET_FEATURE;
++		return 0;
++	default:
++		return -EINVAL;
++	}
++}
++
++ssize_t ithc_legacy_encode_tx(struct ithc *ithc, const struct ithc_data *src, void *dest,
++	size_t maxlen)
++{
++	struct {
++		u32 code;
++		u32 data_size;
++	} *hdr = dest;
++
++	size_t src_size = src->size;
++	const void *src_data = src->data;
++	const u64 get_report_desc_data = 0;
++	u32 code;
++
++	switch (src->type) {
++	case ITHC_DATA_SET_FEATURE:
++		code = TX_CODE_SET_FEATURE;
++		break;
++	case ITHC_DATA_GET_FEATURE:
++		code = TX_CODE_GET_FEATURE;
++		break;
++	case ITHC_DATA_OUTPUT_REPORT:
++		code = TX_CODE_OUTPUT_REPORT;
++		break;
++	case ITHC_DATA_REPORT_DESCRIPTOR:
++		code = TX_CODE_GET_REPORT_DESCRIPTOR;
++		src_size = sizeof(get_report_desc_data);
++		src_data = &get_report_desc_data;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	// Data must be padded to next 4-byte boundary.
++	size_t padded = round_up(src_size, 4);
++	if (sizeof(*hdr) + padded > maxlen)
++		return -EOVERFLOW;
++
++	// Fill the TX buffer with header and data.
++	hdr->code = code;
++	hdr->data_size = src_size;
++	memcpy_and_pad(hdr + 1, padded, src_data, src_size, 0);
++
++	return sizeof(*hdr) + padded;
++}
++
+diff --git a/drivers/hid/ithc/ithc-legacy.h b/drivers/hid/ithc/ithc-legacy.h
+new file mode 100644
+index 000000000..28d692462
+--- /dev/null
++++ b/drivers/hid/ithc/ithc-legacy.h
+@@ -0,0 +1,8 @@
++/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
++
++int ithc_legacy_init(struct ithc *ithc);
++void ithc_legacy_exit(struct ithc *ithc);
++int ithc_legacy_decode_rx(struct ithc *ithc, const void *src, size_t len, struct ithc_data *dest);
++ssize_t ithc_legacy_encode_tx(struct ithc *ithc, const struct ithc_data *src, void *dest,
++	size_t maxlen);
++
+diff --git a/drivers/hid/ithc/ithc-main.c b/drivers/hid/ithc/ithc-main.c
+new file mode 100644
+index 000000000..094d878d6
+--- /dev/null
++++ b/drivers/hid/ithc/ithc-main.c
+@@ -0,0 +1,438 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
++
++#include "ithc.h"
++
++MODULE_DESCRIPTION("Intel Touch Host Controller driver");
++MODULE_LICENSE("Dual BSD/GPL");
++
++static const struct pci_device_id ithc_pci_tbl[] = {
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_LKF_PORT1) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_LKF_PORT2) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_TGL_LP_PORT1) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_TGL_LP_PORT2) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_TGL_H_PORT1) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_TGL_H_PORT2) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_ADL_S_PORT1) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_ADL_S_PORT2) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_ADL_P_PORT1) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_ADL_P_PORT2) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_ADL_M_PORT1) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_ADL_M_PORT2) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_RPL_S_PORT1) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_THC_RPL_S_PORT2) },
++	// MTL and up are handled by drivers/hid/intel-thc-hid
++	{}
++};
++MODULE_DEVICE_TABLE(pci, ithc_pci_tbl);
++
++// Module parameters
++
++static bool ithc_use_polling = false;
++module_param_named(poll, ithc_use_polling, bool, 0);
++MODULE_PARM_DESC(poll, "Use polling instead of interrupts");
++
++// Since all known devices seem to use only channel 1, by default we disable channel 0.
++static bool ithc_use_rx0 = false;
++module_param_named(rx0, ithc_use_rx0, bool, 0);
++MODULE_PARM_DESC(rx0, "Use DMA RX channel 0");
++
++static bool ithc_use_rx1 = true;
++module_param_named(rx1, ithc_use_rx1, bool, 0);
++MODULE_PARM_DESC(rx1, "Use DMA RX channel 1");
++
++static int ithc_active_ltr_us = -1;
++module_param_named(activeltr, ithc_active_ltr_us, int, 0);
++MODULE_PARM_DESC(activeltr, "Active LTR value override (in microseconds)");
++
++static int ithc_idle_ltr_us = -1;
++module_param_named(idleltr, ithc_idle_ltr_us, int, 0);
++MODULE_PARM_DESC(idleltr, "Idle LTR value override (in microseconds)");
++
++static unsigned int ithc_idle_delay_ms = 1000;
++module_param_named(idledelay, ithc_idle_delay_ms, uint, 0);
++MODULE_PARM_DESC(idleltr, "Minimum idle time before applying idle LTR value (in milliseconds)");
++
++static bool ithc_log_regs_enabled = false;
++module_param_named(logregs, ithc_log_regs_enabled, bool, 0);
++MODULE_PARM_DESC(logregs, "Log changes in register values (for debugging)");
++
++// Interrupts/polling
++
++static void ithc_disable_interrupts(struct ithc *ithc)
++{
++	writel(0, &ithc->regs->error_control);
++	bitsb(&ithc->regs->spi_cmd.control, SPI_CMD_CONTROL_IRQ, 0);
++	bitsb(&ithc->regs->dma_rx[0].control, DMA_RX_CONTROL_IRQ_UNKNOWN_1 | DMA_RX_CONTROL_IRQ_ERROR | DMA_RX_CONTROL_IRQ_READY | DMA_RX_CONTROL_IRQ_DATA, 0);
++	bitsb(&ithc->regs->dma_rx[1].control, DMA_RX_CONTROL_IRQ_UNKNOWN_1 | DMA_RX_CONTROL_IRQ_ERROR | DMA_RX_CONTROL_IRQ_READY | DMA_RX_CONTROL_IRQ_DATA, 0);
++	bitsb(&ithc->regs->dma_tx.control, DMA_TX_CONTROL_IRQ, 0);
++}
++
++static void ithc_clear_dma_rx_interrupts(struct ithc *ithc, unsigned int channel)
++{
++	writel(DMA_RX_STATUS_ERROR | DMA_RX_STATUS_READY | DMA_RX_STATUS_HAVE_DATA,
++		&ithc->regs->dma_rx[channel].status);
++}
++
++static void ithc_clear_interrupts(struct ithc *ithc)
++{
++	writel(0xffffffff, &ithc->regs->error_flags);
++	writel(ERROR_STATUS_DMA | ERROR_STATUS_SPI, &ithc->regs->error_status);
++	writel(SPI_CMD_STATUS_DONE | SPI_CMD_STATUS_ERROR, &ithc->regs->spi_cmd.status);
++	ithc_clear_dma_rx_interrupts(ithc, 0);
++	ithc_clear_dma_rx_interrupts(ithc, 1);
++	writel(DMA_TX_STATUS_DONE | DMA_TX_STATUS_ERROR | DMA_TX_STATUS_UNKNOWN_2,
++		&ithc->regs->dma_tx.status);
++}
++
++static void ithc_idle_timer_callback(struct timer_list *t)
++{
++	struct ithc *ithc = container_of(t, struct ithc, idle_timer);
++	ithc_set_ltr_idle(ithc);
++}
++
++static void ithc_process(struct ithc *ithc)
++{
++	ithc_log_regs(ithc);
++
++	// The THC automatically transitions from LTR idle to active at the start of a DMA transfer.
++	// It does not appear to automatically go back to idle, so we switch it back after a delay.
++	mod_timer(&ithc->idle_timer, jiffies + msecs_to_jiffies(ithc_idle_delay_ms));
++
++	bool rx0 = ithc_use_rx0 && (readl(&ithc->regs->dma_rx[0].status) & (DMA_RX_STATUS_ERROR | DMA_RX_STATUS_HAVE_DATA)) != 0;
++	bool rx1 = ithc_use_rx1 && (readl(&ithc->regs->dma_rx[1].status) & (DMA_RX_STATUS_ERROR | DMA_RX_STATUS_HAVE_DATA)) != 0;
++
++	// Read and clear error bits
++	u32 err = readl(&ithc->regs->error_flags);
++	if (err) {
++		writel(err, &ithc->regs->error_flags);
++		if (err & ~ERROR_FLAG_DMA_RX_TIMEOUT)
++			pci_err(ithc->pci, "error flags: 0x%08x\n", err);
++		if (err & ERROR_FLAG_DMA_RX_TIMEOUT)
++			pci_err(ithc->pci, "DMA RX timeout/error (try decreasing activeltr/idleltr if this happens frequently)\n");
++	}
++
++	// Process DMA rx
++	if (ithc_use_rx0) {
++		ithc_clear_dma_rx_interrupts(ithc, 0);
++		if (rx0)
++			ithc_dma_rx(ithc, 0);
++	}
++	if (ithc_use_rx1) {
++		ithc_clear_dma_rx_interrupts(ithc, 1);
++		if (rx1)
++			ithc_dma_rx(ithc, 1);
++	}
++
++	ithc_log_regs(ithc);
++}
++
++static irqreturn_t ithc_interrupt_thread(int irq, void *arg)
++{
++	struct ithc *ithc = arg;
++	pci_dbg(ithc->pci, "IRQ! err=%08x/%08x/%08x, cmd=%02x/%08x, rx0=%02x/%08x, rx1=%02x/%08x, tx=%02x/%08x\n",
++		readl(&ithc->regs->error_control), readl(&ithc->regs->error_status), readl(&ithc->regs->error_flags),
++		readb(&ithc->regs->spi_cmd.control), readl(&ithc->regs->spi_cmd.status),
++		readb(&ithc->regs->dma_rx[0].control), readl(&ithc->regs->dma_rx[0].status),
++		readb(&ithc->regs->dma_rx[1].control), readl(&ithc->regs->dma_rx[1].status),
++		readb(&ithc->regs->dma_tx.control), readl(&ithc->regs->dma_tx.status));
++	ithc_process(ithc);
++	return IRQ_HANDLED;
++}
++
++static int ithc_poll_thread(void *arg)
++{
++	struct ithc *ithc = arg;
++	unsigned int sleep = 100;
++	while (!kthread_should_stop()) {
++		u32 n = ithc->dma_rx[1].num_received;
++		ithc_process(ithc);
++		// Decrease polling interval to 20ms if we received data, otherwise slowly
++		// increase it up to 200ms.
++		sleep = n != ithc->dma_rx[1].num_received ? 20
++			: min(200u, sleep + (sleep >> 4) + 1);
++		msleep_interruptible(sleep);
++	}
++	return 0;
++}
++
++// Device initialization and shutdown
++
++static void ithc_disable(struct ithc *ithc)
++{
++	bitsl_set(&ithc->regs->control_bits, CONTROL_QUIESCE);
++	CHECK(waitl, ithc, &ithc->regs->control_bits, CONTROL_IS_QUIESCED, CONTROL_IS_QUIESCED);
++	bitsl(&ithc->regs->control_bits, CONTROL_NRESET, 0);
++	bitsb(&ithc->regs->spi_cmd.control, SPI_CMD_CONTROL_SEND, 0);
++	bitsb(&ithc->regs->dma_tx.control, DMA_TX_CONTROL_SEND, 0);
++	bitsb(&ithc->regs->dma_rx[0].control, DMA_RX_CONTROL_ENABLE, 0);
++	bitsb(&ithc->regs->dma_rx[1].control, DMA_RX_CONTROL_ENABLE, 0);
++	ithc_disable_interrupts(ithc);
++	ithc_clear_interrupts(ithc);
++}
++
++static int ithc_init_device(struct ithc *ithc)
++{
++	// Read ACPI config for QuickSPI mode
++	struct ithc_acpi_config cfg = { 0 };
++	CHECK_RET(ithc_read_acpi_config, ithc, &cfg);
++	if (!cfg.has_config)
++		pci_info(ithc->pci, "no ACPI config, using legacy mode\n");
++	else
++		ithc_print_acpi_config(ithc, &cfg);
++	ithc->use_quickspi = cfg.has_config;
++
++	// Shut down device
++	ithc_log_regs(ithc);
++	bool was_enabled = (readl(&ithc->regs->control_bits) & CONTROL_NRESET) != 0;
++	ithc_disable(ithc);
++	CHECK_RET(waitl, ithc, &ithc->regs->control_bits, CONTROL_READY, CONTROL_READY);
++	ithc_log_regs(ithc);
++
++	// If the device was previously enabled, wait a bit to make sure it's fully shut down.
++	if (was_enabled)
++		if (msleep_interruptible(100))
++			return -EINTR;
++
++	// Set Latency Tolerance Reporting config. The device will automatically
++	// apply these values depending on whether it is active or idle.
++	// If active value is too high, DMA buffer data can become truncated.
++	// By default, we set the active LTR value to 50us, and idle to 100ms.
++	u64 active_ltr_ns = ithc_active_ltr_us >= 0 ? (u64)ithc_active_ltr_us * 1000
++		: cfg.has_config && cfg.has_active_ltr ? (u64)cfg.active_ltr << 10
++		: 50 * 1000;
++	u64 idle_ltr_ns = ithc_idle_ltr_us >= 0 ? (u64)ithc_idle_ltr_us * 1000
++		: cfg.has_config && cfg.has_idle_ltr ? (u64)cfg.idle_ltr << 10
++		: 100 * 1000 * 1000;
++	ithc_set_ltr_config(ithc, active_ltr_ns, idle_ltr_ns);
++
++	if (ithc->use_quickspi)
++		CHECK_RET(ithc_quickspi_init, ithc, &cfg);
++	else
++		CHECK_RET(ithc_legacy_init, ithc);
++
++	return 0;
++}
++
++int ithc_reset(struct ithc *ithc)
++{
++	// FIXME This should probably do devres_release_group()+ithc_start().
++	// But because this is called during DMA processing, that would have to be done
++	// asynchronously (schedule_work()?). And with extra locking?
++	pci_err(ithc->pci, "reset\n");
++	CHECK(ithc_init_device, ithc);
++	if (ithc_use_rx0)
++		ithc_dma_rx_enable(ithc, 0);
++	if (ithc_use_rx1)
++		ithc_dma_rx_enable(ithc, 1);
++	ithc_log_regs(ithc);
++	pci_dbg(ithc->pci, "reset completed\n");
++	return 0;
++}
++
++static void ithc_stop(void *res)
++{
++	struct ithc *ithc = res;
++	pci_dbg(ithc->pci, "stopping\n");
++	ithc_log_regs(ithc);
++
++	if (ithc->poll_thread)
++		CHECK(kthread_stop, ithc->poll_thread);
++	if (ithc->irq >= 0)
++		disable_irq(ithc->irq);
++	if (ithc->use_quickspi)
++		ithc_quickspi_exit(ithc);
++	else
++		ithc_legacy_exit(ithc);
++	ithc_disable(ithc);
++	timer_delete_sync(&ithc->idle_timer);
++
++	// Clear DMA config.
++	for (unsigned int i = 0; i < 2; i++) {
++		CHECK(waitl, ithc, &ithc->regs->dma_rx[i].status, DMA_RX_STATUS_ENABLED, 0);
++		lo_hi_writeq(0, &ithc->regs->dma_rx[i].addr);
++		writeb(0, &ithc->regs->dma_rx[i].num_bufs);
++		writeb(0, &ithc->regs->dma_rx[i].num_prds);
++	}
++	lo_hi_writeq(0, &ithc->regs->dma_tx.addr);
++	writeb(0, &ithc->regs->dma_tx.num_prds);
++
++	ithc_log_regs(ithc);
++	pci_dbg(ithc->pci, "stopped\n");
++}
++
++static void ithc_clear_drvdata(void *res)
++{
++	struct pci_dev *pci = res;
++	pci_set_drvdata(pci, NULL);
++}
++
++static int ithc_start(struct pci_dev *pci)
++{
++	pci_dbg(pci, "starting\n");
++	if (pci_get_drvdata(pci)) {
++		pci_err(pci, "device already initialized\n");
++		return -EINVAL;
++	}
++	if (!devres_open_group(&pci->dev, ithc_start, GFP_KERNEL))
++		return -ENOMEM;
++
++	// Allocate/init main driver struct.
++	struct ithc *ithc = devm_kzalloc(&pci->dev, sizeof(*ithc), GFP_KERNEL);
++	if (!ithc)
++		return -ENOMEM;
++	ithc->irq = -1;
++	ithc->pci = pci;
++	snprintf(ithc->phys, sizeof(ithc->phys), "pci-%s/" DEVNAME, pci_name(pci));
++	pci_set_drvdata(pci, ithc);
++	CHECK_RET(devm_add_action_or_reset, &pci->dev, ithc_clear_drvdata, pci);
++	if (ithc_log_regs_enabled)
++		ithc->prev_regs = devm_kzalloc(&pci->dev, sizeof(*ithc->prev_regs), GFP_KERNEL);
++
++	// PCI initialization.
++	CHECK_RET(pcim_enable_device, pci);
++	pci_set_master(pci);
++	CHECK_RET(pcim_iomap_regions, pci, BIT(0), DEVNAME " regs");
++	CHECK_RET(dma_set_mask_and_coherent, &pci->dev, DMA_BIT_MASK(64));
++	CHECK_RET(pci_set_power_state, pci, PCI_D0);
++	ithc->regs = pcim_iomap_table(pci)[0];
++
++	// Allocate IRQ.
++	if (!ithc_use_polling) {
++		CHECK_RET(pci_alloc_irq_vectors, pci, 1, 1, PCI_IRQ_MSI | PCI_IRQ_MSIX);
++		ithc->irq = CHECK(pci_irq_vector, pci, 0);
++		if (ithc->irq < 0)
++			return ithc->irq;
++	}
++
++	// Initialize THC and touch device.
++	CHECK_RET(ithc_init_device, ithc);
++
++	// Initialize HID and DMA.
++	CHECK_RET(ithc_hid_init, ithc);
++	if (ithc_use_rx0)
++		CHECK_RET(ithc_dma_rx_init, ithc, 0);
++	if (ithc_use_rx1)
++		CHECK_RET(ithc_dma_rx_init, ithc, 1);
++	CHECK_RET(ithc_dma_tx_init, ithc);
++
++	timer_setup(&ithc->idle_timer, ithc_idle_timer_callback, 0);
++
++	// Add ithc_stop() callback AFTER setting up DMA buffers, so that polling/irqs/DMA are
++	// disabled BEFORE the buffers are freed.
++	CHECK_RET(devm_add_action_or_reset, &pci->dev, ithc_stop, ithc);
++
++	// Start polling/IRQ.
++	if (ithc_use_polling) {
++		pci_info(pci, "using polling instead of irq\n");
++		// Use a thread instead of simple timer because we want to be able to sleep.
++		ithc->poll_thread = kthread_run(ithc_poll_thread, ithc, DEVNAME "poll");
++		if (IS_ERR(ithc->poll_thread)) {
++			int err = PTR_ERR(ithc->poll_thread);
++			ithc->poll_thread = NULL;
++			return err;
++		}
++	} else {
++		CHECK_RET(devm_request_threaded_irq, &pci->dev, ithc->irq, NULL,
++			ithc_interrupt_thread, IRQF_TRIGGER_HIGH | IRQF_ONESHOT, DEVNAME, ithc);
++	}
++
++	if (ithc_use_rx0)
++		ithc_dma_rx_enable(ithc, 0);
++	if (ithc_use_rx1)
++		ithc_dma_rx_enable(ithc, 1);
++
++	// hid_add_device() can only be called after irq/polling is started and DMA is enabled,
++	// because it calls ithc_hid_parse() which reads the report descriptor via DMA.
++	CHECK_RET(hid_add_device, ithc->hid.dev);
++
++	CHECK(ithc_debug_init_device, ithc);
++
++	ithc_set_ltr_idle(ithc);
++
++	pci_dbg(pci, "started\n");
++	return 0;
++}
++
++static int ithc_probe(struct pci_dev *pci, const struct pci_device_id *id)
++{
++	pci_dbg(pci, "device probe\n");
++	return ithc_start(pci);
++}
++
++static void ithc_remove(struct pci_dev *pci)
++{
++	pci_dbg(pci, "device remove\n");
++	// all cleanup is handled by devres
++}
++
++// For suspend/resume, we just deinitialize and reinitialize everything.
++// TODO It might be cleaner to keep the HID device around, however we would then have to signal
++// to userspace that the touch device has lost state and userspace needs to e.g. resend 'set
++// feature' requests. Hidraw does not seem to have a facility to do that.
++static int ithc_suspend(struct device *dev)
++{
++	struct pci_dev *pci = to_pci_dev(dev);
++	pci_dbg(pci, "pm suspend\n");
++	devres_release_group(dev, ithc_start);
++	return 0;
++}
++
++static int ithc_resume(struct device *dev)
++{
++	struct pci_dev *pci = to_pci_dev(dev);
++	pci_dbg(pci, "pm resume\n");
++	return ithc_start(pci);
++}
++
++static int ithc_freeze(struct device *dev)
++{
++	struct pci_dev *pci = to_pci_dev(dev);
++	pci_dbg(pci, "pm freeze\n");
++	devres_release_group(dev, ithc_start);
++	return 0;
++}
++
++static int ithc_thaw(struct device *dev)
++{
++	struct pci_dev *pci = to_pci_dev(dev);
++	pci_dbg(pci, "pm thaw\n");
++	return ithc_start(pci);
++}
++
++static int ithc_restore(struct device *dev)
++{
++	struct pci_dev *pci = to_pci_dev(dev);
++	pci_dbg(pci, "pm restore\n");
++	return ithc_start(pci);
++}
++
++static struct pci_driver ithc_driver = {
++	.name = DEVNAME,
++	.id_table = ithc_pci_tbl,
++	.probe = ithc_probe,
++	.remove = ithc_remove,
++	.driver.pm = &(const struct dev_pm_ops) {
++		.suspend = ithc_suspend,
++		.resume = ithc_resume,
++		.freeze = ithc_freeze,
++		.thaw = ithc_thaw,
++		.restore = ithc_restore,
++	},
++	.driver.probe_type = PROBE_PREFER_ASYNCHRONOUS,
++};
++
++static int __init ithc_init(void)
++{
++	ithc_debug_init_module();
++	return pci_register_driver(&ithc_driver);
++}
++
++static void __exit ithc_exit(void)
++{
++	pci_unregister_driver(&ithc_driver);
++	ithc_debug_exit_module();
++}
++
++module_init(ithc_init);
++module_exit(ithc_exit);
++
+diff --git a/drivers/hid/ithc/ithc-quickspi.c b/drivers/hid/ithc/ithc-quickspi.c
+new file mode 100644
+index 000000000..e2d1690b8
+--- /dev/null
++++ b/drivers/hid/ithc/ithc-quickspi.c
+@@ -0,0 +1,607 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
++
++// Some public THC/QuickSPI documentation can be found in:
++// - Intel Firmware Support Package repo: https://github.com/intel/FSP
++// - HID over SPI (HIDSPI) spec: https://www.microsoft.com/en-us/download/details.aspx?id=103325
++
++#include "ithc.h"
++
++static const guid_t guid_hidspi =
++	GUID_INIT(0x6e2ac436, 0x0fcf, 0x41af, 0xa2, 0x65, 0xb3, 0x2a, 0x22, 0x0d, 0xcf, 0xab);
++static const guid_t guid_thc_quickspi =
++	GUID_INIT(0x300d35b7, 0xac20, 0x413e, 0x8e, 0x9c, 0x92, 0xe4, 0xda, 0xfd, 0x0a, 0xfe);
++static const guid_t guid_thc_ltr =
++	GUID_INIT(0x84005682, 0x5b71, 0x41a4, 0x8d, 0x66, 0x81, 0x30, 0xf7, 0x87, 0xa1, 0x38);
++
++// TODO The HIDSPI spec says revision should be 3. Should we try both?
++#define DSM_REV 2
++
++struct hidspi_header {
++	u8 type;
++	u16 len;
++	u8 id;
++} __packed;
++static_assert(sizeof(struct hidspi_header) == 4);
++
++#define HIDSPI_INPUT_TYPE_DATA                        1
++#define HIDSPI_INPUT_TYPE_RESET_RESPONSE              3
++#define HIDSPI_INPUT_TYPE_COMMAND_RESPONSE            4
++#define HIDSPI_INPUT_TYPE_GET_FEATURE_RESPONSE        5
++#define HIDSPI_INPUT_TYPE_DEVICE_DESCRIPTOR           7
++#define HIDSPI_INPUT_TYPE_REPORT_DESCRIPTOR           8
++#define HIDSPI_INPUT_TYPE_SET_FEATURE_RESPONSE        9
++#define HIDSPI_INPUT_TYPE_OUTPUT_REPORT_RESPONSE      10
++#define HIDSPI_INPUT_TYPE_GET_INPUT_REPORT_RESPONSE   11
++
++#define HIDSPI_OUTPUT_TYPE_DEVICE_DESCRIPTOR_REQUEST  1
++#define HIDSPI_OUTPUT_TYPE_REPORT_DESCRIPTOR_REQUEST  2
++#define HIDSPI_OUTPUT_TYPE_SET_FEATURE                3
++#define HIDSPI_OUTPUT_TYPE_GET_FEATURE                4
++#define HIDSPI_OUTPUT_TYPE_OUTPUT_REPORT              5
++#define HIDSPI_OUTPUT_TYPE_INPUT_REPORT_REQUEST       6
++#define HIDSPI_OUTPUT_TYPE_COMMAND                    7
++
++struct hidspi_device_descriptor {
++	u16 wDeviceDescLength;
++	u16 bcdVersion;
++	u16 wReportDescLength;
++	u16 wMaxInputLength;
++	u16 wMaxOutputLength;
++	u16 wMaxFragmentLength;
++	u16 wVendorID;
++	u16 wProductID;
++	u16 wVersionID;
++	u16 wFlags;
++	u32 dwReserved;
++};
++static_assert(sizeof(struct hidspi_device_descriptor) == 24);
++
++static int read_acpi_u32(struct ithc *ithc, const guid_t *guid, u32 func, u32 *dest)
++{
++	acpi_handle handle = ACPI_HANDLE(&ithc->pci->dev);
++	union acpi_object *o = acpi_evaluate_dsm(handle, guid, DSM_REV, func, NULL);
++	if (!o)
++		return 0;
++	if (o->type != ACPI_TYPE_INTEGER) {
++		pci_err(ithc->pci, "DSM %pUl %u returned type %i instead of integer\n",
++			guid, func, o->type);
++		ACPI_FREE(o);
++		return -1;
++	}
++	pci_dbg(ithc->pci, "DSM %pUl %u = 0x%08x\n", guid, func, (u32)o->integer.value);
++	*dest = (u32)o->integer.value;
++	ACPI_FREE(o);
++	return 1;
++}
++
++static int read_acpi_buf(struct ithc *ithc, const guid_t *guid, u32 func, size_t len, u8 *dest)
++{
++	acpi_handle handle = ACPI_HANDLE(&ithc->pci->dev);
++	union acpi_object *o = acpi_evaluate_dsm(handle, guid, DSM_REV, func, NULL);
++	if (!o)
++		return 0;
++	if (o->type != ACPI_TYPE_BUFFER) {
++		pci_err(ithc->pci, "DSM %pUl %u returned type %i instead of buffer\n",
++			guid, func, o->type);
++		ACPI_FREE(o);
++		return -1;
++	}
++	if (o->buffer.length != len) {
++		pci_err(ithc->pci, "DSM %pUl %u returned len %u instead of %zu\n",
++			guid, func, o->buffer.length, len);
++		ACPI_FREE(o);
++		return -1;
++	}
++	memcpy(dest, o->buffer.pointer, len);
++	pci_dbg(ithc->pci, "DSM %pUl %u = 0x%02x\n", guid, func, dest[0]);
++	ACPI_FREE(o);
++	return 1;
++}
++
++int ithc_read_acpi_config(struct ithc *ithc, struct ithc_acpi_config *cfg)
++{
++	int r;
++	acpi_handle handle = ACPI_HANDLE(&ithc->pci->dev);
++
++	cfg->has_config = acpi_check_dsm(handle, &guid_hidspi, DSM_REV, BIT(0));
++	if (!cfg->has_config)
++		return 0;
++
++	// HIDSPI settings
++
++	r = read_acpi_u32(ithc, &guid_hidspi, 1, &cfg->input_report_header_address);
++	if (r < 0)
++		return r;
++	cfg->has_input_report_header_address = r > 0;
++	if (r > 0 && cfg->input_report_header_address > 0xffffff) {
++		pci_err(ithc->pci, "Invalid input report header address 0x%x\n",
++			cfg->input_report_header_address);
++		return -1;
++	}
++
++	r = read_acpi_u32(ithc, &guid_hidspi, 2, &cfg->input_report_body_address);
++	if (r < 0)
++		return r;
++	cfg->has_input_report_body_address = r > 0;
++	if (r > 0 && cfg->input_report_body_address > 0xffffff) {
++		pci_err(ithc->pci, "Invalid input report body address 0x%x\n",
++			cfg->input_report_body_address);
++		return -1;
++	}
++
++	r = read_acpi_u32(ithc, &guid_hidspi, 3, &cfg->output_report_body_address);
++	if (r < 0)
++		return r;
++	cfg->has_output_report_body_address = r > 0;
++	if (r > 0 && cfg->output_report_body_address > 0xffffff) {
++		pci_err(ithc->pci, "Invalid output report body address 0x%x\n",
++			cfg->output_report_body_address);
++		return -1;
++	}
++
++	r = read_acpi_buf(ithc, &guid_hidspi, 4, sizeof(cfg->read_opcode), &cfg->read_opcode);
++	if (r < 0)
++		return r;
++	cfg->has_read_opcode = r > 0;
++
++	r = read_acpi_buf(ithc, &guid_hidspi, 5, sizeof(cfg->write_opcode), &cfg->write_opcode);
++	if (r < 0)
++		return r;
++	cfg->has_write_opcode = r > 0;
++
++	u32 flags;
++	r = read_acpi_u32(ithc, &guid_hidspi, 6, &flags);
++	if (r < 0)
++		return r;
++	cfg->has_read_mode = cfg->has_write_mode = r > 0;
++	if (r > 0) {
++		cfg->read_mode = (flags >> 14) & 3;
++		cfg->write_mode = flags & BIT(13) ? cfg->read_mode : SPI_MODE_SINGLE;
++	}
++
++	// Quick SPI settings
++
++	r = read_acpi_u32(ithc, &guid_thc_quickspi, 1, &cfg->spi_frequency);
++	if (r < 0)
++		return r;
++	cfg->has_spi_frequency = r > 0;
++
++	r = read_acpi_u32(ithc, &guid_thc_quickspi, 2, &cfg->limit_packet_size);
++	if (r < 0)
++		return r;
++	cfg->has_limit_packet_size = r > 0;
++
++	r = read_acpi_u32(ithc, &guid_thc_quickspi, 3, &cfg->tx_delay);
++	if (r < 0)
++		return r;
++	cfg->has_tx_delay = r > 0;
++	if (r > 0)
++		cfg->tx_delay &= 0xffff;
++
++	// LTR settings
++
++	r = read_acpi_u32(ithc, &guid_thc_ltr, 1, &cfg->active_ltr);
++	if (r < 0)
++		return r;
++	cfg->has_active_ltr = r > 0;
++	if (r > 0 && (!cfg->active_ltr || cfg->active_ltr > 0x3ff)) {
++		if (cfg->active_ltr != 0xffffffff)
++			pci_warn(ithc->pci, "Ignoring invalid active LTR value 0x%x\n",
++				cfg->active_ltr);
++		cfg->active_ltr = 500;
++	}
++
++	r = read_acpi_u32(ithc, &guid_thc_ltr, 2, &cfg->idle_ltr);
++	if (r < 0)
++		return r;
++	cfg->has_idle_ltr = r > 0;
++	if (r > 0 && (!cfg->idle_ltr || cfg->idle_ltr > 0x3ff)) {
++		if (cfg->idle_ltr != 0xffffffff)
++			pci_warn(ithc->pci, "Ignoring invalid idle LTR value 0x%x\n",
++				cfg->idle_ltr);
++		cfg->idle_ltr = 500;
++		if (cfg->has_active_ltr && cfg->active_ltr > cfg->idle_ltr)
++			cfg->idle_ltr = cfg->active_ltr;
++	}
++
++	return 0;
++}
++
++void ithc_print_acpi_config(struct ithc *ithc, const struct ithc_acpi_config *cfg)
++{
++	if (!cfg->has_config) {
++		pci_info(ithc->pci, "No ACPI config");
++		return;
++	}
++
++	char input_report_header_address[16] = "-";
++	if (cfg->has_input_report_header_address)
++		sprintf(input_report_header_address, "0x%x", cfg->input_report_header_address);
++	char input_report_body_address[16] = "-";
++	if (cfg->has_input_report_body_address)
++		sprintf(input_report_body_address, "0x%x", cfg->input_report_body_address);
++	char output_report_body_address[16] = "-";
++	if (cfg->has_output_report_body_address)
++		sprintf(output_report_body_address, "0x%x", cfg->output_report_body_address);
++	char read_opcode[16] = "-";
++	if (cfg->has_read_opcode)
++		sprintf(read_opcode, "0x%02x", cfg->read_opcode);
++	char write_opcode[16] = "-";
++	if (cfg->has_write_opcode)
++		sprintf(write_opcode, "0x%02x", cfg->write_opcode);
++	char read_mode[16] = "-";
++	if (cfg->has_read_mode)
++		sprintf(read_mode, "%i", cfg->read_mode);
++	char write_mode[16] = "-";
++	if (cfg->has_write_mode)
++		sprintf(write_mode, "%i", cfg->write_mode);
++	char spi_frequency[16] = "-";
++	if (cfg->has_spi_frequency)
++		sprintf(spi_frequency, "%u", cfg->spi_frequency);
++	char limit_packet_size[16] = "-";
++	if (cfg->has_limit_packet_size)
++		sprintf(limit_packet_size, "%u", cfg->limit_packet_size);
++	char tx_delay[16] = "-";
++	if (cfg->has_tx_delay)
++		sprintf(tx_delay, "%u", cfg->tx_delay);
++	char active_ltr[16] = "-";
++	if (cfg->has_active_ltr)
++		sprintf(active_ltr, "%u", cfg->active_ltr);
++	char idle_ltr[16] = "-";
++	if (cfg->has_idle_ltr)
++		sprintf(idle_ltr, "%u", cfg->idle_ltr);
++
++	pci_info(ithc->pci, "ACPI config: InputHeaderAddr=%s InputBodyAddr=%s OutputBodyAddr=%s ReadOpcode=%s WriteOpcode=%s ReadMode=%s WriteMode=%s Frequency=%s LimitPacketSize=%s TxDelay=%s ActiveLTR=%s IdleLTR=%s\n",
++		input_report_header_address, input_report_body_address, output_report_body_address,
++		read_opcode, write_opcode, read_mode, write_mode,
++		spi_frequency, limit_packet_size, tx_delay, active_ltr, idle_ltr);
++}
++
++static void set_opcode(struct ithc *ithc, size_t i, u8 opcode)
++{
++	writeb(opcode, &ithc->regs->opcode[i].header);
++	writeb(opcode, &ithc->regs->opcode[i].single);
++	writeb(opcode, &ithc->regs->opcode[i].dual);
++	writeb(opcode, &ithc->regs->opcode[i].quad);
++}
++
++static int ithc_quickspi_init_regs(struct ithc *ithc, const struct ithc_acpi_config *cfg)
++{
++	pci_dbg(ithc->pci, "initializing QuickSPI registers\n");
++
++	// SPI frequency and mode
++	if (!cfg->has_spi_frequency || !cfg->spi_frequency) {
++		pci_err(ithc->pci, "Missing SPI frequency in configuration\n");
++		return -EINVAL;
++	}
++	unsigned int clkdiv = DIV_ROUND_UP(SPI_CLK_FREQ_BASE, cfg->spi_frequency);
++	bool clkdiv8 = clkdiv > 7;
++	if (clkdiv8)
++		clkdiv = min(7u, DIV_ROUND_UP(clkdiv, 8u));
++	if (!clkdiv)
++		clkdiv = 1;
++	CHECK_RET(ithc_set_spi_config, ithc, clkdiv, clkdiv8,
++		cfg->has_read_mode ? cfg->read_mode : SPI_MODE_SINGLE,
++		cfg->has_write_mode ? cfg->write_mode : SPI_MODE_SINGLE);
++
++	// SPI addresses and opcodes
++	if (cfg->has_input_report_header_address)
++		writel(cfg->input_report_header_address, &ithc->regs->spi_header_addr);
++	if (cfg->has_input_report_body_address) {
++		writel(cfg->input_report_body_address, &ithc->regs->dma_rx[0].spi_addr);
++		writel(cfg->input_report_body_address, &ithc->regs->dma_rx[1].spi_addr);
++	}
++	if (cfg->has_output_report_body_address)
++		writel(cfg->output_report_body_address, &ithc->regs->dma_tx.spi_addr);
++
++	switch (ithc->pci->device) {
++	// LKF/TGL don't support QuickSPI.
++	// For ADL, opcode layout is RX/TX/unused.
++	case PCI_DEVICE_ID_INTEL_THC_ADL_S_PORT1:
++	case PCI_DEVICE_ID_INTEL_THC_ADL_S_PORT2:
++	case PCI_DEVICE_ID_INTEL_THC_ADL_P_PORT1:
++	case PCI_DEVICE_ID_INTEL_THC_ADL_P_PORT2:
++	case PCI_DEVICE_ID_INTEL_THC_ADL_M_PORT1:
++	case PCI_DEVICE_ID_INTEL_THC_ADL_M_PORT2:
++		if (cfg->has_read_opcode) {
++			set_opcode(ithc, 0, cfg->read_opcode);
++		}
++		if (cfg->has_write_opcode) {
++			set_opcode(ithc, 1, cfg->write_opcode);
++		}
++		break;
++	// For MTL, opcode layout was changed to RX/RX/TX.
++	// (RPL layout is unknown.)
++	default:
++		if (cfg->has_read_opcode) {
++			set_opcode(ithc, 0, cfg->read_opcode);
++			set_opcode(ithc, 1, cfg->read_opcode);
++		}
++		if (cfg->has_write_opcode) {
++			set_opcode(ithc, 2, cfg->write_opcode);
++		}
++		break;
++	}
++
++	ithc_log_regs(ithc);
++
++	// The rest...
++	bitsl_set(&ithc->regs->dma_rx[0].init_unknown, INIT_UNKNOWN_31);
++
++	bitsl(&ithc->regs->quickspi_config1,
++		QUICKSPI_CONFIG1_UNKNOWN_0(0xff) | QUICKSPI_CONFIG1_UNKNOWN_5(0xff) |
++		QUICKSPI_CONFIG1_UNKNOWN_10(0xff) | QUICKSPI_CONFIG1_UNKNOWN_16(0xffff),
++		QUICKSPI_CONFIG1_UNKNOWN_0(4) | QUICKSPI_CONFIG1_UNKNOWN_5(4) |
++		QUICKSPI_CONFIG1_UNKNOWN_10(22) | QUICKSPI_CONFIG1_UNKNOWN_16(2));
++
++	bitsl(&ithc->regs->quickspi_config2,
++		QUICKSPI_CONFIG2_UNKNOWN_0(0xff) | QUICKSPI_CONFIG2_UNKNOWN_5(0xff) |
++		QUICKSPI_CONFIG2_UNKNOWN_12(0xff),
++		QUICKSPI_CONFIG2_UNKNOWN_0(8) | QUICKSPI_CONFIG2_UNKNOWN_5(14) |
++		QUICKSPI_CONFIG2_UNKNOWN_12(2));
++
++	u32 pktsize = cfg->has_limit_packet_size && cfg->limit_packet_size == 1 ? 4 : 0x80;
++	bitsl(&ithc->regs->spi_config,
++		SPI_CONFIG_READ_PACKET_SIZE(0xfff) | SPI_CONFIG_WRITE_PACKET_SIZE(0xfff),
++		SPI_CONFIG_READ_PACKET_SIZE(pktsize) | SPI_CONFIG_WRITE_PACKET_SIZE(pktsize));
++
++	bitsl_set(&ithc->regs->quickspi_config2,
++		QUICKSPI_CONFIG2_UNKNOWN_16 | QUICKSPI_CONFIG2_UNKNOWN_17);
++	bitsl(&ithc->regs->quickspi_config2,
++		QUICKSPI_CONFIG2_DISABLE_READ_ADDRESS_INCREMENT |
++		QUICKSPI_CONFIG2_DISABLE_WRITE_ADDRESS_INCREMENT |
++		QUICKSPI_CONFIG2_ENABLE_WRITE_STREAMING_MODE, 0);
++
++	return 0;
++}
++
++static int wait_for_report(struct ithc *ithc)
++{
++	CHECK_RET(waitl, ithc, &ithc->regs->dma_rx[0].status,
++		DMA_RX_STATUS_READY, DMA_RX_STATUS_READY);
++	writel(DMA_RX_STATUS_READY, &ithc->regs->dma_rx[0].status);
++
++	u32 h = readl(&ithc->regs->input_header);
++	ithc_log_regs(ithc);
++	if (INPUT_HEADER_SYNC(h) != INPUT_HEADER_SYNC_VALUE
++		|| INPUT_HEADER_VERSION(h) != INPUT_HEADER_VERSION_VALUE) {
++		pci_err(ithc->pci, "invalid input report frame header 0x%08x\n", h);
++		return -ENODATA;
++	}
++	return INPUT_HEADER_REPORT_LENGTH(h) * 4;
++}
++
++static int ithc_quickspi_init_hidspi(struct ithc *ithc, const struct ithc_acpi_config *cfg)
++{
++	pci_dbg(ithc->pci, "initializing HIDSPI\n");
++
++	// HIDSPI initialization sequence:
++	// "1. The host shall invoke the ACPI reset method to clear the device state."
++	acpi_status s = acpi_evaluate_object(ACPI_HANDLE(&ithc->pci->dev), "_RST", NULL, NULL);
++	if (ACPI_FAILURE(s)) {
++		pci_err(ithc->pci, "ACPI reset failed\n");
++		return -EIO;
++	}
++
++	bitsl(&ithc->regs->control_bits, CONTROL_QUIESCE, 0);
++
++	// "2. Within 1 second, the device shall signal an interrupt and make available to the host
++	// an input report containing a device reset response."
++	int size = wait_for_report(ithc);
++	if (size < 0)
++		return size;
++	if (size < sizeof(struct hidspi_header)) {
++		pci_err(ithc->pci, "SPI data size too small for reset response (%u)\n", size);
++		return -EMSGSIZE;
++	}
++
++	// "3. The host shall read the reset response from the device at the Input Report addresses
++	// specified in ACPI."
++	u32 in_addr = cfg->has_input_report_body_address ? cfg->input_report_body_address : 0x1000;
++	struct {
++		struct hidspi_header header;
++		union {
++			struct hidspi_device_descriptor device_desc;
++			u32 data[16];
++		};
++	} resp = { 0 };
++	if (size > sizeof(resp)) {
++		pci_err(ithc->pci, "SPI data size for reset response too big (%u)\n", size);
++		return -EMSGSIZE;
++	}
++	CHECK_RET(ithc_spi_command, ithc, SPI_CMD_CODE_READ, in_addr, size, &resp);
++	if (resp.header.type != HIDSPI_INPUT_TYPE_RESET_RESPONSE) {
++		pci_err(ithc->pci, "received type %i instead of reset response\n", resp.header.type);
++		return -ENOMSG;
++	}
++
++	// "4. The host shall then write an Output Report to the device at the Output Report Address
++	// specified in ACPI, requesting the Device Descriptor from the device."
++	u32 out_addr = cfg->has_output_report_body_address ? cfg->output_report_body_address : 0x1000;
++	struct hidspi_header req = { .type = HIDSPI_OUTPUT_TYPE_DEVICE_DESCRIPTOR_REQUEST };
++	CHECK_RET(ithc_spi_command, ithc, SPI_CMD_CODE_WRITE, out_addr, sizeof(req), &req);
++
++	// "5. Within 1 second, the device shall signal an interrupt and make available to the host
++	// an input report containing the Device Descriptor."
++	size = wait_for_report(ithc);
++	if (size < 0)
++		return size;
++	if (size < sizeof(resp.header) + sizeof(resp.device_desc)) {
++		pci_err(ithc->pci, "SPI data size too small for device descriptor (%u)\n", size);
++		return -EMSGSIZE;
++	}
++
++	// "6. The host shall read the Device Descriptor from the Input Report addresses specified
++	// in ACPI."
++	if (size > sizeof(resp)) {
++		pci_err(ithc->pci, "SPI data size for device descriptor too big (%u)\n", size);
++		return -EMSGSIZE;
++	}
++	memset(&resp, 0, sizeof(resp));
++	CHECK_RET(ithc_spi_command, ithc, SPI_CMD_CODE_READ, in_addr, size, &resp);
++	if (resp.header.type != HIDSPI_INPUT_TYPE_DEVICE_DESCRIPTOR) {
++		pci_err(ithc->pci, "received type %i instead of device descriptor\n",
++			resp.header.type);
++		return -ENOMSG;
++	}
++	struct hidspi_device_descriptor *d = &resp.device_desc;
++	if (resp.header.len < sizeof(*d)) {
++		pci_err(ithc->pci, "response too small for device descriptor (%u)\n",
++			resp.header.len);
++		return -EMSGSIZE;
++	}
++	if (d->wDeviceDescLength != sizeof(*d)) {
++		pci_err(ithc->pci, "invalid device descriptor length (%u)\n",
++			d->wDeviceDescLength);
++		return -EMSGSIZE;
++	}
++
++	pci_info(ithc->pci, "Device descriptor: bcdVersion=0x%04x wReportDescLength=%u wMaxInputLength=%u wMaxOutputLength=%u wMaxFragmentLength=%u wVendorID=0x%04x wProductID=0x%04x wVersionID=0x%04x wFlags=0x%04x dwReserved=0x%08x\n",
++		d->bcdVersion, d->wReportDescLength,
++		d->wMaxInputLength, d->wMaxOutputLength, d->wMaxFragmentLength,
++		d->wVendorID, d->wProductID, d->wVersionID,
++		d->wFlags, d->dwReserved);
++
++	ithc->vendor_id = d->wVendorID;
++	ithc->product_id = d->wProductID;
++	ithc->product_rev = d->wVersionID;
++	ithc->max_rx_size = max_t(u32, d->wMaxInputLength,
++		d->wReportDescLength + sizeof(struct hidspi_header));
++	ithc->max_tx_size = d->wMaxOutputLength;
++	ithc->have_config = true;
++
++	// "7. The device and host shall then enter their "Ready" states - where the device may
++	// begin sending Input Reports, and the device shall be prepared for Output Reports from
++	// the host."
++
++	return 0;
++}
++
++int ithc_quickspi_init(struct ithc *ithc, const struct ithc_acpi_config *cfg)
++{
++	bitsl_set(&ithc->regs->control_bits, CONTROL_QUIESCE);
++	CHECK_RET(waitl, ithc, &ithc->regs->control_bits, CONTROL_IS_QUIESCED, CONTROL_IS_QUIESCED);
++
++	ithc_log_regs(ithc);
++	CHECK_RET(ithc_quickspi_init_regs, ithc, cfg);
++	ithc_log_regs(ithc);
++	CHECK_RET(ithc_quickspi_init_hidspi, ithc, cfg);
++	ithc_log_regs(ithc);
++
++	// This value is set to 2 in ithc_quickspi_init_regs(). It needs to be set to 1 here,
++	// otherwise DMA will not work. Maybe selects between DMA and PIO mode?
++	bitsl(&ithc->regs->quickspi_config1,
++		QUICKSPI_CONFIG1_UNKNOWN_16(0xffff), QUICKSPI_CONFIG1_UNKNOWN_16(1));
++
++	// TODO Do we need to set any of the following bits here?
++	//bitsb_set(&ithc->regs->dma_rx[1].control2, DMA_RX_CONTROL2_UNKNOWN_4);
++	//bitsb_set(&ithc->regs->dma_rx[0].control2, DMA_RX_CONTROL2_UNKNOWN_5);
++	//bitsb_set(&ithc->regs->dma_rx[1].control2, DMA_RX_CONTROL2_UNKNOWN_5);
++	//bitsl_set(&ithc->regs->dma_rx[0].init_unknown, INIT_UNKNOWN_3);
++	//bitsl_set(&ithc->regs->dma_rx[0].init_unknown, INIT_UNKNOWN_31);
++
++	ithc_log_regs(ithc);
++
++	return 0;
++}
++
++void ithc_quickspi_exit(struct ithc *ithc)
++{
++	// TODO Should we send HIDSPI 'power off' command?
++	//struct hidspi_header h = { .type = HIDSPI_OUTPUT_TYPE_COMMAND, .id = 3, };
++	//struct ithc_data d = { .type = ITHC_DATA_RAW, .data = &h, .size = sizeof(h) };
++	//CHECK(ithc_dma_tx, ithc, &d); // or ithc_spi_command()
++}
++
++int ithc_quickspi_decode_rx(struct ithc *ithc, const void *src, size_t len, struct ithc_data *dest)
++{
++	const struct hidspi_header *hdr = src;
++
++	if (len < sizeof(*hdr))
++		return -ENODATA;
++	// TODO Do we need to handle HIDSPI packet fragmentation?
++	if (len < sizeof(*hdr) + hdr->len)
++		return -EMSGSIZE;
++	if (len > round_up(sizeof(*hdr) + hdr->len, 4))
++		return -EMSGSIZE;
++
++	switch (hdr->type) {
++	case HIDSPI_INPUT_TYPE_RESET_RESPONSE:
++		// TODO "When the device detects an error condition, it may interrupt and make
++		// available to the host an Input Report containing an unsolicited Reset Response.
++		// After receiving an unsolicited Reset Response, the host shall initiate the
++		// request procedure from step (4) in the [HIDSPI initialization] process."
++		dest->type = ITHC_DATA_ERROR;
++		return 0;
++	case HIDSPI_INPUT_TYPE_REPORT_DESCRIPTOR:
++		dest->type = ITHC_DATA_REPORT_DESCRIPTOR;
++		dest->data = hdr + 1;
++		dest->size = hdr->len;
++		return 0;
++	case HIDSPI_INPUT_TYPE_DATA:
++	case HIDSPI_INPUT_TYPE_GET_INPUT_REPORT_RESPONSE:
++		dest->type = ITHC_DATA_INPUT_REPORT;
++		dest->data = &hdr->id;
++		dest->size = hdr->len + 1;
++		return 0;
++	case HIDSPI_INPUT_TYPE_GET_FEATURE_RESPONSE:
++		dest->type = ITHC_DATA_GET_FEATURE;
++		dest->data = &hdr->id;
++		dest->size = hdr->len + 1;
++		return 0;
++	case HIDSPI_INPUT_TYPE_SET_FEATURE_RESPONSE:
++	case HIDSPI_INPUT_TYPE_OUTPUT_REPORT_RESPONSE:
++		dest->type = ITHC_DATA_IGNORE;
++		return 0;
++	default:
++		return -EINVAL;
++	}
++}
++
++ssize_t ithc_quickspi_encode_tx(struct ithc *ithc, const struct ithc_data *src, void *dest,
++	size_t maxlen)
++{
++	struct hidspi_header *hdr = dest;
++
++	size_t src_size = src->size;
++	const u8 *src_data = src->data;
++	u8 type;
++
++	switch (src->type) {
++	case ITHC_DATA_SET_FEATURE:
++		type = HIDSPI_OUTPUT_TYPE_SET_FEATURE;
++		break;
++	case ITHC_DATA_GET_FEATURE:
++		type = HIDSPI_OUTPUT_TYPE_GET_FEATURE;
++		break;
++	case ITHC_DATA_OUTPUT_REPORT:
++		type = HIDSPI_OUTPUT_TYPE_OUTPUT_REPORT;
++		break;
++	case ITHC_DATA_REPORT_DESCRIPTOR:
++		type = HIDSPI_OUTPUT_TYPE_REPORT_DESCRIPTOR_REQUEST;
++		src_size = 0;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	u8 id = 0;
++	if (src_size) {
++		id = *src_data++;
++		src_size--;
++	}
++
++	// Data must be padded to next 4-byte boundary.
++	size_t padded = round_up(src_size, 4);
++	if (sizeof(*hdr) + padded > maxlen)
++		return -EOVERFLOW;
++
++	// Fill the TX buffer with header and data.
++	hdr->type = type;
++	hdr->len = (u16)src_size;
++	hdr->id = id;
++	memcpy_and_pad(hdr + 1, padded, src_data, src_size, 0);
++
++	return sizeof(*hdr) + padded;
++}
++
+diff --git a/drivers/hid/ithc/ithc-quickspi.h b/drivers/hid/ithc/ithc-quickspi.h
+new file mode 100644
+index 000000000..74d882f6b
+--- /dev/null
++++ b/drivers/hid/ithc/ithc-quickspi.h
+@@ -0,0 +1,39 @@
++/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
++
++struct ithc_acpi_config {
++	bool has_config: 1;
++	bool has_input_report_header_address: 1;
++	bool has_input_report_body_address: 1;
++	bool has_output_report_body_address: 1;
++	bool has_read_opcode: 1;
++	bool has_write_opcode: 1;
++	bool has_read_mode: 1;
++	bool has_write_mode: 1;
++	bool has_spi_frequency: 1;
++	bool has_limit_packet_size: 1;
++	bool has_tx_delay: 1;
++	bool has_active_ltr: 1;
++	bool has_idle_ltr: 1;
++	u32 input_report_header_address;
++	u32 input_report_body_address;
++	u32 output_report_body_address;
++	u8 read_opcode;
++	u8 write_opcode;
++	u8 read_mode;
++	u8 write_mode;
++	u32 spi_frequency;
++	u32 limit_packet_size;
++	u32 tx_delay; // us/10 // TODO use?
++	u32 active_ltr; // ns/1024
++	u32 idle_ltr; // ns/1024
++};
++
++int ithc_read_acpi_config(struct ithc *ithc, struct ithc_acpi_config *cfg);
++void ithc_print_acpi_config(struct ithc *ithc, const struct ithc_acpi_config *cfg);
++
++int ithc_quickspi_init(struct ithc *ithc, const struct ithc_acpi_config *cfg);
++void ithc_quickspi_exit(struct ithc *ithc);
++int ithc_quickspi_decode_rx(struct ithc *ithc, const void *src, size_t len, struct ithc_data *dest);
++ssize_t ithc_quickspi_encode_tx(struct ithc *ithc, const struct ithc_data *src, void *dest,
++	size_t maxlen);
++
+diff --git a/drivers/hid/ithc/ithc-regs.c b/drivers/hid/ithc/ithc-regs.c
+new file mode 100644
+index 000000000..c0f13506a
+--- /dev/null
++++ b/drivers/hid/ithc/ithc-regs.c
+@@ -0,0 +1,154 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
++
++#include "ithc.h"
++
++#define reg_num(r) (0x1fff & (u16)(__force u64)(r))
++
++void bitsl(__iomem u32 *reg, u32 mask, u32 val)
++{
++	if (val & ~mask)
++		pr_err("register 0x%x: invalid value 0x%x for bitmask 0x%x\n",
++			reg_num(reg), val, mask);
++	writel((readl(reg) & ~mask) | (val & mask), reg);
++}
++
++void bitsb(__iomem u8 *reg, u8 mask, u8 val)
++{
++	if (val & ~mask)
++		pr_err("register 0x%x: invalid value 0x%x for bitmask 0x%x\n",
++			reg_num(reg), val, mask);
++	writeb((readb(reg) & ~mask) | (val & mask), reg);
++}
++
++int waitl(struct ithc *ithc, __iomem u32 *reg, u32 mask, u32 val)
++{
++	ithc_log_regs(ithc);
++	pci_dbg(ithc->pci, "waiting for reg 0x%04x mask 0x%08x val 0x%08x\n",
++		reg_num(reg), mask, val);
++	u32 x;
++	if (readl_poll_timeout(reg, x, (x & mask) == val, 200, 1000*1000)) {
++		ithc_log_regs(ithc);
++		pci_err(ithc->pci, "timed out waiting for reg 0x%04x mask 0x%08x val 0x%08x\n",
++			reg_num(reg), mask, val);
++		return -ETIMEDOUT;
++	}
++	ithc_log_regs(ithc);
++	pci_dbg(ithc->pci, "done waiting\n");
++	return 0;
++}
++
++int waitb(struct ithc *ithc, __iomem u8 *reg, u8 mask, u8 val)
++{
++	ithc_log_regs(ithc);
++	pci_dbg(ithc->pci, "waiting for reg 0x%04x mask 0x%02x val 0x%02x\n",
++		reg_num(reg), mask, val);
++	u8 x;
++	if (readb_poll_timeout(reg, x, (x & mask) == val, 200, 1000*1000)) {
++		ithc_log_regs(ithc);
++		pci_err(ithc->pci, "timed out waiting for reg 0x%04x mask 0x%02x val 0x%02x\n",
++			reg_num(reg), mask, val);
++		return -ETIMEDOUT;
++	}
++	ithc_log_regs(ithc);
++	pci_dbg(ithc->pci, "done waiting\n");
++	return 0;
++}
++
++static void calc_ltr(u64 *ns, unsigned int *val, unsigned int *scale)
++{
++	unsigned int s = 0;
++	u64 v = *ns;
++	while (v > 0x3ff) {
++		s++;
++		v >>= 5;
++	}
++	if (s > 5) {
++		s = 5;
++		v = 0x3ff;
++	}
++	*val = v;
++	*scale = s;
++	*ns = v << (5 * s);
++}
++
++void ithc_set_ltr_config(struct ithc *ithc, u64 active_ltr_ns, u64 idle_ltr_ns)
++{
++	unsigned int active_val, active_scale, idle_val, idle_scale;
++	calc_ltr(&active_ltr_ns, &active_val, &active_scale);
++	calc_ltr(&idle_ltr_ns, &idle_val, &idle_scale);
++	pci_dbg(ithc->pci, "setting active LTR value to %llu ns, idle LTR value to %llu ns\n",
++		active_ltr_ns, idle_ltr_ns);
++	writel(LTR_CONFIG_ENABLE_ACTIVE | LTR_CONFIG_ENABLE_IDLE | LTR_CONFIG_APPLY |
++		LTR_CONFIG_ACTIVE_LTR_SCALE(active_scale) | LTR_CONFIG_ACTIVE_LTR_VALUE(active_val) |
++		LTR_CONFIG_IDLE_LTR_SCALE(idle_scale) | LTR_CONFIG_IDLE_LTR_VALUE(idle_val),
++		&ithc->regs->ltr_config);
++}
++
++void ithc_set_ltr_idle(struct ithc *ithc)
++{
++	u32 ltr = readl(&ithc->regs->ltr_config);
++	switch (ltr & (LTR_CONFIG_STATUS_ACTIVE | LTR_CONFIG_STATUS_IDLE)) {
++	case LTR_CONFIG_STATUS_IDLE:
++		break;
++	case LTR_CONFIG_STATUS_ACTIVE:
++		writel(ltr | LTR_CONFIG_TOGGLE | LTR_CONFIG_APPLY, &ithc->regs->ltr_config);
++		break;
++	default:
++		pci_err(ithc->pci, "invalid LTR state 0x%08x\n", ltr);
++		break;
++	}
++}
++
++int ithc_set_spi_config(struct ithc *ithc, u8 clkdiv, bool clkdiv8, u8 read_mode, u8 write_mode)
++{
++	if (clkdiv == 0 || clkdiv > 7 || read_mode > SPI_MODE_QUAD || write_mode > SPI_MODE_QUAD)
++		return -EINVAL;
++	static const char * const modes[] = { "single", "dual", "quad" };
++	pci_dbg(ithc->pci, "setting SPI frequency to %i Hz, %s read, %s write\n",
++		SPI_CLK_FREQ_BASE / (clkdiv * (clkdiv8 ? 8 : 1)),
++		modes[read_mode], modes[write_mode]);
++	bitsl(&ithc->regs->spi_config,
++		SPI_CONFIG_READ_MODE(0xff) | SPI_CONFIG_READ_CLKDIV(0xff) |
++		SPI_CONFIG_WRITE_MODE(0xff) | SPI_CONFIG_WRITE_CLKDIV(0xff) |
++		SPI_CONFIG_CLKDIV_8,
++		SPI_CONFIG_READ_MODE(read_mode) | SPI_CONFIG_READ_CLKDIV(clkdiv) |
++		SPI_CONFIG_WRITE_MODE(write_mode) | SPI_CONFIG_WRITE_CLKDIV(clkdiv) |
++		(clkdiv8 ? SPI_CONFIG_CLKDIV_8 : 0));
++	return 0;
++}
++
++int ithc_spi_command(struct ithc *ithc, u8 command, u32 offset, u32 size, void *data)
++{
++	pci_dbg(ithc->pci, "SPI command %u, size %u, offset 0x%x\n", command, size, offset);
++	if (size > sizeof(ithc->regs->spi_cmd.data))
++		return -EINVAL;
++
++	// Wait if the device is still busy.
++	CHECK_RET(waitl, ithc, &ithc->regs->spi_cmd.status, SPI_CMD_STATUS_BUSY, 0);
++	// Clear result flags.
++	writel(SPI_CMD_STATUS_DONE | SPI_CMD_STATUS_ERROR, &ithc->regs->spi_cmd.status);
++
++	// Init SPI command data.
++	writeb(command, &ithc->regs->spi_cmd.code);
++	writew(size, &ithc->regs->spi_cmd.size);
++	writel(offset, &ithc->regs->spi_cmd.offset);
++	u32 *p = data, n = (size + 3) / 4;
++	for (u32 i = 0; i < n; i++)
++		writel(p[i], &ithc->regs->spi_cmd.data[i]);
++
++	// Start transmission.
++	bitsb_set(&ithc->regs->spi_cmd.control, SPI_CMD_CONTROL_SEND);
++	CHECK_RET(waitl, ithc, &ithc->regs->spi_cmd.status, SPI_CMD_STATUS_BUSY, 0);
++
++	// Read response.
++	if ((readl(&ithc->regs->spi_cmd.status) & (SPI_CMD_STATUS_DONE | SPI_CMD_STATUS_ERROR)) != SPI_CMD_STATUS_DONE)
++		return -EIO;
++	if (readw(&ithc->regs->spi_cmd.size) != size)
++		return -EMSGSIZE;
++	for (u32 i = 0; i < n; i++)
++		p[i] = readl(&ithc->regs->spi_cmd.data[i]);
++
++	writel(SPI_CMD_STATUS_DONE | SPI_CMD_STATUS_ERROR, &ithc->regs->spi_cmd.status);
++	return 0;
++}
++
+diff --git a/drivers/hid/ithc/ithc-regs.h b/drivers/hid/ithc/ithc-regs.h
+new file mode 100644
+index 000000000..4f541fe53
+--- /dev/null
++++ b/drivers/hid/ithc/ithc-regs.h
+@@ -0,0 +1,211 @@
++/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
++
++#define LTR_CONFIG_ENABLE_ACTIVE            BIT(0)
++#define LTR_CONFIG_TOGGLE                   BIT(1)
++#define LTR_CONFIG_ENABLE_IDLE              BIT(2)
++#define LTR_CONFIG_APPLY                    BIT(3)
++#define LTR_CONFIG_IDLE_LTR_SCALE(x)        (((x) & 7) << 4)
++#define LTR_CONFIG_IDLE_LTR_VALUE(x)        (((x) & 0x3ff) << 7)
++#define LTR_CONFIG_ACTIVE_LTR_SCALE(x)      (((x) & 7) << 17)
++#define LTR_CONFIG_ACTIVE_LTR_VALUE(x)      (((x) & 0x3ff) << 20)
++#define LTR_CONFIG_STATUS_ACTIVE            BIT(30)
++#define LTR_CONFIG_STATUS_IDLE              BIT(31)
++
++#define CONTROL_QUIESCE                     BIT(1)
++#define CONTROL_IS_QUIESCED                 BIT(2)
++#define CONTROL_NRESET                      BIT(3)
++#define CONTROL_UNKNOWN_24(x)               (((x) & 3) << 24)
++#define CONTROL_READY                       BIT(29)
++
++#define SPI_CONFIG_READ_MODE(x)             (((x) & 3) << 2)
++#define SPI_CONFIG_READ_CLKDIV(x)           (((x) & 7) << 4)
++#define SPI_CONFIG_READ_PACKET_SIZE(x)      (((x) & 0x1ff) << 7)
++#define SPI_CONFIG_WRITE_MODE(x)            (((x) & 3) << 18)
++#define SPI_CONFIG_WRITE_CLKDIV(x)          (((x) & 7) << 20)
++#define SPI_CONFIG_CLKDIV_8                 BIT(23) // additionally divide clk by 8, for both read and write
++#define SPI_CONFIG_WRITE_PACKET_SIZE(x)     (((x) & 0xff) << 24)
++
++#define SPI_CLK_FREQ_BASE                   125000000
++#define SPI_MODE_SINGLE                     0
++#define SPI_MODE_DUAL                       1
++#define SPI_MODE_QUAD                       2
++
++#define ERROR_CONTROL_UNKNOWN_0             BIT(0)
++#define ERROR_CONTROL_DISABLE_DMA           BIT(1) // clears DMA_RX_CONTROL_ENABLE when a DMA error occurs
++#define ERROR_CONTROL_UNKNOWN_2             BIT(2)
++#define ERROR_CONTROL_UNKNOWN_3             BIT(3)
++#define ERROR_CONTROL_IRQ_DMA_UNKNOWN_9     BIT(9)
++#define ERROR_CONTROL_IRQ_DMA_UNKNOWN_10    BIT(10)
++#define ERROR_CONTROL_IRQ_DMA_UNKNOWN_12    BIT(12)
++#define ERROR_CONTROL_IRQ_DMA_UNKNOWN_13    BIT(13)
++#define ERROR_CONTROL_UNKNOWN_16(x)         (((x) & 0xff) << 16) // spi error code irq?
++#define ERROR_CONTROL_SET_DMA_STATUS        BIT(29) // sets DMA_RX_STATUS_ERROR when a DMA error occurs
++
++#define ERROR_STATUS_DMA                    BIT(28)
++#define ERROR_STATUS_SPI                    BIT(30)
++
++#define ERROR_FLAG_DMA_UNKNOWN_9            BIT(9)
++#define ERROR_FLAG_DMA_UNKNOWN_10           BIT(10)
++#define ERROR_FLAG_DMA_RX_TIMEOUT           BIT(12) // set when we receive a truncated DMA message
++#define ERROR_FLAG_DMA_UNKNOWN_13           BIT(13)
++#define ERROR_FLAG_SPI_BUS_TURNAROUND       BIT(16)
++#define ERROR_FLAG_SPI_RESPONSE_TIMEOUT     BIT(17)
++#define ERROR_FLAG_SPI_INTRA_PACKET_TIMEOUT BIT(18)
++#define ERROR_FLAG_SPI_INVALID_RESPONSE     BIT(19)
++#define ERROR_FLAG_SPI_HS_RX_TIMEOUT        BIT(20)
++#define ERROR_FLAG_SPI_TOUCH_IC_INIT        BIT(21)
++
++#define SPI_CMD_CONTROL_SEND                BIT(0) // cleared by device when sending is complete
++#define SPI_CMD_CONTROL_IRQ                 BIT(1)
++
++#define SPI_CMD_CODE_READ                   4
++#define SPI_CMD_CODE_WRITE                  6
++
++#define SPI_CMD_STATUS_DONE                 BIT(0)
++#define SPI_CMD_STATUS_ERROR                BIT(1)
++#define SPI_CMD_STATUS_BUSY                 BIT(3)
++
++#define DMA_TX_CONTROL_SEND                 BIT(0) // cleared by device when sending is complete
++#define DMA_TX_CONTROL_IRQ                  BIT(3)
++
++#define DMA_TX_STATUS_DONE                  BIT(0)
++#define DMA_TX_STATUS_ERROR                 BIT(1)
++#define DMA_TX_STATUS_UNKNOWN_2             BIT(2)
++#define DMA_TX_STATUS_UNKNOWN_3             BIT(3) // busy?
++
++#define INPUT_HEADER_VERSION(x)             ((x) & 0xf)
++#define INPUT_HEADER_REPORT_LENGTH(x)       (((x) >> 8) & 0x3fff)
++#define INPUT_HEADER_SYNC(x)                ((x) >> 24)
++#define INPUT_HEADER_VERSION_VALUE          3
++#define INPUT_HEADER_SYNC_VALUE             0x5a
++
++#define QUICKSPI_CONFIG1_UNKNOWN_0(x)       (((x) & 0x1f) << 0)
++#define QUICKSPI_CONFIG1_UNKNOWN_5(x)       (((x) & 0x1f) << 5)
++#define QUICKSPI_CONFIG1_UNKNOWN_10(x)      (((x) & 0x1f) << 10)
++#define QUICKSPI_CONFIG1_UNKNOWN_16(x)      (((x) & 0xffff) << 16)
++
++#define QUICKSPI_CONFIG2_UNKNOWN_0(x)       (((x) & 0x1f) << 0)
++#define QUICKSPI_CONFIG2_UNKNOWN_5(x)       (((x) & 0x1f) << 5)
++#define QUICKSPI_CONFIG2_UNKNOWN_12(x)      (((x) & 0xf) << 12)
++#define QUICKSPI_CONFIG2_UNKNOWN_16         BIT(16)
++#define QUICKSPI_CONFIG2_UNKNOWN_17         BIT(17)
++#define QUICKSPI_CONFIG2_DISABLE_READ_ADDRESS_INCREMENT  BIT(24)
++#define QUICKSPI_CONFIG2_DISABLE_WRITE_ADDRESS_INCREMENT BIT(25)
++#define QUICKSPI_CONFIG2_ENABLE_WRITE_STREAMING_MODE     BIT(27)
++#define QUICKSPI_CONFIG2_IRQ_POLARITY       BIT(28)
++
++#define DMA_RX_CONTROL_ENABLE               BIT(0)
++#define DMA_RX_CONTROL_IRQ_UNKNOWN_1        BIT(1) // rx1 only?
++#define DMA_RX_CONTROL_IRQ_ERROR            BIT(3) // rx1 only?
++#define DMA_RX_CONTROL_IRQ_READY            BIT(4) // rx0 only
++#define DMA_RX_CONTROL_IRQ_DATA             BIT(5)
++
++#define DMA_RX_CONTROL2_UNKNOWN_4           BIT(4) // rx1 only?
++#define DMA_RX_CONTROL2_UNKNOWN_5           BIT(5) // rx0 only?
++#define DMA_RX_CONTROL2_RESET               BIT(7) // resets ringbuffer indices
++
++#define DMA_RX_WRAP_FLAG                    BIT(7)
++
++#define DMA_RX_STATUS_ERROR                 BIT(3)
++#define DMA_RX_STATUS_READY                 BIT(4) // set in rx0 after using CONTROL_NRESET when it becomes possible to read config (can take >100ms)
++#define DMA_RX_STATUS_HAVE_DATA             BIT(5)
++#define DMA_RX_STATUS_ENABLED               BIT(8)
++
++#define INIT_UNKNOWN_GUC_2                  BIT(2)
++#define INIT_UNKNOWN_3                      BIT(3)
++#define INIT_UNKNOWN_GUC_4                  BIT(4)
++#define INIT_UNKNOWN_5                      BIT(5)
++#define INIT_UNKNOWN_31                     BIT(31)
++
++// COUNTER_RESET can be written to counter registers to reset them to zero. However, in some cases this can mess up the THC.
++#define COUNTER_RESET                       BIT(31)
++
++struct ithc_registers {
++	/* 0000 */ u32 _unknown_0000[5];
++	/* 0014 */ u32 ltr_config;
++	/* 0018 */ u32 _unknown_0018[1018];
++	/* 1000 */ u32 _unknown_1000;
++	/* 1004 */ u32 _unknown_1004;
++	/* 1008 */ u32 control_bits;
++	/* 100c */ u32 _unknown_100c;
++	/* 1010 */ u32 spi_config;
++	struct {
++		/* 1014/1018/101c */ u8 header;
++		/* 1015/1019/101d */ u8 quad;
++		/* 1016/101a/101e */ u8 dual;
++		/* 1017/101b/101f */ u8 single;
++	} opcode[3];
++	/* 1020 */ u32 error_control;
++	/* 1024 */ u32 error_status; // write to clear
++	/* 1028 */ u32 error_flags; // write to clear
++	/* 102c */ u32 _unknown_102c[5];
++	struct {
++		/* 1040 */ u8 control;
++		/* 1041 */ u8 code;
++		/* 1042 */ u16 size;
++		/* 1044 */ u32 status; // write to clear
++		/* 1048 */ u32 offset;
++		/* 104c */ u32 data[16];
++		/* 108c */ u32 _unknown_108c;
++	} spi_cmd;
++	struct {
++		/* 1090 */ u64 addr; // cannot be written with writeq(), must use lo_hi_writeq()
++		/* 1098 */ u8 control;
++		/* 1099 */ u8 _unknown_1099;
++		/* 109a */ u8 _unknown_109a;
++		/* 109b */ u8 num_prds;
++		/* 109c */ u32 status; // write to clear
++		/* 10a0 */ u32 _unknown_10a0[5];
++		/* 10b4 */ u32 spi_addr;
++	} dma_tx;
++	/* 10b8 */ u32 spi_header_addr;
++	union {
++		/* 10bc */ u32 irq_cause; // in legacy THC mode
++		/* 10bc */ u32 input_header; // in QuickSPI mode (see HIDSPI spec)
++	};
++	/* 10c0 */ u32 _unknown_10c0[8];
++	/* 10e0 */ u32 _unknown_10e0_counters[3];
++	/* 10ec */ u32 quickspi_config1;
++	/* 10f0 */ u32 quickspi_config2;
++	/* 10f4 */ u32 _unknown_10f4[3];
++	struct {
++		/* 1100/1200 */ u64 addr; // cannot be written with writeq(), must use lo_hi_writeq()
++		/* 1108/1208 */ u8 num_bufs;
++		/* 1109/1209 */ u8 num_prds;
++		/* 110a/120a */ u16 _unknown_110a;
++		/* 110c/120c */ u8 control;
++		/* 110d/120d */ u8 head;
++		/* 110e/120e */ u8 tail;
++		/* 110f/120f */ u8 control2;
++		/* 1110/1210 */ u32 status; // write to clear
++		/* 1114/1214 */ u32 _unknown_1114;
++		/* 1118/1218 */ u64 _unknown_1118_guc_addr;
++		/* 1120/1220 */ u32 _unknown_1120_guc;
++		/* 1124/1224 */ u32 _unknown_1124_guc;
++		/* 1128/1228 */ u32 init_unknown;
++		/* 112c/122c */ u32 _unknown_112c;
++		/* 1130/1230 */ u64 _unknown_1130_guc_addr;
++		/* 1138/1238 */ u32 _unknown_1138_guc;
++		/* 113c/123c */ u32 _unknown_113c;
++		/* 1140/1240 */ u32 _unknown_1140_guc;
++		/* 1144/1244 */ u32 _unknown_1144[11];
++		/* 1170/1270 */ u32 spi_addr;
++		/* 1174/1274 */ u32 _unknown_1174[11];
++		/* 11a0/12a0 */ u32 _unknown_11a0_counters[6];
++		/* 11b8/12b8 */ u32 _unknown_11b8[18];
++	} dma_rx[2];
++};
++static_assert(sizeof(struct ithc_registers) == 0x1300);
++
++void bitsl(__iomem u32 *reg, u32 mask, u32 val);
++void bitsb(__iomem u8 *reg, u8 mask, u8 val);
++#define bitsl_set(reg, x) bitsl(reg, x, x)
++#define bitsb_set(reg, x) bitsb(reg, x, x)
++int waitl(struct ithc *ithc, __iomem u32 *reg, u32 mask, u32 val);
++int waitb(struct ithc *ithc, __iomem u8 *reg, u8 mask, u8 val);
++
++void ithc_set_ltr_config(struct ithc *ithc, u64 active_ltr_ns, u64 idle_ltr_ns);
++void ithc_set_ltr_idle(struct ithc *ithc);
++int ithc_set_spi_config(struct ithc *ithc, u8 clkdiv, bool clkdiv8, u8 read_mode, u8 write_mode);
++int ithc_spi_command(struct ithc *ithc, u8 command, u32 offset, u32 size, void *data);
++
+diff --git a/drivers/hid/ithc/ithc.h b/drivers/hid/ithc/ithc.h
+new file mode 100644
+index 000000000..aec320d4e
+--- /dev/null
++++ b/drivers/hid/ithc/ithc.h
+@@ -0,0 +1,89 @@
++/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
++
++#include <linux/acpi.h>
++#include <linux/debugfs.h>
++#include <linux/delay.h>
++#include <linux/dma-mapping.h>
++#include <linux/hid.h>
++#include <linux/highmem.h>
++#include <linux/input.h>
++#include <linux/io-64-nonatomic-lo-hi.h>
++#include <linux/iopoll.h>
++#include <linux/kthread.h>
++#include <linux/miscdevice.h>
++#include <linux/module.h>
++#include <linux/pci.h>
++#include <linux/poll.h>
++#include <linux/timer.h>
++#include <linux/vmalloc.h>
++
++#define DEVNAME "ithc"
++#define DEVFULLNAME "Intel Touch Host Controller"
++
++#undef pr_fmt
++#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
++
++#define CHECK(fn, ...) ({ int r = fn(__VA_ARGS__); if (r < 0) pci_err(ithc->pci, "%s: %s failed with %i\n", __func__, #fn, r); r; })
++#define CHECK_RET(...) do { int r = CHECK(__VA_ARGS__); if (r < 0) return r; } while (0)
++
++#define NUM_RX_BUF 16
++
++// PCI device IDs:
++// Lakefield
++#define PCI_DEVICE_ID_INTEL_THC_LKF_PORT1    0x98d0
++#define PCI_DEVICE_ID_INTEL_THC_LKF_PORT2    0x98d1
++// Tiger Lake
++#define PCI_DEVICE_ID_INTEL_THC_TGL_LP_PORT1 0xa0d0
++#define PCI_DEVICE_ID_INTEL_THC_TGL_LP_PORT2 0xa0d1
++#define PCI_DEVICE_ID_INTEL_THC_TGL_H_PORT1  0x43d0
++#define PCI_DEVICE_ID_INTEL_THC_TGL_H_PORT2  0x43d1
++// Alder Lake
++#define PCI_DEVICE_ID_INTEL_THC_ADL_S_PORT1  0x7ad8
++#define PCI_DEVICE_ID_INTEL_THC_ADL_S_PORT2  0x7ad9
++#define PCI_DEVICE_ID_INTEL_THC_ADL_P_PORT1  0x51d0
++#define PCI_DEVICE_ID_INTEL_THC_ADL_P_PORT2  0x51d1
++#define PCI_DEVICE_ID_INTEL_THC_ADL_M_PORT1  0x54d0
++#define PCI_DEVICE_ID_INTEL_THC_ADL_M_PORT2  0x54d1
++// Raptor Lake
++#define PCI_DEVICE_ID_INTEL_THC_RPL_S_PORT1  0x7a58
++#define PCI_DEVICE_ID_INTEL_THC_RPL_S_PORT2  0x7a59
++// Meteor Lake
++#define PCI_DEVICE_ID_INTEL_THC_MTL_S_PORT1  0x7f59
++#define PCI_DEVICE_ID_INTEL_THC_MTL_S_PORT2  0x7f5b
++#define PCI_DEVICE_ID_INTEL_THC_MTL_MP_PORT1 0x7e49
++#define PCI_DEVICE_ID_INTEL_THC_MTL_MP_PORT2 0x7e4b
++
++struct ithc;
++
++#include "ithc-regs.h"
++#include "ithc-hid.h"
++#include "ithc-dma.h"
++#include "ithc-legacy.h"
++#include "ithc-quickspi.h"
++#include "ithc-debug.h"
++
++struct ithc {
++	char phys[32];
++	struct pci_dev *pci;
++	int irq;
++	struct task_struct *poll_thread;
++	struct timer_list idle_timer;
++
++	struct ithc_registers __iomem *regs;
++	struct ithc_registers *prev_regs; // for debugging
++	struct ithc_dma_rx dma_rx[2];
++	struct ithc_dma_tx dma_tx;
++	struct ithc_hid hid;
++
++	bool use_quickspi;
++	bool have_config;
++	u16 vendor_id;
++	u16 product_id;
++	u32 product_rev;
++	u32 max_rx_size;
++	u32 max_tx_size;
++	u32 legacy_touch_cfg;
++};
++
++int ithc_reset(struct ithc *ithc);
++
+-- 
+2.53.0
+

--- a/patches/7.0/0007-surface-sam.patch
+++ b/patches/7.0/0007-surface-sam.patch
@@ -1,0 +1,211 @@
+From ecae0cc0c11be8bf32d363f0c7f3e6d3242bdc9f Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Fri, 17 Jun 2022 02:14:00 +0200
+Subject: [PATCH] rtc: Add basic support for RTC via Surface System Aggregator
+ Module
+
+Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>
+Patchset: surface-sam
+---
+ drivers/rtc/Kconfig       |   7 +++
+ drivers/rtc/Makefile      |   1 +
+ drivers/rtc/rtc-surface.c | 129 ++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 137 insertions(+)
+ create mode 100644 drivers/rtc/rtc-surface.c
+
+diff --git a/drivers/rtc/Kconfig b/drivers/rtc/Kconfig
+index 50ba48609..c0afe893e 100644
+--- a/drivers/rtc/Kconfig
++++ b/drivers/rtc/Kconfig
+@@ -1424,6 +1424,13 @@ config RTC_DRV_NTXEC
+ 	  embedded controller found in certain e-book readers designed by the
+ 	  original design manufacturer Netronix.
+ 
++config RTC_DRV_SURFACE
++	tristate "Microsoft Surface Aggregator RTC"
++	depends on SURFACE_AGGREGATOR
++	depends on SURFACE_AGGREGATOR_BUS
++	help
++	  TODO
++
+ comment "on-CPU RTC drivers"
+ 
+ config RTC_DRV_ASM9260
+diff --git a/drivers/rtc/Makefile b/drivers/rtc/Makefile
+index 6cf7e0663..18bd33b84 100644
+--- a/drivers/rtc/Makefile
++++ b/drivers/rtc/Makefile
+@@ -186,6 +186,7 @@ obj-$(CONFIG_RTC_DRV_SUN4V)	+= rtc-sun4v.o
+ obj-$(CONFIG_RTC_DRV_SUN6I)	+= rtc-sun6i.o
+ obj-$(CONFIG_RTC_DRV_SUNPLUS)	+= rtc-sunplus.o
+ obj-$(CONFIG_RTC_DRV_SUNXI)	+= rtc-sunxi.o
++obj-$(CONFIG_RTC_DRV_SURFACE)	+= rtc-surface.o
+ obj-$(CONFIG_RTC_DRV_TEGRA)	+= rtc-tegra.o
+ obj-$(CONFIG_RTC_DRV_TEST)	+= rtc-test.o
+ obj-$(CONFIG_RTC_DRV_TI_K3)	+= rtc-ti-k3.o
+diff --git a/drivers/rtc/rtc-surface.c b/drivers/rtc/rtc-surface.c
+new file mode 100644
+index 000000000..f6c17c4e9
+--- /dev/null
++++ b/drivers/rtc/rtc-surface.c
+@@ -0,0 +1,129 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * AC driver for 7th-generation Microsoft Surface devices via Surface System
++ * Aggregator Module (SSAM).
++ *
++ * Copyright (C) 2019-2021 Maximilian Luz <luzmaximilian@gmail.com>
++ */
++
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/rtc.h>
++#include <linux/slab.h>
++#include <linux/types.h>
++
++#include <linux/surface_aggregator/device.h>
++
++struct surface_rtc {
++	struct ssam_device *sdev;
++	struct rtc_device *rtc;
++};
++
++SSAM_DEFINE_SYNC_REQUEST_R(__ssam_rtc_get_unix_time, __le32, {
++	.target_category = SSAM_SSH_TC_SAM,
++	.target_id       = SSAM_SSH_TID_SAM,
++	.instance_id     = 0x00,
++	.command_id      = 0x10,
++});
++
++SSAM_DEFINE_SYNC_REQUEST_W(__ssam_rtc_set_unix_time, __le32, {
++	.target_category = SSAM_SSH_TC_SAM,
++	.target_id       = SSAM_SSH_TID_SAM,
++	.instance_id     = 0x00,
++	.command_id      = 0x0f,
++});
++
++static int ssam_rtc_get_unix_time(struct surface_rtc *srtc, u32 *time)
++{
++	__le32 time_le;
++	int status;
++
++	status = __ssam_rtc_get_unix_time(srtc->sdev->ctrl, &time_le);
++	if (status)
++		return status;
++
++	*time = le32_to_cpu(time_le);
++	return 0;
++}
++
++static int ssam_rtc_set_unix_time(struct surface_rtc *srtc, u32 time)
++{
++	__le32 time_le = cpu_to_le32(time);
++
++	return __ssam_rtc_set_unix_time(srtc->sdev->ctrl, &time_le);
++}
++
++static int surface_rtc_read_time(struct device *dev, struct rtc_time *tm)
++{
++	struct surface_rtc *srtc = dev_get_drvdata(dev);
++	int status;
++	u32 time;
++
++	status = ssam_rtc_get_unix_time(srtc, &time);
++	if (status)
++		return status;
++
++	rtc_time64_to_tm(time, tm);
++	return 0;
++}
++
++static int surface_rtc_set_time(struct device *dev, struct rtc_time *tm)
++{
++	struct surface_rtc *srtc = dev_get_drvdata(dev);
++	time64_t time = rtc_tm_to_time64(tm);
++
++	return ssam_rtc_set_unix_time(srtc, (u32)time);
++}
++
++static const struct rtc_class_ops surface_rtc_ops = {
++	.read_time = surface_rtc_read_time,
++	.set_time = surface_rtc_set_time,
++};
++
++static int surface_rtc_probe(struct ssam_device *sdev)
++{
++	struct surface_rtc *srtc;
++
++	srtc = devm_kzalloc(&sdev->dev, sizeof(*srtc), GFP_KERNEL);
++	if (!srtc)
++		return -ENOMEM;
++
++	srtc->sdev = sdev;
++
++	srtc->rtc = devm_rtc_allocate_device(&sdev->dev);
++	if (IS_ERR(srtc->rtc))
++		return PTR_ERR(srtc->rtc);
++
++	srtc->rtc->ops = &surface_rtc_ops;
++	srtc->rtc->range_max = U32_MAX;
++
++	ssam_device_set_drvdata(sdev, srtc);
++
++	return devm_rtc_register_device(srtc->rtc);
++}
++
++static void surface_rtc_remove(struct ssam_device *sdev)
++{
++	/* Device-managed allocations take care of everything... */
++}
++
++static const struct ssam_device_id surface_rtc_match[] = {
++	{ SSAM_SDEV(SAM, SAM, 0x00, 0x00) },
++	{ },
++};
++MODULE_DEVICE_TABLE(ssam, surface_rtc_match);
++
++static struct ssam_device_driver surface_rtc_driver = {
++	.probe = surface_rtc_probe,
++	.remove = surface_rtc_remove,
++	.match_table = surface_rtc_match,
++	.driver = {
++		.name = "surface_rtc",
++		.probe_type = PROBE_PREFER_ASYNCHRONOUS,
++	},
++};
++module_ssam_device_driver(surface_rtc_driver);
++
++MODULE_AUTHOR("Maximilian Luz <luzmaximilian@gmail.com>");
++MODULE_DESCRIPTION("RTC driver for Surface System Aggregator Module");
++MODULE_LICENSE("GPL");
+-- 
+2.53.0
+
+From 3d1173c2c4513aa4da28ac1f3fd883671769ca02 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Sun, 20 Apr 2025 01:05:14 +0200
+Subject: [PATCH] platform/surface: aggregator_registry: Add Surface Laptop 7
+ (ACPI)
+
+Patchset: surface-sam
+---
+ drivers/platform/surface/surface_aggregator_registry.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/platform/surface/surface_aggregator_registry.c b/drivers/platform/surface/surface_aggregator_registry.c
+index 78ac3a8fb..10fe004e4 100644
+--- a/drivers/platform/surface/surface_aggregator_registry.c
++++ b/drivers/platform/surface/surface_aggregator_registry.c
+@@ -460,6 +460,9 @@ static const struct acpi_device_id ssam_platform_hub_acpi_match[] = {
+ 	/* Surface Laptop 6 */
+ 	{ "MSHW0530", (unsigned long)ssam_node_group_sl6 },
+ 
++	/* Surface Laptop 7 */
++	{ "MSHW0551", (unsigned long)ssam_node_group_sl7 },
++
+ 	/* Surface Laptop Go 1 */
+ 	{ "MSHW0118", (unsigned long)ssam_node_group_slg1 },
+ 
+-- 
+2.53.0
+

--- a/patches/7.0/0008-surface-sam-over-hid.patch
+++ b/patches/7.0/0008-surface-sam-over-hid.patch
@@ -1,0 +1,308 @@
+From 3ea6bdb7f77252d22d062947f8aa00f383864777 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Sat, 25 Jul 2020 17:19:53 +0200
+Subject: [PATCH] i2c: acpi: Implement RawBytes read access
+
+Microsoft Surface Pro 4 and Book 1 devices access the MSHW0030 I2C
+device via a generic serial bus operation region and RawBytes read
+access. On the Surface Book 1, this access is required to turn on (and
+off) the discrete GPU.
+
+Multiple things are to note here:
+
+a) The RawBytes access is device/driver dependent. The ACPI
+   specification states:
+
+   > Raw accesses assume that the writer has knowledge of the bus that
+   > the access is made over and the device that is being accessed. The
+   > protocol may only ensure that the buffer is transmitted to the
+   > appropriate driver, but the driver must be able to interpret the
+   > buffer to communicate to a register.
+
+   Thus this implementation may likely not work on other devices
+   accessing I2C via the RawBytes accessor type.
+
+b) The MSHW0030 I2C device is an HID-over-I2C device which seems to
+   serve multiple functions:
+
+   1. It is the main access point for the legacy-type Surface Aggregator
+      Module (also referred to as SAM-over-HID, as opposed to the newer
+      SAM-over-SSH/UART). It has currently not been determined on how
+      support for the legacy SAM should be implemented. Likely via a
+      custom HID driver.
+
+   2. It seems to serve as the HID device for the Integrated Sensor Hub.
+      This might complicate matters with regards to implementing a
+      SAM-over-HID driver required by legacy SAM.
+
+In light of this, the simplest approach has been chosen for now.
+However, it may make more sense regarding breakage and compatibility to
+either provide functionality for replacing or enhancing the default
+operation region handler via some additional API functions, or even to
+completely blacklist MSHW0030 from the I2C core and provide a custom
+driver for it.
+
+Replacing/enhancing the default operation region handler would, however,
+either require some sort of secondary driver and access point for it,
+from which the new API functions would be called and the new handler
+(part) would be installed, or hard-coding them via some sort of
+quirk-like interface into the I2C core.
+
+Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>
+Patchset: surface-sam-over-hid
+---
+ drivers/i2c/i2c-core-acpi.c | 34 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
+
+diff --git a/drivers/i2c/i2c-core-acpi.c b/drivers/i2c/i2c-core-acpi.c
+index ed90858a2..070c36637 100644
+--- a/drivers/i2c/i2c-core-acpi.c
++++ b/drivers/i2c/i2c-core-acpi.c
+@@ -662,6 +662,27 @@ static int acpi_gsb_i2c_write_bytes(struct i2c_client *client,
+ 	return (ret == 1) ? 0 : -EIO;
+ }
+ 
++static int acpi_gsb_i2c_write_raw_bytes(struct i2c_client *client,
++		u8 *data, u8 data_len)
++{
++	struct i2c_msg msgs[1];
++	int ret;
++
++	msgs[0].addr = client->addr;
++	msgs[0].flags = client->flags;
++	msgs[0].len = data_len + 1;
++	msgs[0].buf = data;
++
++	ret = i2c_transfer(client->adapter, msgs, ARRAY_SIZE(msgs));
++	if (ret < 0) {
++		dev_err(&client->adapter->dev, "i2c write failed: %d\n", ret);
++		return ret;
++	}
++
++	/* 1 transfer must have completed successfully */
++	return (ret == 1) ? 0 : -EIO;
++}
++
+ static acpi_status
+ i2c_acpi_space_handler(u32 function, acpi_physical_address command,
+ 			u32 bits, u64 *value64,
+@@ -763,6 +784,19 @@ i2c_acpi_space_handler(u32 function, acpi_physical_address command,
+ 		}
+ 		break;
+ 
++	case ACPI_GSB_ACCESS_ATTRIB_RAW_BYTES:
++		if (action == ACPI_READ) {
++			dev_warn(&adapter->dev,
++				 "protocol 0x%02x not supported for client 0x%02x\n",
++				 accessor_type, client->addr);
++			ret = AE_BAD_PARAMETER;
++			goto err;
++		} else {
++			status = acpi_gsb_i2c_write_raw_bytes(client,
++					gsb->data, info->access_length);
++		}
++		break;
++
+ 	default:
+ 		dev_warn(&adapter->dev, "protocol 0x%02x not supported for client 0x%02x\n",
+ 			 accessor_type, client->addr);
+-- 
+2.53.0
+
+From 2b9da1194a4f203a0707700a59393e6920393c34 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Sat, 13 Feb 2021 16:41:18 +0100
+Subject: [PATCH] platform/surface: Add driver for Surface Book 1 dGPU switch
+
+Add driver exposing the discrete GPU power-switch of the  Microsoft
+Surface Book 1 to user-space.
+
+On the Surface Book 1, the dGPU power is controlled via the Surface
+System Aggregator Module (SAM). The specific SAM-over-HID command for
+this is exposed via ACPI. This module provides a simple driver exposing
+the ACPI call via a sysfs parameter to user-space, so that users can
+easily power-on/-off the dGPU.
+
+Patchset: surface-sam-over-hid
+---
+ drivers/platform/surface/Kconfig              |   7 +
+ drivers/platform/surface/Makefile             |   1 +
+ .../surface/surfacebook1_dgpu_switch.c        | 136 ++++++++++++++++++
+ 3 files changed, 144 insertions(+)
+ create mode 100644 drivers/platform/surface/surfacebook1_dgpu_switch.c
+
+diff --git a/drivers/platform/surface/Kconfig b/drivers/platform/surface/Kconfig
+index f775c6ca1..2075e3852 100644
+--- a/drivers/platform/surface/Kconfig
++++ b/drivers/platform/surface/Kconfig
+@@ -149,6 +149,13 @@ config SURFACE_AGGREGATOR_TABLET_SWITCH
+ 	  Select M or Y here, if you want to provide tablet-mode switch input
+ 	  events on the Surface Pro 8, Surface Pro X, and Surface Laptop Studio.
+ 
++config SURFACE_BOOK1_DGPU_SWITCH
++	tristate "Surface Book 1 dGPU Switch Driver"
++	depends on SYSFS
++	help
++	  This driver provides a sysfs switch to set the power-state of the
++	  discrete GPU found on the Microsoft Surface Book 1.
++
+ config SURFACE_DTX
+ 	tristate "Surface DTX (Detachment System) Driver"
+ 	depends on SURFACE_AGGREGATOR
+diff --git a/drivers/platform/surface/Makefile b/drivers/platform/surface/Makefile
+index 533443309..7efcd0cdb 100644
+--- a/drivers/platform/surface/Makefile
++++ b/drivers/platform/surface/Makefile
+@@ -12,6 +12,7 @@ obj-$(CONFIG_SURFACE_AGGREGATOR_CDEV)	+= surface_aggregator_cdev.o
+ obj-$(CONFIG_SURFACE_AGGREGATOR_HUB)	+= surface_aggregator_hub.o
+ obj-$(CONFIG_SURFACE_AGGREGATOR_REGISTRY) += surface_aggregator_registry.o
+ obj-$(CONFIG_SURFACE_AGGREGATOR_TABLET_SWITCH) += surface_aggregator_tabletsw.o
++obj-$(CONFIG_SURFACE_BOOK1_DGPU_SWITCH) += surfacebook1_dgpu_switch.o
+ obj-$(CONFIG_SURFACE_DTX)		+= surface_dtx.o
+ obj-$(CONFIG_SURFACE_GPE)		+= surface_gpe.o
+ obj-$(CONFIG_SURFACE_HOTPLUG)		+= surface_hotplug.o
+diff --git a/drivers/platform/surface/surfacebook1_dgpu_switch.c b/drivers/platform/surface/surfacebook1_dgpu_switch.c
+new file mode 100644
+index 000000000..68db23773
+--- /dev/null
++++ b/drivers/platform/surface/surfacebook1_dgpu_switch.c
+@@ -0,0 +1,136 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++
++#include <linux/module.h>
++#include <linux/acpi.h>
++#include <linux/platform_device.h>
++
++/* MSHW0040/VGBI DSM UUID: 6fd05c69-cde3-49f4-95ed-ab1665498035 */
++static const guid_t dgpu_sw_guid =
++	GUID_INIT(0x6fd05c69, 0xcde3, 0x49f4,
++		  0x95, 0xed, 0xab, 0x16, 0x65, 0x49, 0x80, 0x35);
++
++#define DGPUSW_ACPI_PATH_DSM	"\\_SB_.PCI0.LPCB.EC0_.VGBI"
++#define DGPUSW_ACPI_PATH_HGON	"\\_SB_.PCI0.RP05.HGON"
++#define DGPUSW_ACPI_PATH_HGOF	"\\_SB_.PCI0.RP05.HGOF"
++
++static int sb1_dgpu_sw_dsmcall(void)
++{
++	union acpi_object *obj;
++	acpi_handle handle;
++	acpi_status status;
++
++	status = acpi_get_handle(NULL, DGPUSW_ACPI_PATH_DSM, &handle);
++	if (status)
++		return -EINVAL;
++
++	obj = acpi_evaluate_dsm_typed(handle, &dgpu_sw_guid, 1, 1, NULL, ACPI_TYPE_BUFFER);
++	if (!obj)
++		return -EINVAL;
++
++	ACPI_FREE(obj);
++	return 0;
++}
++
++static int sb1_dgpu_sw_hgon(struct device *dev)
++{
++	struct acpi_buffer buf = {ACPI_ALLOCATE_BUFFER, NULL};
++	acpi_status status;
++
++	status = acpi_evaluate_object(NULL, DGPUSW_ACPI_PATH_HGON, NULL, &buf);
++	if (status) {
++		dev_err(dev, "failed to run HGON: %d\n", status);
++		return -EINVAL;
++	}
++
++	ACPI_FREE(buf.pointer);
++
++	dev_info(dev, "turned-on dGPU via HGON\n");
++	return 0;
++}
++
++static int sb1_dgpu_sw_hgof(struct device *dev)
++{
++	struct acpi_buffer buf = {ACPI_ALLOCATE_BUFFER, NULL};
++	acpi_status status;
++
++	status = acpi_evaluate_object(NULL, DGPUSW_ACPI_PATH_HGOF, NULL, &buf);
++	if (status) {
++		dev_err(dev, "failed to run HGOF: %d\n", status);
++		return -EINVAL;
++	}
++
++	ACPI_FREE(buf.pointer);
++
++	dev_info(dev, "turned-off dGPU via HGOF\n");
++	return 0;
++}
++
++static ssize_t dgpu_dsmcall_store(struct device *dev, struct device_attribute *attr,
++				  const char *buf, size_t len)
++{
++	bool value;
++	int status;
++
++	status = kstrtobool(buf, &value);
++	if (status < 0)
++		return status;
++
++	if (!value)
++		return 0;
++
++	status = sb1_dgpu_sw_dsmcall();
++
++	return status < 0 ? status : len;
++}
++static DEVICE_ATTR_WO(dgpu_dsmcall);
++
++static ssize_t dgpu_power_store(struct device *dev, struct device_attribute *attr,
++				const char *buf, size_t len)
++{
++	bool power;
++	int status;
++
++	status = kstrtobool(buf, &power);
++	if (status < 0)
++		return status;
++
++	if (power)
++		status = sb1_dgpu_sw_hgon(dev);
++	else
++		status = sb1_dgpu_sw_hgof(dev);
++
++	return status < 0 ? status : len;
++}
++static DEVICE_ATTR_WO(dgpu_power);
++
++static struct attribute *sb1_dgpu_sw_attrs[] = {
++	&dev_attr_dgpu_dsmcall.attr,
++	&dev_attr_dgpu_power.attr,
++	NULL
++};
++ATTRIBUTE_GROUPS(sb1_dgpu_sw);
++
++/*
++ * The dGPU power seems to be actually handled by MSHW0040. However, that is
++ * also the power-/volume-button device with a mainline driver. So let's use
++ * MSHW0041 instead for now, which seems to be the LTCH (latch/DTX) device.
++ */
++static const struct acpi_device_id sb1_dgpu_sw_match[] = {
++	{ "MSHW0041", },
++	{ }
++};
++MODULE_DEVICE_TABLE(acpi, sb1_dgpu_sw_match);
++
++static struct platform_driver sb1_dgpu_sw = {
++	.driver = {
++		.name = "surfacebook1_dgpu_switch",
++		.acpi_match_table = sb1_dgpu_sw_match,
++		.probe_type = PROBE_PREFER_ASYNCHRONOUS,
++		.dev_groups = sb1_dgpu_sw_groups,
++	},
++};
++module_platform_driver(sb1_dgpu_sw);
++
++MODULE_AUTHOR("Maximilian Luz <luzmaximilian@gmail.com>");
++MODULE_DESCRIPTION("Discrete GPU Power-Switch for Surface Book 1");
++MODULE_LICENSE("GPL");
+-- 
+2.53.0
+

--- a/patches/7.0/0009-surface-button.patch
+++ b/patches/7.0/0009-surface-button.patch
@@ -1,0 +1,149 @@
+From da7cd214e4a45c233a6be4a97449030592d005e1 Mon Sep 17 00:00:00 2001
+From: Sachi King <nakato@nakato.io>
+Date: Tue, 5 Oct 2021 00:05:09 +1100
+Subject: [PATCH] Input: soc_button_array - support AMD variant Surface devices
+
+The power button on the AMD variant of the Surface Laptop uses the
+same MSHW0040 device ID as the 5th and later generation of Surface
+devices, however they report 0 for their OEM platform revision.  As the
+_DSM does not exist on the devices requiring special casing, check for
+the existance of the _DSM to determine if soc_button_array should be
+loaded.
+
+Fixes: c394159310d0 ("Input: soc_button_array - add support for newer surface devices")
+Co-developed-by: Maximilian Luz <luzmaximilian@gmail.com>
+
+Signed-off-by: Sachi King <nakato@nakato.io>
+Patchset: surface-button
+---
+ drivers/input/misc/soc_button_array.c | 33 +++++++--------------------
+ 1 file changed, 8 insertions(+), 25 deletions(-)
+
+diff --git a/drivers/input/misc/soc_button_array.c b/drivers/input/misc/soc_button_array.c
+index b8cad415c..43b5d5638 100644
+--- a/drivers/input/misc/soc_button_array.c
++++ b/drivers/input/misc/soc_button_array.c
+@@ -540,8 +540,8 @@ static const struct soc_device_data soc_device_MSHW0028 = {
+  * Both, the Surface Pro 4 (surfacepro3_button.c) and the above mentioned
+  * devices use MSHW0040 for power and volume buttons, however the way they
+  * have to be addressed differs. Make sure that we only load this drivers
+- * for the correct devices by checking the OEM Platform Revision provided by
+- * the _DSM method.
++ * for the correct devices by checking if the OEM Platform Revision DSM call
++ * exists.
+  */
+ #define MSHW0040_DSM_REVISION		0x01
+ #define MSHW0040_DSM_GET_OMPR		0x02	// get OEM Platform Revision
+@@ -552,31 +552,14 @@ static const guid_t MSHW0040_DSM_UUID =
+ static int soc_device_check_MSHW0040(struct device *dev)
+ {
+ 	acpi_handle handle = ACPI_HANDLE(dev);
+-	union acpi_object *result;
+-	u64 oem_platform_rev = 0;	// valid revisions are nonzero
+-
+-	// get OEM platform revision
+-	result = acpi_evaluate_dsm_typed(handle, &MSHW0040_DSM_UUID,
+-					 MSHW0040_DSM_REVISION,
+-					 MSHW0040_DSM_GET_OMPR, NULL,
+-					 ACPI_TYPE_INTEGER);
+-
+-	if (result) {
+-		oem_platform_rev = result->integer.value;
+-		ACPI_FREE(result);
+-	}
+-
+-	/*
+-	 * If the revision is zero here, the _DSM evaluation has failed. This
+-	 * indicates that we have a Pro 4 or Book 1 and this driver should not
+-	 * be used.
+-	 */
+-	if (oem_platform_rev == 0)
+-		return -ENODEV;
++	bool exists;
+ 
+-	dev_dbg(dev, "OEM Platform Revision %llu\n", oem_platform_rev);
++	// check if OEM platform revision DSM call exists
++	exists = acpi_check_dsm(handle, &MSHW0040_DSM_UUID,
++				MSHW0040_DSM_REVISION,
++				BIT(MSHW0040_DSM_GET_OMPR));
+ 
+-	return 0;
++	return exists ? 0 : -ENODEV;
+ }
+ 
+ /*
+-- 
+2.53.0
+
+From 3ec94f2758eaae1d2d7e84e2205ff5ad2c582ae1 Mon Sep 17 00:00:00 2001
+From: Sachi King <nakato@nakato.io>
+Date: Tue, 5 Oct 2021 00:22:57 +1100
+Subject: [PATCH] platform/surface: surfacepro3_button: don't load on amd
+ variant
+
+The AMD variant of the Surface Laptop report 0 for their OEM platform
+revision.  The Surface devices that require the surfacepro3_button
+driver do not have the _DSM that gets the OEM platform revision.  If the
+method does not exist, load surfacepro3_button.
+
+Fixes: 64dd243d7356 ("platform/x86: surfacepro3_button: Fix device check")
+Co-developed-by: Maximilian Luz <luzmaximilian@gmail.com>
+
+Signed-off-by: Sachi King <nakato@nakato.io>
+Patchset: surface-button
+---
+ drivers/platform/surface/surfacepro3_button.c | 30 ++++---------------
+ 1 file changed, 6 insertions(+), 24 deletions(-)
+
+diff --git a/drivers/platform/surface/surfacepro3_button.c b/drivers/platform/surface/surfacepro3_button.c
+index 2755601f9..4240c98ca 100644
+--- a/drivers/platform/surface/surfacepro3_button.c
++++ b/drivers/platform/surface/surfacepro3_button.c
+@@ -149,7 +149,8 @@ static int surface_button_resume(struct device *dev)
+ /*
+  * Surface Pro 4 and Surface Book 2 / Surface Pro 2017 use the same device
+  * ID (MSHW0040) for the power/volume buttons. Make sure this is the right
+- * device by checking for the _DSM method and OEM Platform Revision.
++ * device by checking for the _DSM method and OEM Platform Revision DSM
++ * function.
+  *
+  * Returns true if the driver should bind to this device, i.e. the device is
+  * either MSWH0028 (Pro 3) or MSHW0040 on a Pro 4 or Book 1.
+@@ -157,30 +158,11 @@ static int surface_button_resume(struct device *dev)
+ static bool surface_button_check_MSHW0040(struct acpi_device *dev)
+ {
+ 	acpi_handle handle = dev->handle;
+-	union acpi_object *result;
+-	u64 oem_platform_rev = 0;	// valid revisions are nonzero
+-
+-	// get OEM platform revision
+-	result = acpi_evaluate_dsm_typed(handle, &MSHW0040_DSM_UUID,
+-					 MSHW0040_DSM_REVISION,
+-					 MSHW0040_DSM_GET_OMPR,
+-					 NULL, ACPI_TYPE_INTEGER);
+-
+-	/*
+-	 * If evaluating the _DSM fails, the method is not present. This means
+-	 * that we have either MSHW0028 or MSHW0040 on Pro 4 or Book 1, so we
+-	 * should use this driver. We use revision 0 indicating it is
+-	 * unavailable.
+-	 */
+-
+-	if (result) {
+-		oem_platform_rev = result->integer.value;
+-		ACPI_FREE(result);
+-	}
+-
+-	dev_dbg(&dev->dev, "OEM Platform Revision %llu\n", oem_platform_rev);
+ 
+-	return oem_platform_rev == 0;
++	// make sure that OEM platform revision DSM call does not exist
++	return !acpi_check_dsm(handle, &MSHW0040_DSM_UUID,
++			       MSHW0040_DSM_REVISION,
++			       BIT(MSHW0040_DSM_GET_OMPR));
+ }
+ 
+ 
+-- 
+2.53.0
+

--- a/patches/7.0/0010-surface-typecover.patch
+++ b/patches/7.0/0010-surface-typecover.patch
@@ -1,0 +1,576 @@
+From ff5baefb34222c3fdeac0852a4a7501bc659e486 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Sat, 18 Feb 2023 01:02:49 +0100
+Subject: [PATCH] USB: quirks: Add USB_QUIRK_DELAY_INIT for Surface Go 3
+ Type-Cover
+
+The touchpad on the Type-Cover of the Surface Go 3 is sometimes not
+being initialized properly. Apply USB_QUIRK_DELAY_INIT to fix this
+issue.
+
+More specifically, the device in question is a fairly standard modern
+touchpad with pointer and touchpad input modes. During setup, the device
+needs to be switched from pointer- to touchpad-mode (which is done in
+hid-multitouch) to fully utilize it as intended. Unfortunately, however,
+this seems to occasionally fail silently, leaving the device in
+pointer-mode. Applying USB_QUIRK_DELAY_INIT seems to fix this.
+
+Link: https://github.com/linux-surface/linux-surface/issues/1059
+Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>
+Patchset: surface-typecover
+---
+ drivers/usb/core/quirks.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
+index c4d85089d..3d0d35c72 100644
+--- a/drivers/usb/core/quirks.c
++++ b/drivers/usb/core/quirks.c
+@@ -223,6 +223,9 @@ static const struct usb_device_id usb_quirk_list[] = {
+ 	/* Microsoft Surface Dock Ethernet (RTL8153 GigE) */
+ 	{ USB_DEVICE(0x045e, 0x07c6), .driver_info = USB_QUIRK_NO_LPM },
+ 
++	/* Microsoft Surface Go 3 Type-Cover */
++	{ USB_DEVICE(0x045e, 0x09b5), .driver_info = USB_QUIRK_DELAY_INIT },
++
+ 	/* Cherry Stream G230 2.0 (G85-231) and 3.0 (G85-232) */
+ 	{ USB_DEVICE(0x046a, 0x0023), .driver_info = USB_QUIRK_RESET_RESUME },
+ 
+-- 
+2.53.0
+
+From 09af9d07fa295c8f3b7768a74fd7737a7cbaddcf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jonas=20Dre=C3=9Fler?= <verdre@v0yd.nl>
+Date: Thu, 5 Nov 2020 13:09:45 +0100
+Subject: [PATCH] hid/multitouch: Turn off Type Cover keyboard backlight when
+ suspending
+
+The Type Cover for Microsoft Surface devices supports a special usb
+control request to disable or enable the built-in keyboard backlight.
+On Windows, this request happens when putting the device into suspend or
+resuming it, without it the backlight of the Type Cover will remain
+enabled for some time even though the computer is suspended, which looks
+weird to the user.
+
+So add support for this special usb control request to hid-multitouch,
+which is the driver that's handling the Type Cover.
+
+The reason we have to use a pm_notifier for this instead of the usual
+suspend/resume methods is that those won't get called in case the usb
+device is already autosuspended.
+
+Also, if the device is autosuspended, we have to briefly autoresume it
+in order to send the request. Doing that should be fine, the usb-core
+driver does something similar during suspend inside choose_wakeup().
+
+To make sure we don't send that request to every device but only to
+devices which support it, add a new quirk
+MT_CLS_WIN_8_MS_SURFACE_TYPE_COVER to hid-multitouch. For now this quirk
+is only enabled for the usb id of the Surface Pro 2017 Type Cover, which
+is where I confirmed that it's working.
+
+Patchset: surface-typecover
+---
+ drivers/hid/hid-multitouch.c | 100 ++++++++++++++++++++++++++++++++++-
+ 1 file changed, 98 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
+index b8a748bbf..c47a492a1 100644
+--- a/drivers/hid/hid-multitouch.c
++++ b/drivers/hid/hid-multitouch.c
+@@ -35,7 +35,10 @@
+ #include <linux/device.h>
+ #include <linux/hid.h>
+ #include <linux/module.h>
++#include <linux/pm_runtime.h>
+ #include <linux/slab.h>
++#include <linux/suspend.h>
++#include <linux/usb.h>
+ #include <linux/input/mt.h>
+ #include <linux/jiffies.h>
+ #include <linux/string.h>
+@@ -48,6 +51,7 @@ MODULE_DESCRIPTION("HID multitouch panels");
+ MODULE_LICENSE("GPL");
+ 
+ #include "hid-ids.h"
++#include "usbhid/usbhid.h"
+ 
+ #include "hid-haptic.h"
+ 
+@@ -78,6 +82,7 @@ MODULE_LICENSE("GPL");
+ #define MT_QUIRK_APPLE_TOUCHBAR		BIT(23)
+ #define MT_QUIRK_YOGABOOK9I		BIT(24)
+ #define MT_QUIRK_KEEP_LATENCY_ON_CLOSE	BIT(25)
++#define MT_QUIRK_HAS_TYPE_COVER_BACKLIGHT	BIT(26)
+ 
+ #define MT_INPUTMODE_TOUCHSCREEN	0x02
+ #define MT_INPUTMODE_TOUCHPAD		0x03
+@@ -85,6 +90,8 @@ MODULE_LICENSE("GPL");
+ #define MT_BUTTONTYPE_CLICKPAD		0
+ #define MT_BUTTONTYPE_PRESSUREPAD	1
+ 
++#define MS_TYPE_COVER_FEATURE_REPORT_USAGE	0xff050086
++
+ enum latency_mode {
+ 	HID_LATENCY_NORMAL = 0,
+ 	HID_LATENCY_HIGH = 1,
+@@ -188,6 +195,8 @@ struct mt_device {
+ 
+ 	struct list_head applications;
+ 	struct list_head reports;
++
++	struct notifier_block pm_notifier;
+ };
+ 
+ static void mt_post_parse_default_settings(struct mt_device *td,
+@@ -236,6 +245,7 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app);
+ #define MT_CLS_APPLE_TOUCHBAR			0x0114
+ #define MT_CLS_YOGABOOK9I			0x0115
+ #define MT_CLS_EGALAX_P80H84			0x0116
++#define MT_CLS_WIN_8_MS_SURFACE_TYPE_COVER	0x0117
+ #define MT_CLS_SIS				0x0457
+ 
+ #define MT_DEFAULT_MAXCONTACT	10
+@@ -455,6 +465,16 @@ static const struct mt_class mt_classes[] = {
+ 			MT_QUIRK_IGNORE_DUPLICATES |
+ 			MT_QUIRK_CONTACT_CNT_ACCURATE,
+ 	},
++	{ .name = MT_CLS_WIN_8_MS_SURFACE_TYPE_COVER,
++		.quirks = MT_QUIRK_HAS_TYPE_COVER_BACKLIGHT |
++			MT_QUIRK_ALWAYS_VALID |
++			MT_QUIRK_IGNORE_DUPLICATES |
++			MT_QUIRK_HOVERING |
++			MT_QUIRK_CONTACT_CNT_ACCURATE |
++			MT_QUIRK_STICKY_FINGERS |
++			MT_QUIRK_WIN8_PTP_BUTTONS,
++		.export_all_inputs = true
++	},
+ 	{ }
+ };
+ 
+@@ -1938,6 +1958,69 @@ static void mt_expired_timeout(struct timer_list *t)
+ 	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
+ }
+ 
++static void get_type_cover_backlight_field(struct hid_device *hdev,
++					   struct hid_field **field)
++{
++	struct hid_report_enum *rep_enum;
++	struct hid_report *rep;
++	struct hid_field *cur_field;
++	int i, j;
++
++	rep_enum = &hdev->report_enum[HID_FEATURE_REPORT];
++	list_for_each_entry(rep, &rep_enum->report_list, list) {
++		for (i = 0; i < rep->maxfield; i++) {
++			cur_field = rep->field[i];
++
++			for (j = 0; j < cur_field->maxusage; j++) {
++				if (cur_field->usage[j].hid
++				    == MS_TYPE_COVER_FEATURE_REPORT_USAGE) {
++					*field = cur_field;
++					return;
++				}
++			}
++		}
++	}
++}
++
++static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
++{
++	struct usb_device *udev = hid_to_usb_dev(hdev);
++	struct hid_field *field = NULL;
++
++	/* Wake up the device in case it's already suspended */
++	pm_runtime_get_sync(&udev->dev);
++
++	get_type_cover_backlight_field(hdev, &field);
++	if (!field) {
++		hid_err(hdev, "couldn't find backlight field\n");
++		goto out;
++	}
++
++	field->value[field->index] = enabled ? 0x01ff00ff : 0x00ff00ff;
++	hid_hw_request(hdev, field->report, HID_REQ_SET_REPORT);
++
++out:
++	pm_runtime_put_sync(&udev->dev);
++}
++
++static int mt_pm_notifier(struct notifier_block *notifier,
++			  unsigned long pm_event,
++			  void *unused)
++{
++	struct mt_device *td =
++		container_of(notifier, struct mt_device, pm_notifier);
++	struct hid_device *hdev = td->hdev;
++
++	if (td->mtclass.quirks & MT_QUIRK_HAS_TYPE_COVER_BACKLIGHT) {
++		if (pm_event == PM_SUSPEND_PREPARE)
++			update_keyboard_backlight(hdev, 0);
++		else if (pm_event == PM_POST_SUSPEND)
++			update_keyboard_backlight(hdev, 1);
++	}
++
++	return NOTIFY_DONE;
++}
++
+ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+ {
+ 	int ret, i;
+@@ -1966,6 +2049,9 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+ 	td->inputmode_value = MT_INPUTMODE_TOUCHSCREEN;
+ 	hid_set_drvdata(hdev, td);
+ 
++	td->pm_notifier.notifier_call = mt_pm_notifier;
++	register_pm_notifier(&td->pm_notifier);
++
+ 	INIT_LIST_HEAD(&td->applications);
+ 	INIT_LIST_HEAD(&td->reports);
+ 
+@@ -2004,8 +2090,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+ 	timer_setup(&td->release_timer, mt_expired_timeout, 0);
+ 
+ 	ret = hid_parse(hdev);
+-	if (ret != 0)
++	if (ret != 0) {
++		unregister_pm_notifier(&td->pm_notifier);
+ 		return ret;
++	}
+ 
+ 	if (mtclass->name == MT_CLS_APPLE_TOUCHBAR &&
+ 	    !hid_find_field(hdev, HID_INPUT_REPORT,
+@@ -2019,8 +2107,10 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+ 		hdev->quirks |= HID_QUIRK_NOGET;
+ 
+ 	ret = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
+-	if (ret)
++	if (ret) {
++		unregister_pm_notifier(&td->pm_notifier);
+ 		return ret;
++	}
+ 
+ 	ret = sysfs_create_group(&hdev->dev.kobj, &mt_attribute_group);
+ 	if (ret)
+@@ -2081,6 +2171,7 @@ static void mt_remove(struct hid_device *hdev)
+ {
+ 	struct mt_device *td = hid_get_drvdata(hdev);
+ 
++	unregister_pm_notifier(&td->pm_notifier);
+ 	timer_delete_sync(&td->release_timer);
+ 
+ 	sysfs_remove_group(&hdev->dev.kobj, &mt_attribute_group);
+@@ -2548,6 +2639,11 @@ static const struct hid_device_id mt_devices[] = {
+ 		HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
+ 			USB_DEVICE_ID_APPLE_TOUCHBAR_DISPLAY) },
+ 
++	/* Microsoft Surface type cover */
++	{ .driver_data = MT_CLS_WIN_8_MS_SURFACE_TYPE_COVER,
++		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY,
++			USB_VENDOR_ID_MICROSOFT, 0x09c0) },
++
+ 	/* Google MT devices */
+ 	{ .driver_data = MT_CLS_GOOGLE,
+ 		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY, USB_VENDOR_ID_GOOGLE,
+-- 
+2.53.0
+
+From 0344ec52910f491718ad1c2457a11be29096be8f Mon Sep 17 00:00:00 2001
+From: PJungkamp <p.jungkamp@gmail.com>
+Date: Fri, 25 Feb 2022 12:04:25 +0100
+Subject: [PATCH] hid/multitouch: Add support for surface pro type cover tablet
+ switch
+
+The Surface Pro Type Cover has several non standard HID usages in it's
+hid report descriptor.
+I noticed that, upon folding the typecover back, a vendor specific range
+of 4 32 bit integer hid usages is transmitted.
+Only the first byte of the message seems to convey reliable information
+about the keyboard state.
+
+0x22 => Normal (keys enabled)
+0x33 => Folded back (keys disabled)
+0x53 => Rotated left/right side up (keys disabled)
+0x13 => Cover closed (keys disabled)
+0x43 => Folded back and Tablet upside down (keys disabled)
+This list may not be exhaustive.
+
+The tablet mode switch will be disabled for a value of 0x22 and enabled
+on any other value.
+
+Patchset: surface-typecover
+---
+ drivers/hid/hid-multitouch.c | 148 +++++++++++++++++++++++++++++------
+ 1 file changed, 122 insertions(+), 26 deletions(-)
+
+diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
+index c47a492a1..c92ab7949 100644
+--- a/drivers/hid/hid-multitouch.c
++++ b/drivers/hid/hid-multitouch.c
+@@ -83,6 +83,7 @@ MODULE_LICENSE("GPL");
+ #define MT_QUIRK_YOGABOOK9I		BIT(24)
+ #define MT_QUIRK_KEEP_LATENCY_ON_CLOSE	BIT(25)
+ #define MT_QUIRK_HAS_TYPE_COVER_BACKLIGHT	BIT(26)
++#define MT_QUIRK_HAS_TYPE_COVER_TABLET_MODE_SWITCH	BIT(27)
+ 
+ #define MT_INPUTMODE_TOUCHSCREEN	0x02
+ #define MT_INPUTMODE_TOUCHPAD		0x03
+@@ -91,6 +92,8 @@ MODULE_LICENSE("GPL");
+ #define MT_BUTTONTYPE_PRESSUREPAD	1
+ 
+ #define MS_TYPE_COVER_FEATURE_REPORT_USAGE	0xff050086
++#define MS_TYPE_COVER_TABLET_MODE_SWITCH_USAGE	0xff050072
++#define MS_TYPE_COVER_APPLICATION	0xff050050
+ 
+ enum latency_mode {
+ 	HID_LATENCY_NORMAL = 0,
+@@ -467,6 +470,7 @@ static const struct mt_class mt_classes[] = {
+ 	},
+ 	{ .name = MT_CLS_WIN_8_MS_SURFACE_TYPE_COVER,
+ 		.quirks = MT_QUIRK_HAS_TYPE_COVER_BACKLIGHT |
++			MT_QUIRK_HAS_TYPE_COVER_TABLET_MODE_SWITCH |
+ 			MT_QUIRK_ALWAYS_VALID |
+ 			MT_QUIRK_IGNORE_DUPLICATES |
+ 			MT_QUIRK_HOVERING |
+@@ -1502,6 +1506,9 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+ 	    field->application != HID_CP_CONSUMER_CONTROL &&
+ 	    field->application != HID_GD_WIRELESS_RADIO_CTLS &&
+ 	    field->application != HID_GD_SYSTEM_MULTIAXIS &&
++	    !(field->application == MS_TYPE_COVER_APPLICATION &&
++	      application->quirks & MT_QUIRK_HAS_TYPE_COVER_TABLET_MODE_SWITCH &&
++	      usage->hid == MS_TYPE_COVER_TABLET_MODE_SWITCH_USAGE) &&
+ 	    !(field->application == HID_VD_ASUS_CUSTOM_MEDIA_KEYS &&
+ 	      application->quirks & MT_QUIRK_ASUS_CUSTOM_UP))
+ 		return -1;
+@@ -1529,6 +1536,21 @@ static int mt_input_mapping(struct hid_device *hdev, struct hid_input *hi,
+ 		return 1;
+ 	}
+ 
++	/*
++	 * The Microsoft Surface Pro Typecover has a non-standard HID
++	 * tablet mode switch on a vendor specific usage page with vendor
++	 * specific usage.
++	 */
++	if (field->application == MS_TYPE_COVER_APPLICATION &&
++	    application->quirks & MT_QUIRK_HAS_TYPE_COVER_TABLET_MODE_SWITCH &&
++	    usage->hid == MS_TYPE_COVER_TABLET_MODE_SWITCH_USAGE) {
++		usage->type = EV_SW;
++		usage->code = SW_TABLET_MODE;
++		*max = SW_MAX;
++		*bit = hi->input->swbit;
++		return 1;
++	}
++
+ 	if (rdata->is_mt_collection)
+ 		return mt_touch_input_mapping(hdev, hi, field, usage, bit, max,
+ 					      application);
+@@ -1555,6 +1577,7 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+ {
+ 	struct mt_device *td = hid_get_drvdata(hdev);
+ 	struct mt_report_data *rdata;
++	struct input_dev *input;
+ 
+ 	rdata = mt_find_report_data(td, field->report);
+ 	if (rdata && rdata->is_mt_collection) {
+@@ -1562,6 +1585,19 @@ static int mt_input_mapped(struct hid_device *hdev, struct hid_input *hi,
+ 		return -1;
+ 	}
+ 
++	/*
++	 * We own an input device which acts as a tablet mode switch for
++	 * the Surface Pro Typecover.
++	 */
++	if (field->application == MS_TYPE_COVER_APPLICATION &&
++	    rdata->application->quirks & MT_QUIRK_HAS_TYPE_COVER_TABLET_MODE_SWITCH &&
++	    usage->hid == MS_TYPE_COVER_TABLET_MODE_SWITCH_USAGE) {
++		input = hi->input;
++		input_set_capability(input, EV_SW, SW_TABLET_MODE);
++		input_report_switch(input, SW_TABLET_MODE, 0);
++		return -1;
++	}
++
+ 	/* let hid-core decide for the others */
+ 	return 0;
+ }
+@@ -1571,11 +1607,21 @@ static int mt_event(struct hid_device *hid, struct hid_field *field,
+ {
+ 	struct mt_device *td = hid_get_drvdata(hid);
+ 	struct mt_report_data *rdata;
++	struct input_dev *input;
+ 
+ 	rdata = mt_find_report_data(td, field->report);
+ 	if (rdata && rdata->is_mt_collection)
+ 		return mt_touch_event(hid, field, usage, value);
+ 
++	if (field->application == MS_TYPE_COVER_APPLICATION &&
++	    rdata->application->quirks & MT_QUIRK_HAS_TYPE_COVER_TABLET_MODE_SWITCH &&
++	    usage->hid == MS_TYPE_COVER_TABLET_MODE_SWITCH_USAGE) {
++		input = field->hidinput->input;
++		input_report_switch(input, SW_TABLET_MODE, (value & 0xFF) != 0x22);
++		input_sync(input);
++		return 1;
++	}
++
+ 	return 0;
+ }
+ 
+@@ -1790,6 +1836,42 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app)
+ 		app->quirks &= ~MT_QUIRK_CONTACT_CNT_ACCURATE;
+ }
+ 
++static int get_type_cover_field(struct hid_report_enum *rep_enum,
++				struct hid_field **field, int usage)
++{
++	struct hid_report *rep;
++	struct hid_field *cur_field;
++	int i, j;
++
++	list_for_each_entry(rep, &rep_enum->report_list, list) {
++		for (i = 0; i < rep->maxfield; i++) {
++			cur_field = rep->field[i];
++			if (cur_field->application != MS_TYPE_COVER_APPLICATION)
++				continue;
++			for (j = 0; j < cur_field->maxusage; j++) {
++				if (cur_field->usage[j].hid == usage) {
++					*field = cur_field;
++					return true;
++				}
++			}
++		}
++	}
++	return false;
++}
++
++static void request_type_cover_tablet_mode_switch(struct hid_device *hdev)
++{
++	struct hid_field *field;
++
++	if (get_type_cover_field(&hdev->report_enum[HID_INPUT_REPORT],
++				 &field,
++				 MS_TYPE_COVER_TABLET_MODE_SWITCH_USAGE)) {
++		hid_hw_request(hdev, field->report, HID_REQ_GET_REPORT);
++	} else {
++		hid_err(hdev, "couldn't find tablet mode field\n");
++	}
++}
++
+ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
+ {
+ 	struct mt_device *td = hid_get_drvdata(hdev);
+@@ -1848,6 +1930,13 @@ static int mt_input_configured(struct hid_device *hdev, struct hid_input *hi)
+ 		/* force BTN_STYLUS to allow tablet matching in udev */
+ 		__set_bit(BTN_STYLUS, hi->input->keybit);
+ 		break;
++	case MS_TYPE_COVER_APPLICATION:
++		if (td->mtclass.quirks & MT_QUIRK_HAS_TYPE_COVER_TABLET_MODE_SWITCH) {
++			suffix = "Tablet Mode Switch";
++			request_type_cover_tablet_mode_switch(hdev);
++			break;
++		}
++		fallthrough;
+ 	default:
+ 		suffix = "UNKNOWN";
+ 		break;
+@@ -1958,30 +2047,6 @@ static void mt_expired_timeout(struct timer_list *t)
+ 	clear_bit_unlock(MT_IO_FLAGS_RUNNING, &td->mt_io_flags);
+ }
+ 
+-static void get_type_cover_backlight_field(struct hid_device *hdev,
+-					   struct hid_field **field)
+-{
+-	struct hid_report_enum *rep_enum;
+-	struct hid_report *rep;
+-	struct hid_field *cur_field;
+-	int i, j;
+-
+-	rep_enum = &hdev->report_enum[HID_FEATURE_REPORT];
+-	list_for_each_entry(rep, &rep_enum->report_list, list) {
+-		for (i = 0; i < rep->maxfield; i++) {
+-			cur_field = rep->field[i];
+-
+-			for (j = 0; j < cur_field->maxusage; j++) {
+-				if (cur_field->usage[j].hid
+-				    == MS_TYPE_COVER_FEATURE_REPORT_USAGE) {
+-					*field = cur_field;
+-					return;
+-				}
+-			}
+-		}
+-	}
+-}
+-
+ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
+ {
+ 	struct usb_device *udev = hid_to_usb_dev(hdev);
+@@ -1990,8 +2055,9 @@ static void update_keyboard_backlight(struct hid_device *hdev, bool enabled)
+ 	/* Wake up the device in case it's already suspended */
+ 	pm_runtime_get_sync(&udev->dev);
+ 
+-	get_type_cover_backlight_field(hdev, &field);
+-	if (!field) {
++	if (!get_type_cover_field(&hdev->report_enum[HID_FEATURE_REPORT],
++				  &field,
++				  MS_TYPE_COVER_FEATURE_REPORT_USAGE)) {
+ 		hid_err(hdev, "couldn't find backlight field\n");
+ 		goto out;
+ 	}
+@@ -2149,13 +2215,24 @@ static int mt_suspend(struct hid_device *hdev, pm_message_t state)
+ 
+ static int mt_reset_resume(struct hid_device *hdev)
+ {
++	struct mt_device *td = hid_get_drvdata(hdev);
++
+ 	mt_release_contacts(hdev);
+ 	mt_set_modes(hdev, HID_LATENCY_NORMAL, TOUCHPAD_REPORT_ALL);
++
++	/* Request an update on the typecover folding state on resume
++	 * after reset.
++	 */
++	if (td->mtclass.quirks & MT_QUIRK_HAS_TYPE_COVER_TABLET_MODE_SWITCH)
++		request_type_cover_tablet_mode_switch(hdev);
++
+ 	return 0;
+ }
+ 
+ static int mt_resume(struct hid_device *hdev)
+ {
++	struct mt_device *td = hid_get_drvdata(hdev);
++
+ 	/* Some Elan legacy devices require SET_IDLE to be set on resume.
+ 	 * It should be safe to send it to other devices too.
+ 	 * Tested on 3M, Stantum, Cypress, Zytronic, eGalax, and Elan panels. */
+@@ -2164,12 +2241,31 @@ static int mt_resume(struct hid_device *hdev)
+ 
+ 	mt_set_modes(hdev, HID_LATENCY_NORMAL, TOUCHPAD_REPORT_ALL);
+ 
++	/* Request an update on the typecover folding state on resume. */
++	if (td->mtclass.quirks & MT_QUIRK_HAS_TYPE_COVER_TABLET_MODE_SWITCH)
++		request_type_cover_tablet_mode_switch(hdev);
++
+ 	return 0;
+ }
+ 
+ static void mt_remove(struct hid_device *hdev)
+ {
+ 	struct mt_device *td = hid_get_drvdata(hdev);
++	struct hid_field *field;
++	struct input_dev *input;
++
++	/* Reset tablet mode switch on disconnect. */
++	if (td->mtclass.quirks & MT_QUIRK_HAS_TYPE_COVER_TABLET_MODE_SWITCH) {
++		if (get_type_cover_field(&hdev->report_enum[HID_INPUT_REPORT],
++					 &field,
++					 MS_TYPE_COVER_TABLET_MODE_SWITCH_USAGE)) {
++			input = field->hidinput->input;
++			input_report_switch(input, SW_TABLET_MODE, 0);
++			input_sync(input);
++		} else {
++			hid_err(hdev, "couldn't find tablet mode field\n");
++		}
++	}
+ 
+ 	unregister_pm_notifier(&td->pm_notifier);
+ 	timer_delete_sync(&td->release_timer);
+-- 
+2.53.0
+

--- a/patches/7.0/0011-surface-shutdown.patch
+++ b/patches/7.0/0011-surface-shutdown.patch
@@ -1,0 +1,140 @@
+From dd2208ea4f12d8eafde91b5fd6861db06cb7710e Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Sun, 19 Feb 2023 22:12:24 +0100
+Subject: [PATCH] PCI: Add quirk to prevent calling shutdown method
+
+Work around buggy EFI firmware: On some Microsoft Surface devices
+(Surface Pro 9 and Surface Laptop 5) the EFI ResetSystem call with
+EFI_RESET_SHUTDOWN doesn't function properly. Instead of shutting the
+system down, it returns and the system stays on.
+
+It turns out that this only happens after PCI shutdown callbacks ran for
+specific devices. Excluding those devices from the shutdown process
+makes the ResetSystem call work as expected.
+
+TODO: Maybe we can find a better way or the root cause of this?
+
+Not-Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>
+Patchset: surface-shutdown
+---
+ drivers/pci/pci-driver.c |  3 +++
+ drivers/pci/quirks.c     | 36 ++++++++++++++++++++++++++++++++++++
+ include/linux/pci.h      |  1 +
+ 3 files changed, 40 insertions(+)
+
+diff --git a/drivers/pci/pci-driver.c b/drivers/pci/pci-driver.c
+index 301a9418e..c49bdf527 100644
+--- a/drivers/pci/pci-driver.c
++++ b/drivers/pci/pci-driver.c
+@@ -505,6 +505,9 @@ static void pci_device_shutdown(struct device *dev)
+ 	struct pci_dev *pci_dev = to_pci_dev(dev);
+ 	struct pci_driver *drv = pci_dev->driver;
+ 
++	if (pci_dev->no_shutdown)
++		return;
++
+ 	pm_runtime_resume(dev);
+ 
+ 	if (drv && drv->shutdown)
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index fd86f72f5..14f03bf95 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -6377,3 +6377,39 @@ static void pci_mask_replay_timer_timeout(struct pci_dev *pdev)
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_GLI, 0x9750, pci_mask_replay_timer_timeout);
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_GLI, 0x9755, pci_mask_replay_timer_timeout);
+ #endif
++
++static const struct dmi_system_id no_shutdown_dmi_table[] = {
++	/*
++	 * Systems on which some devices should not be touched during shutdown.
++	 */
++	{
++		.ident = "Microsoft Surface Pro 9",
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "Surface Pro 9"),
++		},
++	},
++	{
++		.ident = "Microsoft Surface Laptop 5",
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "Surface Laptop 5"),
++		},
++	},
++	{}
++};
++
++static void quirk_no_shutdown(struct pci_dev *dev)
++{
++	if (!dmi_check_system(no_shutdown_dmi_table))
++		return;
++
++	dev->no_shutdown = 1;
++	pci_info(dev, "disabling shutdown ops for [%04x:%04x]\n",
++		 dev->vendor, dev->device);
++}
++DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x461e, quirk_no_shutdown);  // Thunderbolt 4 USB Controller
++DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x461f, quirk_no_shutdown);  // Thunderbolt 4 PCI Express Root Port
++DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x462f, quirk_no_shutdown);  // Thunderbolt 4 PCI Express Root Port
++DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x466d, quirk_no_shutdown);  // Thunderbolt 4 NHI
++DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x46a8, quirk_no_shutdown);  // GPU
+diff --git a/include/linux/pci.h b/include/linux/pci.h
+index e958ff744..2053f3396 100644
+--- a/include/linux/pci.h
++++ b/include/linux/pci.h
+@@ -489,6 +489,7 @@ struct pci_dev {
+ 	unsigned int	rom_bar_overlap:1;	/* ROM BAR disable broken */
+ 	unsigned int	rom_attr_enabled:1;	/* Display of ROM attribute enabled? */
+ 	unsigned int	non_mappable_bars:1;	/* BARs can't be mapped to user-space  */
++	unsigned int	no_shutdown:1;		/* Do not touch device on shutdown */
+ 	pci_dev_flags_t dev_flags;
+ 	atomic_t	enable_cnt;	/* pci_enable_device has been called */
+ 
+-- 
+2.53.0
+
+From 4951c289333bfc16f42fac59a5d02afbdd1979c9 Mon Sep 17 00:00:00 2001
+From: LegendaryFire <tristan.balon@outlook.com>
+Date: Wed, 7 Jan 2026 01:06:25 +0100
+Subject: [PATCH] PCI: Add Surface Laptop Studio 2 devices to shutdown ops
+ quirk
+
+Link: https://github.com/linux-surface/linux-surface/pull/1948
+Patchset: surface-shutdown
+---
+ drivers/pci/quirks.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index 14f03bf95..06b2debf3 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -6396,6 +6396,13 @@ static const struct dmi_system_id no_shutdown_dmi_table[] = {
+ 			DMI_MATCH(DMI_PRODUCT_NAME, "Surface Laptop 5"),
+ 		},
+ 	},
++	{
++		.ident = "Microsoft Surface Laptop Studio 2",
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "Surface Laptop Studio 2"),
++		},
++	},
+ 	{}
+ };
+ 
+@@ -6413,3 +6420,9 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x461f, quirk_no_shutdown);  // Thu
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x462f, quirk_no_shutdown);  // Thunderbolt 4 PCI Express Root Port
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x466d, quirk_no_shutdown);  // Thunderbolt 4 NHI
+ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x46a8, quirk_no_shutdown);  // GPU
++
++DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa76e, quirk_no_shutdown);  // Thunderbolt 4 USB Controller
++DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa71e, quirk_no_shutdown);  // Thunderbolt 4 PCI Express Root Port
++DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa73f, quirk_no_shutdown);  // Thunderbolt 4 PCI Express Root Port
++DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa73e, quirk_no_shutdown);  // Thunderbolt 4 NHI
++DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0xa7a0, quirk_no_shutdown);  // GPU
+-- 
+2.53.0
+

--- a/patches/7.0/0012-surface-gpe.patch
+++ b/patches/7.0/0012-surface-gpe.patch
@@ -1,0 +1,51 @@
+From 958fc5f748b02cf51b294f693215d1c1d40fd66e Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Sun, 12 Mar 2023 01:41:57 +0100
+Subject: [PATCH] platform/surface: gpe: Add support for Surface Pro 9
+
+Add the lid GPE used by the Surface Pro 9.
+
+Signed-off-by: Maximilian Luz <luzmaximilian@gmail.com>
+Patchset: surface-gpe
+---
+ drivers/platform/surface/surface_gpe.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/drivers/platform/surface/surface_gpe.c b/drivers/platform/surface/surface_gpe.c
+index b35941390..b4496db79 100644
+--- a/drivers/platform/surface/surface_gpe.c
++++ b/drivers/platform/surface/surface_gpe.c
+@@ -41,6 +41,11 @@ static const struct property_entry lid_device_props_l4F[] = {
+ 	{},
+ };
+ 
++static const struct property_entry lid_device_props_l52[] = {
++	PROPERTY_ENTRY_U32("gpe", 0x52),
++	{},
++};
++
+ static const struct property_entry lid_device_props_l57[] = {
+ 	PROPERTY_ENTRY_U32("gpe", 0x57),
+ 	{},
+@@ -107,6 +112,18 @@ static const struct dmi_system_id dmi_lid_device_table[] = {
+ 		},
+ 		.driver_data = (void *)lid_device_props_l4B,
+ 	},
++	{
++		/*
++		 * We match for SKU here due to product name clash with the ARM
++		 * version.
++		 */
++		.ident = "Surface Pro 9",
++		.matches = {
++			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
++			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "Surface_Pro_9_2038"),
++		},
++		.driver_data = (void *)lid_device_props_l52,
++	},
+ 	{
+ 		.ident = "Surface Book 1",
+ 		.matches = {
+-- 
+2.53.0
+

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1103,7 +1103,7 @@ diff --git a/drivers/media/i2c/imx681.c b/drivers/media/i2c/imx681.c
 new file mode 100644
 --- /dev/null
 +++ b/drivers/media/i2c/imx681.c
-@@ -0,0 +1,1073 @@
+@@ -0,0 +1,915 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Sony IMX681 CMOS Image Sensor Driver
@@ -1216,7 +1216,7 @@ new file mode 100644
 +	/* CSI lane mode: 2 lanes */
 +	{ CCI_REG8(0x0114),  0x01 },
 +	/* Image orientation: H-flip to match Windows AIQB (RGGB native → GRBG) */
-+	{ CCI_REG8(0x0101),  0x00 },
++	{ CCI_REG8(0x0101),  0x03 },
 +	/* Vendor access unlock sequence */
 +	{ CCI_REG8(0x30EB),  0x05 },
 +	{ CCI_REG8(0x30EB),  0x0C },
@@ -1533,71 +1533,6 @@ new file mode 100644
 +
 +	dev_dbg(imx681->dev, "init registers written successfully\n");
 +
-+	/* DIAGNOSTIC: read CHIP_ID, CSI mode, and all frame geometry registers */
-+	{
-+		u64 id_msb = 0, id_lsb = 0, csi_mode = 0;
-+		u64 y_sta_h = 0, y_sta_l = 0, y_end_h = 0, y_end_l = 0;
-+		u64 x_out_h = 0, x_out_l = 0, y_out_h = 0, y_out_l = 0, fll_h = 0, fll_l = 0;
-+		u64 llp_h = 0, llp_l = 0;
-+		u64 dc_w_h = 0, dc_w_l = 0, dc_h_h = 0, dc_h_l = 0;
-+		u64 v300a_h = 0, v300a_l = 0, v3532_h = 0, v3532_l = 0;
-+		u64 reg0368_h = 0, reg0368_l = 0;
-+		int rc;
-+		rc  = cci_read(imx681->cci, CCI_REG8(0x0016), &id_msb, NULL);
-+		rc |= cci_read(imx681->cci, CCI_REG8(0x0017), &id_lsb, NULL);
-+		rc |= cci_read(imx681->cci, CCI_REG8(0x0111), &csi_mode, NULL);
-+		dev_info(imx681->dev, "imx681 CHIP_ID=0x%02llx%02llx CSI_SIGNALLING_MODE=0x%02llx (rc=%d)\n",
-+			 id_msb, id_lsb, csi_mode, rc);
-+		/* Frame geometry readback */
-+		cci_read(imx681->cci, CCI_REG8(0x0346), &y_sta_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0347), &y_sta_l, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x034A), &y_end_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x034B), &y_end_l, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x034C), &x_out_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x034D), &x_out_l, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x034E), &y_out_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x034F), &y_out_l, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0340), &fll_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0341), &fll_l, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0342), &llp_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0343), &llp_l, NULL);
-+		dev_info(imx681->dev,
-+			 "imx681 Y_ADDR_START=0x%02llx%02llx Y_ADDR_END=0x%02llx%02llx X_OUT=0x%02llx%02llx Y_OUT=0x%02llx%02llx FLL=0x%02llx%02llx LLP=0x%02llx%02llx\n",
-+			 y_sta_h, y_sta_l, y_end_h, y_end_l,
-+			 x_out_h, x_out_l, y_out_h, y_out_l, fll_h, fll_l, llp_h, llp_l);
-+		/* Digital crop registers */
-+		u64 dc_y_off_h = 0, dc_y_off_l = 0;
-+		cci_read(imx681->cci, CCI_REG8(0x040A), &dc_y_off_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x040B), &dc_y_off_l, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x040C), &dc_w_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x040D), &dc_w_l, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x040E), &dc_h_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x040F), &dc_h_l, NULL);
-+		u64 d00=0, d01=0, d02=0, d03=0, d04=0, d05=0, d06=0, d07=0;
-+		cci_read(imx681->cci, CCI_REG8(0x0D00), &d00, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0D01), &d01, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0D02), &d02, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0D03), &d03, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0D04), &d04, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0D05), &d05, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0D06), &d06, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0D07), &d07, NULL);
-+		dev_info(imx681->dev,
-+			 "imx681 0x0D00-07: %02llx %02llx %02llx %02llx %02llx %02llx %02llx %02llx\n",
-+			 d00, d01, d02, d03, d04, d05, d06, d07);
-+		/* Vendor-specific registers */
-+		cci_read(imx681->cci, CCI_REG8(0x300A), &v300a_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x300B), &v300a_l, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x3532), &v3532_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x3533), &v3532_l, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0368), &reg0368_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0369), &reg0368_l, NULL);
-+		dev_info(imx681->dev,
-+			 "imx681 DIG_CROP_Y_OFF=0x%02llx%02llx DIG_CROP_W=0x%02llx%02llx DIG_CROP_H=0x%02llx%02llx 0x300A=0x%02llx%02llx 0x3532=0x%02llx%02llx 0x0368=0x%02llx%02llx\n",
-+			 dc_y_off_h, dc_y_off_l, dc_w_h, dc_w_l, dc_h_h, dc_h_l,
-+			 v300a_h, v300a_l, v3532_h, v3532_l,
-+			 reg0368_h, reg0368_l);
-+	}
 +
 +	/* Wait for sensor to stabilise after configuration */
 +	usleep_range(IMX681_INIT_DELAY_US, IMX681_INIT_DELAY_US + 1000);
@@ -1617,104 +1552,12 @@ new file mode 100644
 +		return ret;
 +	}
 +
-+	/* FORCE high exposure+gain with group hold, try both 0x0229 and CCS 0x0202 */
-+	{
-+		int fret = 0;
-+		cci_write(imx681->cci, IMX681_REG_GROUP_HOLD, 0x01, NULL);
-+		fret |= cci_write(imx681->cci, CCI_REG16(0x0340), 3177, NULL); /* CCS FLL */
-+		fret |= cci_write(imx681->cci, IMX681_REG_EXPOSURE, 500, NULL);
-+		fret |= cci_write(imx681->cci, IMX681_REG_ANALOG_GAIN, 0x0020, NULL); /* low gain */
-+		fret |= cci_write(imx681->cci, IMX681_REG_DIGITAL_GAIN, 0x0100, NULL); /* 1x dgain */
-+		cci_write(imx681->cci, IMX681_REG_GROUP_HOLD, 0x00, NULL);
-+		dev_info(imx681->dev, "forced FLL=3177 exp=500 gain=0x20 ret=%d\n", fret);
-+	}
 +	/* Start streaming */
 +	ret = cci_write(imx681->cci, IMX681_REG_MODE_SELECT,
 +			IMX681_MODE_STREAMING, NULL);
 +	if (ret) {
 +		dev_err(imx681->dev, "failed to start streaming: %d\n", ret);
 +		return ret;
-+	}
-+
-+	/* DIAGNOSTIC: read embedded data and MIPI config registers */
-+	{
-+		u64 ebd_0=0,ebd_1=0,ebd_2=0,ebd_3=0,ebd_4=0,ebd_5=0;
-+		u64 r3002=0,r3004=0,r3006=0,r0114=0,r0112=0;
-+		cci_read(imx681->cci, CCI_REG8(0x3A00), &ebd_0, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x3A01), &ebd_1, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x3A02), &ebd_2, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x3A03), &ebd_3, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x3A04), &ebd_4, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x3A05), &ebd_5, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x3002), &r3002, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x3004), &r3004, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x3006), &r3006, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0112), &r0112, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0114), &r0114, NULL);
-+		dev_info(imx681->dev, "EBD: 0x3A00-05=%02llx %02llx %02llx %02llx %02llx %02llx 0x3002=%02llx 0x3004=%02llx 0x3006=%02llx CSI_DT=0x%02llx LANES=0x%02llx\n",
-+			ebd_0,ebd_1,ebd_2,ebd_3,ebd_4,ebd_5,r3002,r3004,r3006,r0112,r0114);
-+	}
-+	/* DIAGNOSTIC: binning and array geometry */
-+	{
-+		u64 xas_h=0,xas_l=0,xae_h=0,xae_l=0,bm=0,bt=0,ss_mode=0;
-+		cci_read(imx681->cci, CCI_REG8(0x0344), &xas_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0345), &xas_l, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0348), &xae_h, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0349), &xae_l, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0900), &bm, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0901), &bt, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0390), &ss_mode, NULL);
-+		dev_info(imx681->dev, "ARRAY: X_START=0x%02llx%02llx X_END=0x%02llx%02llx BINNING_MODE=0x%02llx BINNING_TYPE=0x%02llx SUB_SAMPLE=0x%02llx\n",
-+			xas_h,xas_l,xae_h,xae_l,bm,bt,ss_mode);
-+	}
-+	dev_info(imx681->dev, "streaming started\n");
-+
-+	/* DIAGNOSTIC: read back exposure/gain registers to verify writes stuck */
-+	{
-+		u64 exp_hi=0, exp_mid=0, exp_lo=0, gain=0, gain_alt=0, dgain=0;
-+		u64 exp_ccs_hi=0, exp_ccs_mid=0;
-+		cci_read(imx681->cci, CCI_REG8(0x0229), &exp_hi, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x022A), &exp_mid, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x022B), &exp_lo, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0202), &exp_ccs_hi, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0203), &exp_ccs_mid, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0204), &gain, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x0205), &gain_alt, NULL);
-+		cci_read(imx681->cci, CCI_REG8(0x020E), &dgain, NULL);
-+		dev_info(imx681->dev,
-+			 "regcheck: 0x0229=%02llx%02llx%02llx 0x0202=%02llx%02llx gain=0x%02llx%02llx dgain=0x%02llx\n",
-+			 exp_hi, exp_mid, exp_lo, exp_ccs_hi, exp_ccs_mid, gain, gain_alt, dgain);
-+		{
-+			u64 p0=0,p1=0,p2=0,p3=0,p4=0,p5=0,p6=0,p7=0,p8=0;
-+			cci_read(imx681->cci, CCI_REG8(0x0301), &p0, NULL); /* IVTPXCK_DIV */
-+			cci_read(imx681->cci, CCI_REG8(0x0303), &p1, NULL); /* IVTSYCK_DIV */
-+			cci_read(imx681->cci, CCI_REG8(0x0305), &p2, NULL); /* PREPLLCK_VT_DIV */
-+			cci_read(imx681->cci, CCI_REG8(0x0306), &p3, NULL); /* PLL_VT_MPY hi */
-+			cci_read(imx681->cci, CCI_REG8(0x0307), &p4, NULL); /* PLL_VT_MPY lo */
-+			cci_read(imx681->cci, CCI_REG8(0x030B), &p5, NULL); /* IOPPXCK_DIV */
-+			cci_read(imx681->cci, CCI_REG8(0x030D), &p6, NULL); /* PREPLLCK_OP_DIV */
-+			cci_read(imx681->cci, CCI_REG8(0x030E), &p7, NULL); /* PLL_OP_MPY hi */
-+			cci_read(imx681->cci, CCI_REG8(0x030F), &p8, NULL); /* PLL_OP_MPY lo */
-+			dev_info(imx681->dev,
-+				 "pll: 0301=%02llx 0303=%02llx 0305=%02llx 0306=%02llx 0307=%02llx 030B=%02llx 030D=%02llx 030E=%02llx 030F=%02llx\n",
-+				 p0,p1,p2,p3,p4,p5,p6,p7,p8);
-+		}
-+	}
-+	/* DIAGNOSTIC: confirm streaming command stuck and sensor is emitting frames */
-+	{
-+		u64 mode = 0, fcnt0 = 0, fcnt1 = 0;
-+		int rc;
-+		rc = cci_read(imx681->cci, CCI_REG8(0x0100), &mode, NULL);
-+		rc |= cci_read(imx681->cci, CCI_REG8(0x0005), &fcnt0, NULL);
-+		msleep(200);
-+		rc |= cci_read(imx681->cci, CCI_REG8(0x0005), &fcnt1, NULL);
-+		msleep(500);
-+		{
-+			u64 fcnt2 = 0;
-+			cci_read(imx681->cci, CCI_REG8(0x0005), &fcnt2, NULL);
-+			dev_info(imx681->dev, "imx681 MODE_SEL=0x%02llx FRAME_CNT t=0:0x%02llx t=200ms:0x%02llx t=700ms:0x%02llx (rc=%d)\n",
-+				 mode, fcnt0, fcnt1, fcnt2, rc);
-+		}
 +	}
 +	return 0;
 +}
@@ -1735,7 +1578,6 @@ new file mode 100644
 +				 struct v4l2_subdev_state *state,
 +				 u32 pad, u64 streams_mask)
 +{
-+	dev_info(sd->dev, "enable_streams called pad=%d mask=0x%llx\n", pad, streams_mask);
 +	struct imx681 *imx681 = to_imx681(sd);
 +	int ret;
 +

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1061,9 +1061,9 @@ index f5456330b..3418ff475 100644
 -- 
 2.53.0
 
-From 96812b7d52c84c3e4d3d710d4faa6669dc28c609 Mon Sep 17 00:00:00 2001
+From 8a2cb982bb5f1fe027a800396d09f86c02d8b119 Mon Sep 17 00:00:00 2001
 From: "D.J. Mulder" <djmulder@example.com>
-Date: Fri, 29 May 2026 15:28:15 +0200
+Date: Fri, 29 May 2026 15:55:28 +0200
 Subject: [PATCH 1/5] media: i2c: Add Sony IMX681 sensor driver for Surface Pro
  10/11
 
@@ -1081,18 +1081,23 @@ Register sequences reverse-engineered from Windows I2C traces.
 Uses H-flip (reg 0x0101=0x01) to convert native RGGB Bayer to GRBG
 matching the Windows AIQB calibration data.
 
+Note: On Surface Pro 10 (MTL), the front camera currently produces
+black frames due to missing C-PHY support in ipu6-isys-dwc-phy.c.
+This driver is correct and complete; the limitation is in the IPU6
+PHY driver which requires Intel to add C-PHY initialisation support.
+
 Patchset: cameras
 ---
- drivers/media/i2c/imx681.c | 924 +++++++++++++++++++++++++++++++++++++
- 1 file changed, 924 insertions(+)
+ drivers/media/i2c/imx681.c | 895 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 895 insertions(+)
  create mode 100644 drivers/media/i2c/imx681.c
 
 diff --git a/drivers/media/i2c/imx681.c b/drivers/media/i2c/imx681.c
 new file mode 100644
-index 0000000..f559d53
+index 0000000..0459085
 --- /dev/null
 +++ b/drivers/media/i2c/imx681.c
-@@ -0,0 +1,924 @@
+@@ -0,0 +1,895 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Sony IMX681 CMOS Image Sensor Driver
@@ -1164,12 +1169,14 @@ index 0000000..f559d53
 +/* MIPI lanes */
 +#define IMX681_NUM_LANES		2
 +
-+#define IMX681_LINK_FREQ_MTL    380800000LL  /* Meteor Lake (SP10), C-PHY */
-+#define IMX681_LINK_FREQ_LNL    969600000LL  /* Lunar Lake (SP11), D-PHY */
++/* SP10: Link freq = 19.2MHz × 119 / 3 / 2 = 380.8 MHz */
++#define IMX681_LINK_FREQ    		380800000LL
++
++/* PLL multiplier = 119 = 0x77 */
++/* PLL2: pre_div=3, multiplier=119 (0x0077) */
 +
 +/* Pixel rate = link_freq * 2 (DDR) * num_lanes / bpp */
-+#define IMX681_PIXEL_RATE_MTL	(IMX681_LINK_FREQ_MTL * 2 * IMX681_NUM_LANES / 10)
-+#define IMX681_PIXEL_RATE_LNL	(IMX681_LINK_FREQ_LNL * 2 * IMX681_NUM_LANES / 10)
++#define IMX681_PIXEL_RATE		(IMX681_LINK_FREQ * 2 * IMX681_NUM_LANES / 10)
 +
 +/* Power-on delay after reset deassert */
 +#define IMX681_RESET_DELAY_US		1000
@@ -1181,8 +1188,7 @@ index 0000000..f559d53
 +#define IMAGE_PAD			0
 +
 +static const s64 imx681_link_frequencies[] = {
-+	IMX681_LINK_FREQ_MTL,
-+	IMX681_LINK_FREQ_LNL,
++	IMX681_LINK_FREQ,
 +};
 +
 +/*
@@ -1219,24 +1225,16 @@ index 0000000..f559d53
 +	{ CCI_REG24(0x040D), 0x040A50 },
 +	/* X_OUTPUT_SIZE=3844, Y_OUTPUT_SIZE=2640 */
 +	{ CCI_REG32(0x034C), 0x0F040A50 },
++	/* PLL multiplier = 225 */
++	{ CCI_REG8(0x0307),  0x77 },
++	/* PLL2: pre_div=3, multiplier=303 (0x012F) */
++	{ CCI_REG24(0x030D), 0x030077 },
 +	/* Frame duration initial */
 +	{ CCI_REG16(0x022A), 0x0C61 },
 +	/* Vendor specific registers */
 +	{ CCI_REG8(0x7E9B),  0x02 },
 +	{ CCI_REG8(0x0368),  0x00 },
 +	{ CCI_REG8(0xD383),  0x01 },
-+};
-+
-+/* SP10: Meteor Lake, C-PHY, 380.8 MHz */
-+static const struct cci_reg_sequence imx681_pll_regs_mtl[] = {
-+	{ CCI_REG8(0x0307),  0x77 },      /* PLL multiplier = 119 */
-+	{ CCI_REG24(0x030D), 0x030077 },  /* PLL2: pre_div=3, mul=119 */
-+};
-+
-+/* SP11: Lunar Lake, D-PHY, 969.6 MHz */
-+static const struct cci_reg_sequence imx681_pll_regs_lnl[] = {
-+	{ CCI_REG8(0x0307),  0xE1 },      /* PLL multiplier = 225 */
-+	{ CCI_REG24(0x030D), 0x03012F },  /* PLL2: pre_div=3, mul=303 */
 +};
 +
 +/*
@@ -1499,29 +1497,12 @@ index 0000000..f559d53
 +{
 +	int ret;
 +
-+	dev_info(imx681->dev, "starting stream: %dx%d RAW10 2-lane\n",
-+		IMX681_WIDTH, IMX681_HEIGHT);
 +
 +	/* Write init register sequence */
 +	ret = cci_multi_reg_write(imx681->cci, imx681_init_regs,
 +				  ARRAY_SIZE(imx681_init_regs), NULL);
 +	if (ret) {
 +		dev_err(imx681->dev, "failed to write init regs: %d\n", ret);
-+		return ret;
-+	}
-+
-+	/* Select PLL registers based on negotiated link frequency */
-+	if (imx681->link_freq_bitmap & BIT(0)) {
-+		/* MTL / SP10: 380.8 MHz C-PHY */
-+		ret = cci_multi_reg_write(imx681->cci, imx681_pll_regs_mtl,
-+					  ARRAY_SIZE(imx681_pll_regs_mtl), NULL);
-+	} else {
-+		/* LNL / SP11: 969.6 MHz D-PHY */
-+		ret = cci_multi_reg_write(imx681->cci, imx681_pll_regs_lnl,
-+					  ARRAY_SIZE(imx681_pll_regs_lnl), NULL);
-+	}
-+	if (ret) {
-+		dev_err(imx681->dev, "failed to write PLL regs: %d\n", ret);
 +		return ret;
 +	}
 +
@@ -1553,7 +1534,6 @@ index 0000000..f559d53
 +		return ret;
 +	}
 +
-+	dev_info(imx681->dev, "streaming started\n");
 +	return 0;
 +}
 +
@@ -1573,7 +1553,6 @@ index 0000000..f559d53
 +				 struct v4l2_subdev_state *state,
 +				 u32 pad, u64 streams_mask)
 +{
-+	dev_info(sd->dev, "enable_streams called pad=%d mask=0x%llx\n", pad, streams_mask);
 +	struct imx681 *imx681 = to_imx681(sd);
 +	int ret;
 +
@@ -1587,7 +1566,6 @@ index 0000000..f559d53
 +	}
 +
 +	ret = imx681_start_streaming(imx681);
-+	dev_info(sd->dev, "start_streaming returned %d\n", ret);
 +	if (ret)
 +		pm_runtime_put_autosuspend(imx681->dev);
 +
@@ -1708,19 +1686,16 @@ index 0000000..f559d53
 +	struct v4l2_fwnode_device_properties props;
 +	struct v4l2_ctrl *link_freq;
 +	s64 hblank, vblank;
-+	u64 pixel_rate;
 +	int ret;
 +
 +	ret = v4l2_ctrl_handler_init(ctrl_hdlr, 9);
 +	if (ret)
 +		return ret;
 +
-+	/* Pixel rate (read-only) — depends on platform link frequency */
-+	pixel_rate = (imx681->link_freq_bitmap & BIT(0)) ?
-+			 IMX681_PIXEL_RATE_MTL : IMX681_PIXEL_RATE_LNL;
++	/* Pixel rate (read-only) */
 +	v4l2_ctrl_new_std(ctrl_hdlr, &imx681_ctrl_ops,
-+			  V4L2_CID_PIXEL_RATE, pixel_rate,
-+			  pixel_rate, 1, pixel_rate);
++			  V4L2_CID_PIXEL_RATE, IMX681_PIXEL_RATE,
++			  IMX681_PIXEL_RATE, 1, IMX681_PIXEL_RATE);
 +
 +	/* Link frequency (read-only) */
 +	link_freq = v4l2_ctrl_new_int_menu(ctrl_hdlr, &imx681_ctrl_ops,
@@ -1796,7 +1771,7 @@ index 0000000..f559d53
 +{
 +	struct fwnode_handle *fwnode = dev_fwnode(imx681->dev);
 +	struct v4l2_fwnode_endpoint bus_cfg = {
-+		.bus_type = V4L2_MBUS_UNKNOWN,
++		.bus_type = V4L2_MBUS_CSI2_CPHY,
 +	};
 +	struct fwnode_handle *ep;
 +	int ret;
@@ -1951,8 +1926,9 @@ index 0000000..f559d53
 +	pm_runtime_put_autosuspend(imx681->dev);
 +
 +	dev_info(imx681->dev,
-+		 "IMX681 probed successfully: %dx%d\n",
-+		 IMX681_WIDTH, IMX681_HEIGHT);
++		 "IMX681 probed successfully: %dx%d @ %lld Hz link freq\n",
++		 IMX681_WIDTH, IMX681_HEIGHT, IMX681_LINK_FREQ);
++
 +	return 0;
 +
 +error_subdev_cleanup:
@@ -2021,9 +1997,9 @@ index 0000000..f559d53
 2.53.0
 
 
-From 929c24b59a5066c83593634105c830c887588509 Mon Sep 17 00:00:00 2001
+From 6d3417b5fff9e0d6a8aabf260756bf2ae5daa5d1 Mon Sep 17 00:00:00 2001
 From: "D.J. Mulder" <djmulder@example.com>
-Date: Fri, 29 May 2026 15:28:53 +0200
+Date: Fri, 29 May 2026 15:57:33 +0200
 Subject: [PATCH 2/5] media: ipu-bridge: Add Surface Pro 10 camera sensor
  support
 
@@ -2041,11 +2017,11 @@ Surface Pro 10 (Meteor Lake / IPU6EP-MTL):
 
 Patchset: cameras
 ---
- drivers/media/pci/intel/ipu-bridge.c | 80 +++++++++++++++++++++++++---
- 1 file changed, 72 insertions(+), 8 deletions(-)
+ drivers/media/pci/intel/ipu-bridge.c | 84 ++++++++++++++++++++++++----
+ 1 file changed, 74 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/media/pci/intel/ipu-bridge.c b/drivers/media/pci/intel/ipu-bridge.c
-index a986e30..fb17d20 100644
+index a986e30..3aaea3b 100644
 --- a/drivers/media/pci/intel/ipu-bridge.c
 +++ b/drivers/media/pci/intel/ipu-bridge.c
 @@ -5,6 +5,7 @@
@@ -2185,11 +2161,11 @@ index a986e30..fb17d20 100644
  	int ret;
  
  	for_each_acpi_dev_match(adev, cfg->hid, NULL, -1) {
-+		dev_info(bridge->dev, "Trying to connect sensor %s\n", cfg->hid);
++		dev_dbg(bridge->dev, "Trying to connect sensor %s\n", cfg->hid);
  		if (!ACPI_PTR(adev->status.enabled))
  			continue;
  
-@@ -705,6 +764,10 @@ static int ipu_bridge_connect_sensor(const struct ipu_sensor_config *cfg,
+@@ -705,11 +764,15 @@ static int ipu_bridge_connect_sensor(const struct ipu_sensor_config *cfg,
  		primary = acpi_fwnode_handle(adev);
  		primary->secondary = fwnode;
  
@@ -2200,6 +2176,12 @@ index a986e30..fb17d20 100644
  		ret = ipu_bridge_instantiate_ivsc(sensor);
  		if (ret)
  			goto err_free_swnodes;
+ 
+-		dev_info(bridge->dev, "Found supported sensor %s\n",
++		dev_dbg(bridge->dev, "Found supported sensor %s\n",
+ 			 acpi_dev_name(adev));
+ 
+ 		bridge->n_sensors++;
 @@ -811,9 +874,10 @@ int ipu_bridge_init(struct device *dev,
  		return 0;
  
@@ -2213,13 +2195,22 @@ index a986e30..fb17d20 100644
  	if (!bridge)
  		return -ENOMEM;
  
+@@ -843,7 +907,7 @@ int ipu_bridge_init(struct device *dev,
+ 	if (ret || bridge->n_sensors == 0)
+ 		goto err_unregister_ipu;
+ 
+-	dev_info(dev, "Connected %d cameras\n", bridge->n_sensors);
++	dev_dbg(dev, "Connected %d cameras\n", bridge->n_sensors);
+ 
+ 	fwnode = software_node_fwnode(&bridge->ipu_hid_node);
+ 	if (!fwnode) {
 -- 
 2.53.0
 
 
-From 200de783ce8201f1f9d679141c65c1bc4e6e94ff Mon Sep 17 00:00:00 2001
+From 3694289bbf97d2004146090d384ea73562e19692 Mon Sep 17 00:00:00 2001
 From: "D.J. Mulder" <djmulder@example.com>
-Date: Fri, 29 May 2026 15:29:18 +0200
+Date: Fri, 29 May 2026 15:57:52 +0200
 Subject: [PATCH 3/5] platform/x86: int3472: Add GPIO type 0x08 (DVDD) and 0x10
  (DOVDD) support
 
@@ -2240,11 +2231,11 @@ Replaces the Surface Pro 9 workaround which used raw magic numbers
 
 Patchset: cameras
 ---
- drivers/platform/x86/intel/int3472/discrete.c | 156 +++++++++++++-----
- 1 file changed, 117 insertions(+), 39 deletions(-)
+ drivers/platform/x86/intel/int3472/discrete.c | 154 +++++++++++++-----
+ 1 file changed, 115 insertions(+), 39 deletions(-)
 
 diff --git a/drivers/platform/x86/intel/int3472/discrete.c b/drivers/platform/x86/intel/int3472/discrete.c
-index fee7e56..e2562b3 100644
+index fee7e56..b0c8da3 100644
 --- a/drivers/platform/x86/intel/int3472/discrete.c
 +++ b/drivers/platform/x86/intel/int3472/discrete.c
 @@ -5,18 +5,18 @@
@@ -2277,7 +2268,7 @@ index fee7e56..e2562b3 100644
  {
  	char *path = agpio->resource_source.string_ptr;
  	struct acpi_device *adev;
-@@ -71,24 +71,26 @@ static int skl_int3472_fill_gpiod_lookup(struct gpiod_lookup *table_entry,
+@@ -71,24 +71,25 @@ static int skl_int3472_fill_gpiod_lookup(struct gpiod_lookup *table_entry,
  	if (!adev)
  		return -ENODEV;
  
@@ -2294,7 +2285,6 @@ index fee7e56..e2562b3 100644
  {
  	int ret;
  
-+	dev_info(int3472->dev, "Mapping GPIO pin %d to sensor as %s (sensor gpio %d/%d)\n",
 +         	agpio->pin_table[0], con_id, int3472->n_sensor_gpios, INT3472_MAX_SENSOR_GPIOS);
  	if (int3472->n_sensor_gpios >= INT3472_MAX_SENSOR_GPIOS) {
  		dev_warn(int3472->dev, "Too many GPIOs mapped\n");
@@ -2307,7 +2297,7 @@ index fee7e56..e2562b3 100644
  	if (ret)
  		return ret;
  
-@@ -101,23 +103,23 @@ static int skl_int3472_map_gpio_to_sensor(struct int3472_discrete_device *int347
+@@ -101,23 +102,23 @@ static int skl_int3472_map_gpio_to_sensor(struct int3472_discrete_device *int347
  static struct gpio_desc *
  skl_int3472_gpiod_get_from_temp_lookup(struct int3472_discrete_device *int3472,
  				       struct acpi_resource_gpio *agpio,
@@ -2335,7 +2325,7 @@ index fee7e56..e2562b3 100644
  	gpiod_remove_lookup_table(lookup);
  
  	return desc;
-@@ -129,7 +131,8 @@ skl_int3472_gpiod_get_from_temp_lookup(struct int3472_discrete_device *int3472,
+@@ -129,7 +130,8 @@ skl_int3472_gpiod_get_from_temp_lookup(struct int3472_discrete_device *int3472,
   * @hid: The ACPI HID of the device without the instance number e.g. INT347E
   * @type_from: The GPIO type from ACPI ?SDT
   * @type_to: The assigned GPIO type, typically same as @type_from
@@ -2345,7 +2335,7 @@ index fee7e56..e2562b3 100644
   * @polarity_low: GPIO_ACTIVE_LOW true if the @polarity_low is true,
   * GPIO_ACTIVE_HIGH otherwise
   */
-@@ -138,16 +141,38 @@ struct int3472_gpio_map {
+@@ -138,16 +140,38 @@ struct int3472_gpio_map {
  	u8 type_from;
  	u8 type_to;
  	bool polarity_low;
@@ -2388,7 +2378,7 @@ index fee7e56..e2562b3 100644
  	unsigned int i;
  
  	for (i = 0; i < ARRAY_SIZE(int3472_gpio_map); i++) {
-@@ -162,40 +187,60 @@ static void int3472_get_func_and_polarity(struct acpi_device *adev, u8 *type,
+@@ -162,40 +186,60 @@ static void int3472_get_func_and_polarity(struct acpi_device *adev, u8 *type,
  		if (!acpi_dev_hid_uid_match(adev, int3472_gpio_map[i].hid, NULL))
  			continue;
  
@@ -2457,7 +2447,7 @@ index fee7e56..e2562b3 100644
  		*gpio_flags = GPIO_ACTIVE_HIGH;
  		break;
  	}
-@@ -216,6 +261,8 @@ static void int3472_get_func_and_polarity(struct acpi_device *adev, u8 *type,
+@@ -216,6 +260,8 @@ static void int3472_get_func_and_polarity(struct acpi_device *adev, u8 *type,
   * 0x0b Power enable
   * 0x0c Clock enable
   * 0x0d Privacy LED
@@ -2466,7 +2456,7 @@ index fee7e56..e2562b3 100644
   *
   * There are some known platform specific quirks where that does not quite
   * hold up; for example where a pin with type 0x01 (Power down) is mapped to
-@@ -237,13 +284,15 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
+@@ -237,13 +283,15 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
  					     void *data)
  {
  	struct int3472_discrete_device *int3472 = data;
@@ -2484,14 +2474,13 @@ index fee7e56..e2562b3 100644
  	int ret;
  
  	if (!acpi_gpio_get_io_resource(ares, &agpio))
-@@ -266,27 +315,28 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
+@@ -266,27 +314,27 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
  
  	type = FIELD_GET(INT3472_GPIO_DSM_TYPE, obj->integer.value);
  
 -	int3472_get_func_and_polarity(int3472->sensor, &type, &func, &gpio_flags);
 -
 +	int3472_get_con_id_and_polarity(int3472, &type, &con_id, &gpio_flags, &enable_time_us);
-+	dev_info(int3472->dev, "Processing GPIO pin %d type 0x%02x con_id %s\n",
 +        	agpio->pin_table[0], type, con_id);
  	pin = FIELD_GET(INT3472_GPIO_DSM_PIN, obj->integer.value);
  	/* Pin field is not really used under Windows and wraps around at 8 bits */
@@ -2519,7 +2508,7 @@ index fee7e56..e2562b3 100644
  		if (ret)
  			err_msg = "Failed to map GPIO pin to sensor\n";
  
-@@ -294,7 +344,10 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
+@@ -294,7 +342,10 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
  	case INT3472_GPIO_TYPE_CLK_ENABLE:
  	case INT3472_GPIO_TYPE_PRIVACY_LED:
  	case INT3472_GPIO_TYPE_POWER_ENABLE:
@@ -2531,7 +2520,7 @@ index fee7e56..e2562b3 100644
  		if (IS_ERR(gpio)) {
  			ret = PTR_ERR(gpio);
  			err_msg = "Failed to get GPIO\n";
-@@ -315,15 +368,25 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
+@@ -315,15 +366,25 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
  
  			break;
  		case INT3472_GPIO_TYPE_POWER_ENABLE:
@@ -2559,7 +2548,7 @@ index fee7e56..e2562b3 100644
  		break;
  	default:
  		dev_warn(int3472->dev,
-@@ -343,7 +406,7 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
+@@ -343,7 +404,7 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
  	return 1;
  }
  
@@ -2568,7 +2557,7 @@ index fee7e56..e2562b3 100644
  {
  	LIST_HEAD(resource_list);
  	int ret;
-@@ -368,28 +431,39 @@ static int skl_int3472_parse_crs(struct int3472_discrete_device *int3472)
+@@ -368,28 +429,39 @@ static int skl_int3472_parse_crs(struct int3472_discrete_device *int3472)
  
  	return 0;
  }
@@ -2611,7 +2600,7 @@ index fee7e56..e2562b3 100644
  	ret = skl_int3472_fill_cldb(adev, &cldb);
  	if (ret) {
  		dev_err(&pdev->dev, "Couldn't fill CLDB structure\n");
-@@ -413,6 +487,9 @@ static int skl_int3472_discrete_probe(struct platform_device *pdev)
+@@ -413,6 +485,9 @@ static int skl_int3472_discrete_probe(struct platform_device *pdev)
  	platform_set_drvdata(pdev, int3472);
  	int3472->clock.imgclk_index = cldb.clock_source;
  
@@ -2621,7 +2610,7 @@ index fee7e56..e2562b3 100644
  	ret = skl_int3472_get_sensor_adev_and_name(&pdev->dev, &int3472->sensor,
  						   &int3472->sensor_name);
  	if (ret)
-@@ -424,7 +501,7 @@ static int skl_int3472_discrete_probe(struct platform_device *pdev)
+@@ -424,7 +499,7 @@ static int skl_int3472_discrete_probe(struct platform_device *pdev)
  	 */
  	INIT_LIST_HEAD(&int3472->gpios.list);
  
@@ -2630,7 +2619,7 @@ index fee7e56..e2562b3 100644
  	if (ret) {
  		skl_int3472_discrete_remove(pdev);
  		return ret;
-@@ -453,3 +530,4 @@ module_platform_driver(int3472_discrete);
+@@ -453,3 +528,4 @@ module_platform_driver(int3472_discrete);
  MODULE_DESCRIPTION("Intel SkyLake INT3472 ACPI Discrete Device Driver");
  MODULE_AUTHOR("Daniel Scally <djrscally@gmail.com>");
  MODULE_LICENSE("GPL v2");
@@ -2639,9 +2628,9 @@ index fee7e56..e2562b3 100644
 2.53.0
 
 
-From 856ae2750ccc39b53ee4cd98e77ffb5ff1c9ef10 Mon Sep 17 00:00:00 2001
+From c09b1a55bdfc1b3b3943ef93d7f6c4428a97e8d3 Mon Sep 17 00:00:00 2001
 From: "D.J. Mulder" <djmulder@example.com>
-Date: Fri, 29 May 2026 15:29:38 +0200
+Date: Fri, 29 May 2026 15:58:07 +0200
 Subject: [PATCH 4/5] platform/x86: int3472: Mark clock critical and regulators
  always-on for SP10
 
@@ -2919,9 +2908,9 @@ index 16e36ac..3f280ef 100644
 2.53.0
 
 
-From 07977dd74206fd7459896f6fe144f2e0e5f9b5eb Mon Sep 17 00:00:00 2001
+From 5f303220052fe7290be7d93a43cfdaa3be874892 Mon Sep 17 00:00:00 2001
 From: "D.J. Mulder" <djmulder@example.com>
-Date: Fri, 29 May 2026 15:30:00 +0200
+Date: Fri, 29 May 2026 15:58:25 +0200
 Subject: [PATCH 5/5] media: i2c: ov13858: Add reset GPIO handling for Surface
  Pro 10
 
@@ -2939,11 +2928,11 @@ reads return 0xFF, causing probe to fail with -EIO on chip ID check.
 
 Patchset: cameras
 ---
- drivers/media/i2c/ov13858.c | 94 +++++++++++++++++++++++++------------
- 1 file changed, 63 insertions(+), 31 deletions(-)
+ drivers/media/i2c/ov13858.c | 93 ++++++++++++++++++++++++-------------
+ 1 file changed, 62 insertions(+), 31 deletions(-)
 
 diff --git a/drivers/media/i2c/ov13858.c b/drivers/media/i2c/ov13858.c
-index 7a3fc1d..f4e8493 100644
+index 7a3fc1d..c924fc2 100644
 --- a/drivers/media/i2c/ov13858.c
 +++ b/drivers/media/i2c/ov13858.c
 @@ -2,9 +2,12 @@
@@ -3009,7 +2998,7 @@ index 7a3fc1d..f4e8493 100644
  		break;
  	default:
 -		dev_info(&client->dev,
-+		dev_info(ov13858->dev,
++		dev_dbg(ov13858->dev,
  			 "ctrl(id:0x%x,val:0x%x) is not handled\n",
  			 ctrl->id, ctrl->val);
  		break;
@@ -3128,7 +3117,7 @@ index 7a3fc1d..f4e8493 100644
  	if (ret)
  		goto error;
  
-@@ -1660,24 +1661,55 @@ static void ov13858_free_controls(struct ov13858 *ov13858)
+@@ -1660,24 +1661,54 @@ static void ov13858_free_controls(struct ov13858 *ov13858)
  static int ov13858_probe(struct i2c_client *client)
  {
  	struct ov13858 *ov13858;
@@ -3164,7 +3153,6 @@ index 7a3fc1d..f4e8493 100644
 +
 +	/* Take sensor out of reset */
 +	ov13858->reset_gpio = devm_gpiod_get_optional(ov13858->dev, "reset", GPIOD_OUT_HIGH);
-+	dev_info(ov13858->dev, "reset_gpio = %p, IS_ERR=%d\n",
 +		 ov13858->reset_gpio, IS_ERR(ov13858->reset_gpio));
 +	if (IS_ERR(ov13858->reset_gpio))
 +		return dev_err_probe(ov13858->dev, PTR_ERR(ov13858->reset_gpio),
@@ -3190,7 +3178,7 @@ index 7a3fc1d..f4e8493 100644
  		return ret;
  	}
  
-@@ -1699,7 +1731,7 @@ static int ov13858_probe(struct i2c_client *client)
+@@ -1699,7 +1730,7 @@ static int ov13858_probe(struct i2c_client *client)
  	ov13858->pad.flags = MEDIA_PAD_FL_SOURCE;
  	ret = media_entity_pads_init(&ov13858->sd.entity, 1, &ov13858->pad);
  	if (ret) {
@@ -3199,7 +3187,7 @@ index 7a3fc1d..f4e8493 100644
  		goto error_handler_free;
  	}
  
-@@ -1711,9 +1743,9 @@ static int ov13858_probe(struct i2c_client *client)
+@@ -1711,9 +1742,9 @@ static int ov13858_probe(struct i2c_client *client)
  	 * Device is already turned on by i2c-core with ACPI domain PM.
  	 * Enable runtime PM and turn off the device.
  	 */
@@ -3212,7 +3200,7 @@ index 7a3fc1d..f4e8493 100644
  
  	return 0;
  
-@@ -1722,7 +1754,7 @@ error_media_entity:
+@@ -1722,7 +1753,7 @@ error_media_entity:
  
  error_handler_free:
  	ov13858_free_controls(ov13858);
@@ -3221,7 +3209,7 @@ index 7a3fc1d..f4e8493 100644
  
  	return ret;
  }
-@@ -1736,7 +1768,7 @@ static void ov13858_remove(struct i2c_client *client)
+@@ -1736,7 +1767,7 @@ static void ov13858_remove(struct i2c_client *client)
  	media_entity_cleanup(&sd->entity);
  	ov13858_free_controls(ov13858);
  

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1103,7 +1103,7 @@ diff --git a/drivers/media/i2c/imx681.c b/drivers/media/i2c/imx681.c
 new file mode 100644
 --- /dev/null
 +++ b/drivers/media/i2c/imx681.c
-@@ -0,0 +1,915 @@
+@@ -0,0 +1,918 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Sony IMX681 CMOS Image Sensor Driver
@@ -1235,8 +1235,8 @@ new file mode 100644
 +	{ CCI_REG24(0x0349), 0x670B4F }, /* Crop window end: X_ADD_END=3943, Y_ADD_END=2895 */
 +	/* Digital crop / vendor config */
 +	/* Digital crop: explicit write of all 8 registers to known-good values */
-+	{ CCI_REG8(0x0408),  0x03 }, /* DIG_CROP_X_OFFSET high = 0x03 */
-+	{ CCI_REG8(0x0409),  0xC2 }, /* DIG_CROP_X_OFFSET low = 0xC2 (962 = center) */
++	{ CCI_REG8(0x0408),  0x00 }, /* DIG_CROP_X_OFFSET high = 0 */
++	{ CCI_REG8(0x0409),  0x01 }, /* DIG_CROP_X_OFFSET low = 1 (center 1922→1920) */
 +	{ CCI_REG8(0x040A),  0x00 }, /* DIG_CROP_Y_OFFSET high = 0 */
 +	{ CCI_REG8(0x040B),  0x00 }, /* DIG_CROP_Y_OFFSET low  = 0 */
 +	{ CCI_REG8(0x040C),  0x07 }, /* DIG_CROP_WIDTH high = 0x07 */
@@ -1246,6 +1246,9 @@ new file mode 100644
 +	/* 2x2 binning */
 +	{ CCI_REG8(0x0900),  0x01 }, /* BINNING_MODE = 1 (enable) */
 +	{ CCI_REG8(0x0901),  0x22 }, /* BINNING_TYPE = 0x22 (2x2) */
++	{ CCI_REG8(0x0401),  0x01 }, /* SCALE_MODE = 1 (enabled) */
++	{ CCI_REG16(0x0404), 0x0020 }, /* SCALE_M = 32 (16/32 = 0.5x horizontal) */
++	{ CCI_REG8(0x0902),  0x08 }, /* BINNING_WEIGHTING */
 +	/* X_OUTPUT_SIZE=3844, Y_OUTPUT_SIZE=2640 */
 +	{ CCI_REG32(0x034C), 0x07800528 }, /* X_OUTPUT_SIZE=1920, Y=1320 */
 +	/* PLL multiplier = 225 */

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1245,7 +1245,7 @@ new file mode 100644
 +	/* 2x2 binning */
 +	{ CCI_REG8(0x0900),  0x01 }, /* BINNING_MODE = 1 (enable) */
 +	{ CCI_REG8(0x0901),  0x22 }, /* BINNING_TYPE = 0x22 (2x2) */
-+	{ CCI_REG8(0x0401),  0x00 }, /* SCALE_MODE = 0 (disabled — incompatible with v_flip) */
++	{ CCI_REG8(0x0401),  0x01 }, /* SCALE_MODE = 1 (horizontal scaler enabled) */
 +	{ CCI_REG16(0x0404), 0x0020 }, /* SCALE_M = 32 (0.5x horizontal) */
 +	{ CCI_REG8(0x0902),  0x08 }, /* BINNING_WEIGHTING */
 +	/* X_OUTPUT_SIZE=3844, Y_OUTPUT_SIZE=2640 */

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1,0 +1,3235 @@
+From c1c1eb1b2d1d034dfe351ea51efd25ef502db25e Mon Sep 17 00:00:00 2001
+From: Hans de Goede <hdegoede@redhat.com>
+Date: Sun, 10 Oct 2021 20:56:57 +0200
+Subject: [PATCH] ACPI: delay enumeration of devices with a _DEP pointing to an
+ INT3472 device
+
+The clk and regulator frameworks expect clk/regulator consumer-devices
+to have info about the consumed clks/regulators described in the device's
+fw_node.
+
+To work around cases where this info is not present in the firmware tables,
+which is often the case on x86/ACPI devices, both frameworks allow the
+provider-driver to attach info about consumers to the clks/regulators
+when registering these.
+
+This causes problems with the probe ordering wrt drivers for consumers
+of these clks/regulators. Since the lookups are only registered when the
+provider-driver binds, trying to get these clks/regulators before then
+results in a -ENOENT error for clks and a dummy regulator for regulators.
+
+One case where we hit this issue is camera sensors such as e.g. the OV8865
+sensor found on the Microsoft Surface Go. The sensor uses clks, regulators
+and GPIOs provided by a TPS68470 PMIC which is described in an INT3472
+ACPI device. There is special platform code handling this and setting
+platform_data with the necessary consumer info on the MFD cells
+instantiated for the PMIC under: drivers/platform/x86/intel/int3472.
+
+For this to work properly the ov8865 driver must not bind to the I2C-client
+for the OV8865 sensor until after the TPS68470 PMIC gpio, regulator and
+clk MFD cells have all been fully setup.
+
+The OV8865 on the Microsoft Surface Go is just one example, all X86
+devices using the Intel IPU3 camera block found on recent Intel SoCs
+have similar issues where there is an INT3472 HID ACPI-device, which
+describes the clks and regulators, and the driver for this INT3472 device
+must be fully initialized before the sensor driver (any sensor driver)
+binds for things to work properly.
+
+On these devices the ACPI nodes describing the sensors all have a _DEP
+dependency on the matching INT3472 ACPI device (there is one per sensor).
+
+This allows solving the probe-ordering problem by delaying the enumeration
+(instantiation of the I2C-client in the ov8865 example) of ACPI-devices
+which have a _DEP dependency on an INT3472 device.
+
+The new acpi_dev_ready_for_enumeration() helper used for this is also
+exported because for devices, which have the enumeration_by_parent flag
+set, the parent-driver will do its own scan of child ACPI devices and
+it will try to enumerate those during its probe(). Code doing this such
+as e.g. the i2c-core-acpi.c code must call this new helper to ensure
+that it too delays the enumeration until all the _DEP dependencies are
+met on devices which have the new honor_deps flag set.
+
+Signed-off-by: Hans de Goede <hdegoede@redhat.com>
+Patchset: cameras
+---
+ drivers/acpi/scan.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/acpi/scan.c b/drivers/acpi/scan.c
+index b78f6be2f..801171e2a 100644
+--- a/drivers/acpi/scan.c
++++ b/drivers/acpi/scan.c
+@@ -2206,6 +2206,9 @@ static acpi_status acpi_bus_check_add_2(acpi_handle handle, u32 lvl_not_used,
+ 
+ static void acpi_default_enumeration(struct acpi_device *device)
+ {
++	if (!acpi_dev_ready_for_enumeration(device))
++		return;
++
+ 	/*
+ 	 * Do not enumerate devices with enumeration_by_parent flag set as
+ 	 * they will be enumerated by their respective parents.
+-- 
+2.53.0
+
+From 4b553e59c7d3ff31429e4dd08a0460b11bab94dd Mon Sep 17 00:00:00 2001
+From: zouxiaoh <xiaohong.zou@intel.com>
+Date: Fri, 25 Jun 2021 08:52:59 +0800
+Subject: [PATCH] iommu: intel-ipu: use IOMMU passthrough mode for Intel IPUs
+
+Intel IPU(Image Processing Unit) has its own (IO)MMU hardware,
+The IPU driver allocates its own page table that is not mapped
+via the DMA, and thus the Intel IOMMU driver blocks access giving
+this error: DMAR: DRHD: handling fault status reg 3 DMAR:
+[DMA Read] Request device [00:05.0] PASID ffffffff
+fault addr 76406000 [fault reason 06] PTE Read access is not set
+As IPU is not an external facing device which is not risky, so use
+IOMMU passthrough mode for Intel IPUs.
+
+Change-Id: I6dcccdadac308cf42e20a18e1b593381391e3e6b
+Depends-On: Iacd67578e8c6a9b9ac73285f52b4081b72fb68a6
+Tracked-On: #JIITL8-411
+Signed-off-by: Bingbu Cao <bingbu.cao@intel.com>
+Signed-off-by: zouxiaoh <xiaohong.zou@intel.com>
+Signed-off-by: Xu Chongyang <chongyang.xu@intel.com>
+Patchset: cameras
+---
+ drivers/iommu/intel/iommu.c | 30 ++++++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
+index 1400bf283..cca97e5b2 100644
+--- a/drivers/iommu/intel/iommu.c
++++ b/drivers/iommu/intel/iommu.c
+@@ -44,6 +44,13 @@
+ 		((pdev)->vendor == PCI_VENDOR_ID_INTEL && (pdev)->device == 0x34E4) \
+ 	)
+ 
++#define IS_INTEL_IPU(pdev) ((pdev)->vendor == PCI_VENDOR_ID_INTEL &&	\
++			   ((pdev)->device == 0x9a19 ||		\
++			    (pdev)->device == 0x9a39 ||		\
++			    (pdev)->device == 0x4e19 ||		\
++			    (pdev)->device == 0x465d ||		\
++			    (pdev)->device == 0x1919))
++
+ #define IOAPIC_RANGE_START	(0xfee00000)
+ #define IOAPIC_RANGE_END	(0xfeefffff)
+ #define IOVA_START_ADDR		(0x1000)
+@@ -208,12 +215,14 @@ int intel_iommu_enabled = 0;
+ EXPORT_SYMBOL_GPL(intel_iommu_enabled);
+ 
+ static int dmar_map_ipts = 1;
++static int dmar_map_ipu = 1;
+ static int intel_iommu_superpage = 1;
+ static int iommu_identity_mapping;
+ static int iommu_skip_te_disable;
+ static int disable_igfx_iommu;
+ 
+ #define IDENTMAP_AZALIA		4
++#define IDENTMAP_IPU		8
+ #define IDENTMAP_IPTS		16
+ 
+ const struct iommu_ops intel_iommu_ops;
+@@ -1406,6 +1415,9 @@ static int device_def_domain_type(struct device *dev)
+ 		if ((iommu_identity_mapping & IDENTMAP_AZALIA) && IS_AZALIA(pdev))
+ 			return IOMMU_DOMAIN_IDENTITY;
+ 
++		if ((iommu_identity_mapping & IDENTMAP_IPU) && IS_INTEL_IPU(pdev))
++			return IOMMU_DOMAIN_IDENTITY;
++
+ 		if ((iommu_identity_mapping & IDENTMAP_IPTS) && IS_IPTS(pdev))
+ 			return IOMMU_DOMAIN_IDENTITY;
+ 	}
+@@ -1698,6 +1710,9 @@ static int __init init_dmars(void)
+ 		iommu_set_root_entry(iommu);
+ 	}
+ 
++	if (!dmar_map_ipu)
++		iommu_identity_mapping |= IDENTMAP_IPU;
++
+ 	if (!dmar_map_ipts)
+ 		iommu_identity_mapping |= IDENTMAP_IPTS;
+ 
+@@ -3946,6 +3961,18 @@ static void quirk_iommu_igfx(struct pci_dev *dev)
+ 	disable_igfx_iommu = 1;
+ }
+ 
++static void quirk_iommu_ipu(struct pci_dev *dev)
++{
++	if (!IS_INTEL_IPU(dev))
++		return;
++
++	if (risky_device(dev))
++		return;
++
++	pci_info(dev, "Passthrough IOMMU for integrated Intel IPU\n");
++	dmar_map_ipu = 0;
++}
++
+ static void quirk_iommu_ipts(struct pci_dev *dev)
+ {
+ 	if (!IS_IPTS(dev))
+@@ -3996,6 +4023,9 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x1632, quirk_iommu_igfx);
+ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x163A, quirk_iommu_igfx);
+ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x163D, quirk_iommu_igfx);
+ 
++/* disable IPU dmar support */
++DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, PCI_ANY_ID, quirk_iommu_ipu);
++
+ /* disable IPTS dmar support */
+ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x9D3E, quirk_iommu_ipts);
+ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x34E4, quirk_iommu_ipts);
+-- 
+2.53.0
+
+From e161e5012e6858f2715f72668ea2fc0d7aeb89da Mon Sep 17 00:00:00 2001
+From: Daniel Scally <djrscally@gmail.com>
+Date: Sun, 10 Oct 2021 20:57:02 +0200
+Subject: [PATCH] platform/x86: int3472: Enable I2c daisy chain
+
+The TPS68470 PMIC has an I2C passthrough mode through which I2C traffic
+can be forwarded to a device connected to the PMIC as though it were
+connected directly to the system bus. Enable this mode when the chip
+is initialised.
+
+Signed-off-by: Daniel Scally <djrscally@gmail.com>
+Patchset: cameras
+---
+ drivers/platform/x86/intel/int3472/tps68470.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/drivers/platform/x86/intel/int3472/tps68470.c b/drivers/platform/x86/intel/int3472/tps68470.c
+index 013340569..9e0763bdc 100644
+--- a/drivers/platform/x86/intel/int3472/tps68470.c
++++ b/drivers/platform/x86/intel/int3472/tps68470.c
+@@ -46,6 +46,13 @@ static int tps68470_chip_init(struct device *dev, struct regmap *regmap)
+ 		return ret;
+ 	}
+ 
++	/* Enable I2C daisy chain */
++	ret = regmap_write(regmap, TPS68470_REG_S_I2C_CTL, 0x03);
++	if (ret) {
++		dev_err(dev, "Failed to enable i2c daisy chain\n");
++		return ret;
++	}
++
+ 	dev_info(dev, "TPS68470 REVID: 0x%02x\n", version);
+ 
+ 	return 0;
+-- 
+2.53.0
+
+From 9c649457de8b93596baaa80f4f8c00e3d9baba20 Mon Sep 17 00:00:00 2001
+From: Daniel Scally <dan.scally@ideasonboard.com>
+Date: Tue, 21 Mar 2023 13:45:26 +0000
+Subject: [PATCH] media: i2c: Clarify that gain is Analogue gain in OV7251
+
+Update the control ID for the gain control in the ov7251 driver to
+V4L2_CID_ANALOGUE_GAIN.
+
+Signed-off-by: Daniel Scally <dan.scally@ideasonboard.com>
+Patchset: cameras
+---
+ drivers/media/i2c/ov7251.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/i2c/ov7251.c b/drivers/media/i2c/ov7251.c
+index 27afc3fc0..28b192c9a 100644
+--- a/drivers/media/i2c/ov7251.c
++++ b/drivers/media/i2c/ov7251.c
+@@ -1053,7 +1053,7 @@ static int ov7251_s_ctrl(struct v4l2_ctrl *ctrl)
+ 	case V4L2_CID_EXPOSURE:
+ 		ret = ov7251_set_exposure(ov7251, ctrl->val);
+ 		break;
+-	case V4L2_CID_GAIN:
++	case V4L2_CID_ANALOGUE_GAIN:
+ 		ret = ov7251_set_gain(ov7251, ctrl->val);
+ 		break;
+ 	case V4L2_CID_TEST_PATTERN:
+@@ -1579,7 +1579,7 @@ static int ov7251_init_ctrls(struct ov7251 *ov7251)
+ 	ov7251->exposure = v4l2_ctrl_new_std(&ov7251->ctrls, &ov7251_ctrl_ops,
+ 					     V4L2_CID_EXPOSURE, 1, 32, 1, 32);
+ 	ov7251->gain = v4l2_ctrl_new_std(&ov7251->ctrls, &ov7251_ctrl_ops,
+-					 V4L2_CID_GAIN, 16, 1023, 1, 16);
++					 V4L2_CID_ANALOGUE_GAIN, 16, 1023, 1, 16);
+ 	v4l2_ctrl_new_std_menu_items(&ov7251->ctrls, &ov7251_ctrl_ops,
+ 				     V4L2_CID_TEST_PATTERN,
+ 				     ARRAY_SIZE(ov7251_test_pattern_menu) - 1,
+-- 
+2.53.0
+
+From a83903189bc92cdd72dd802072f2518bbad79ee3 Mon Sep 17 00:00:00 2001
+From: Daniel Scally <dan.scally@ideasonboard.com>
+Date: Wed, 22 Mar 2023 11:01:42 +0000
+Subject: [PATCH] media: v4l2-core: Acquire privacy led in
+ v4l2_async_register_subdev()
+
+The current call to v4l2_subdev_get_privacy_led() is contained in
+v4l2_async_register_subdev_sensor(), but that function isn't used by
+all the sensor drivers. Move the acquisition of the privacy led to
+v4l2_async_register_subdev() instead.
+
+Signed-off-by: Daniel Scally <dan.scally@ideasonboard.com>
+Patchset: cameras
+---
+ drivers/media/v4l2-core/v4l2-async.c  | 4 ++++
+ drivers/media/v4l2-core/v4l2-fwnode.c | 4 ----
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/media/v4l2-core/v4l2-async.c b/drivers/media/v4l2-core/v4l2-async.c
+index 1c08bba9e..57a990d7d 100644
+--- a/drivers/media/v4l2-core/v4l2-async.c
++++ b/drivers/media/v4l2-core/v4l2-async.c
+@@ -811,6 +811,10 @@ int __v4l2_async_register_subdev(struct v4l2_subdev *sd, struct module *module)
+ 
+ 	INIT_LIST_HEAD(&sd->asc_list);
+ 
++	ret = v4l2_subdev_get_privacy_led(sd);
++	if (ret < 0)
++		return ret;
++
+ 	/*
+ 	 * No reference taken. The reference is held by the device (struct
+ 	 * v4l2_subdev.dev), and async sub-device does not exist independently
+diff --git a/drivers/media/v4l2-core/v4l2-fwnode.c b/drivers/media/v4l2-core/v4l2-fwnode.c
+index cb153ce42..f11b499e1 100644
+--- a/drivers/media/v4l2-core/v4l2-fwnode.c
++++ b/drivers/media/v4l2-core/v4l2-fwnode.c
+@@ -1260,10 +1260,6 @@ int v4l2_async_register_subdev_sensor(struct v4l2_subdev *sd)
+ 
+ 	v4l2_async_subdev_nf_init(notifier, sd);
+ 
+-	ret = v4l2_subdev_get_privacy_led(sd);
+-	if (ret < 0)
+-		goto out_cleanup;
+-
+ 	ret = v4l2_async_nf_parse_fwnode_sensor(sd->dev, notifier);
+ 	if (ret < 0)
+ 		goto out_cleanup;
+-- 
+2.53.0
+
+From bd907090c2084997d86042ba1961a066e5f6cce8 Mon Sep 17 00:00:00 2001
+From: Kate Hsuan <hpa@redhat.com>
+Date: Tue, 21 Mar 2023 23:37:16 +0800
+Subject: [PATCH] platform: x86: int3472: Add MFD cell for tps68470 LED
+
+Add MFD cell for tps68470-led.
+
+Reviewed-by: Daniel Scally <dan.scally@ideasonboard.com>
+Signed-off-by: Kate Hsuan <hpa@redhat.com>
+Reviewed-by: Hans de Goede <hdegoede@redhat.com>
+Patchset: cameras
+---
+ drivers/platform/x86/intel/int3472/tps68470.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/int3472/tps68470.c b/drivers/platform/x86/intel/int3472/tps68470.c
+index 9e0763bdc..0976b2679 100644
+--- a/drivers/platform/x86/intel/int3472/tps68470.c
++++ b/drivers/platform/x86/intel/int3472/tps68470.c
+@@ -17,7 +17,7 @@
+ #define DESIGNED_FOR_CHROMEOS		1
+ #define DESIGNED_FOR_WINDOWS		2
+ 
+-#define TPS68470_WIN_MFD_CELL_COUNT	3
++#define TPS68470_WIN_MFD_CELL_COUNT	4
+ 
+ static const struct mfd_cell tps68470_cros[] = {
+ 	{ .name = "tps68470-gpio" },
+@@ -203,7 +203,8 @@ static int skl_int3472_tps68470_probe(struct i2c_client *client)
+ 		cells[1].name = "tps68470-regulator";
+ 		cells[1].platform_data = (void *)board_data->tps68470_regulator_pdata;
+ 		cells[1].pdata_size = sizeof(struct tps68470_regulator_platform_data);
+-		cells[2].name = "tps68470-gpio";
++		cells[2].name = "tps68470-led";
++		cells[3].name = "tps68470-gpio";
+ 
+ 		for (i = 0; i < board_data->n_gpiod_lookups; i++)
+ 			gpiod_add_lookup_table(board_data->tps68470_gpio_lookup_tables[i]);
+-- 
+2.53.0
+
+From b4551d25d8d3b88500baa0b2d0cd3e5b60438daf Mon Sep 17 00:00:00 2001
+From: Kate Hsuan <hpa@redhat.com>
+Date: Tue, 21 Mar 2023 23:37:17 +0800
+Subject: [PATCH] include: mfd: tps68470: Add masks for LEDA and LEDB
+
+Add flags for both LEDA(TPS68470_ILEDCTL_ENA), LEDB
+(TPS68470_ILEDCTL_ENB), and current control mask for LEDB
+(TPS68470_ILEDCTL_CTRLB)
+
+Reviewed-by: Daniel Scally <dan.scally@ideasonboard.com>
+Reviewed-by: Hans de Goede <hdegoede@redhat.com>
+Signed-off-by: Kate Hsuan <hpa@redhat.com>
+Patchset: cameras
+---
+ include/linux/mfd/tps68470.h | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/include/linux/mfd/tps68470.h b/include/linux/mfd/tps68470.h
+index 7807fa329..2d2abb25b 100644
+--- a/include/linux/mfd/tps68470.h
++++ b/include/linux/mfd/tps68470.h
+@@ -34,6 +34,7 @@
+ #define TPS68470_REG_SGPO		0x22
+ #define TPS68470_REG_GPDI		0x26
+ #define TPS68470_REG_GPDO		0x27
++#define TPS68470_REG_ILEDCTL		0x28
+ #define TPS68470_REG_VCMVAL		0x3C
+ #define TPS68470_REG_VAUX1VAL		0x3D
+ #define TPS68470_REG_VAUX2VAL		0x3E
+@@ -94,4 +95,8 @@
+ #define TPS68470_GPIO_MODE_OUT_CMOS	2
+ #define TPS68470_GPIO_MODE_OUT_ODRAIN	3
+ 
++#define TPS68470_ILEDCTL_ENA		BIT(2)
++#define TPS68470_ILEDCTL_ENB		BIT(6)
++#define TPS68470_ILEDCTL_CTRLB		GENMASK(5, 4)
++
+ #endif /* __LINUX_MFD_TPS68470_H */
+-- 
+2.53.0
+
+From 3a215fa6681957570a03d2fa2a936c4400a0248c Mon Sep 17 00:00:00 2001
+From: Kate Hsuan <hpa@redhat.com>
+Date: Tue, 21 Mar 2023 23:37:18 +0800
+Subject: [PATCH] leds: tps68470: Add LED control for tps68470
+
+There are two LED controllers, LEDA indicator LED and LEDB flash LED for
+tps68470. LEDA can be enabled by setting TPS68470_ILEDCTL_ENA. Moreover,
+tps68470 provides four levels of power status for LEDB. If the
+properties called "ti,ledb-current" can be found, the current will be
+set according to the property values. These two LEDs can be controlled
+through the LED class of sysfs (tps68470-leda and tps68470-ledb).
+
+Signed-off-by: Kate Hsuan <hpa@redhat.com>
+Reviewed-by: Hans de Goede <hdegoede@redhat.com>
+Patchset: cameras
+---
+ drivers/leds/Kconfig         |  12 +++
+ drivers/leds/Makefile        |   1 +
+ drivers/leds/leds-tps68470.c | 185 +++++++++++++++++++++++++++++++++++
+ 3 files changed, 198 insertions(+)
+ create mode 100644 drivers/leds/leds-tps68470.c
+
+diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
+index 11e7282dc..c5665bd5e 100644
+--- a/drivers/leds/Kconfig
++++ b/drivers/leds/Kconfig
+@@ -998,6 +998,18 @@ config LEDS_TPS6105X
+ 	  It is a single boost converter primarily for white LEDs and
+ 	  audio amplifiers.
+ 
++config LEDS_TPS68470
++	tristate "LED support for TI TPS68470"
++	depends on LEDS_CLASS
++	depends on INTEL_SKL_INT3472
++	help
++	  This driver supports TPS68470 PMIC with LED chip.
++	  It provides two LED controllers, with the ability to drive 2
++	  indicator LEDs and 2 flash LEDs.
++
++	  To compile this driver as a module, choose M and it will be
++	  called leds-tps68470
++
+ config LEDS_IP30
+ 	tristate "LED support for SGI Octane machines"
+ 	depends on LEDS_CLASS
+diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
+index 9a0333ec1..4e1ca8fc9 100644
+--- a/drivers/leds/Makefile
++++ b/drivers/leds/Makefile
+@@ -93,6 +93,7 @@ obj-$(CONFIG_LEDS_TCA6507)		+= leds-tca6507.o
+ obj-$(CONFIG_LEDS_TI_LMU_COMMON)	+= leds-ti-lmu-common.o
+ obj-$(CONFIG_LEDS_TLC591XX)		+= leds-tlc591xx.o
+ obj-$(CONFIG_LEDS_TPS6105X)		+= leds-tps6105x.o
++obj-$(CONFIG_LEDS_TPS68470)		+= leds-tps68470.o
+ obj-$(CONFIG_LEDS_TURRIS_OMNIA)		+= leds-turris-omnia.o
+ obj-$(CONFIG_LEDS_UPBOARD)		+= leds-upboard.o
+ obj-$(CONFIG_LEDS_WM831X_STATUS)	+= leds-wm831x-status.o
+diff --git a/drivers/leds/leds-tps68470.c b/drivers/leds/leds-tps68470.c
+new file mode 100644
+index 000000000..35aeb5db8
+--- /dev/null
++++ b/drivers/leds/leds-tps68470.c
+@@ -0,0 +1,185 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * LED driver for TPS68470 PMIC
++ *
++ * Copyright (C) 2023 Red Hat
++ *
++ * Authors:
++ *	Kate Hsuan <hpa@redhat.com>
++ */
++
++#include <linux/leds.h>
++#include <linux/mfd/tps68470.h>
++#include <linux/module.h>
++#include <linux/platform_device.h>
++#include <linux/property.h>
++#include <linux/regmap.h>
++
++
++#define lcdev_to_led(led_cdev) \
++	container_of(led_cdev, struct tps68470_led, lcdev)
++
++#define led_to_tps68470(led, index) \
++	container_of(led, struct tps68470_device, leds[index])
++
++enum tps68470_led_ids {
++	TPS68470_ILED_A,
++	TPS68470_ILED_B,
++	TPS68470_NUM_LEDS
++};
++
++static const char *tps68470_led_names[] = {
++	[TPS68470_ILED_A] = "tps68470-iled_a",
++	[TPS68470_ILED_B] = "tps68470-iled_b",
++};
++
++struct tps68470_led {
++	unsigned int led_id;
++	struct led_classdev lcdev;
++};
++
++struct tps68470_device {
++	struct device *dev;
++	struct regmap *regmap;
++	struct tps68470_led leds[TPS68470_NUM_LEDS];
++};
++
++enum ctrlb_current {
++	CTRLB_2MA	= 0,
++	CTRLB_4MA	= 1,
++	CTRLB_8MA	= 2,
++	CTRLB_16MA	= 3,
++};
++
++static int tps68470_brightness_set(struct led_classdev *led_cdev, enum led_brightness brightness)
++{
++	struct tps68470_led *led = lcdev_to_led(led_cdev);
++	struct tps68470_device *tps68470 = led_to_tps68470(led, led->led_id);
++	struct regmap *regmap = tps68470->regmap;
++
++	switch (led->led_id) {
++	case TPS68470_ILED_A:
++		return regmap_update_bits(regmap, TPS68470_REG_ILEDCTL, TPS68470_ILEDCTL_ENA,
++					  brightness ? TPS68470_ILEDCTL_ENA : 0);
++	case TPS68470_ILED_B:
++		return regmap_update_bits(regmap, TPS68470_REG_ILEDCTL, TPS68470_ILEDCTL_ENB,
++					  brightness ? TPS68470_ILEDCTL_ENB : 0);
++	}
++	return -EINVAL;
++}
++
++static enum led_brightness tps68470_brightness_get(struct led_classdev *led_cdev)
++{
++	struct tps68470_led *led = lcdev_to_led(led_cdev);
++	struct tps68470_device *tps68470 = led_to_tps68470(led, led->led_id);
++	struct regmap *regmap = tps68470->regmap;
++	int ret = 0;
++	int value = 0;
++
++	ret =  regmap_read(regmap, TPS68470_REG_ILEDCTL, &value);
++	if (ret)
++		return dev_err_probe(led_cdev->dev, -EINVAL, "failed on reading register\n");
++
++	switch (led->led_id) {
++	case TPS68470_ILED_A:
++		value = value & TPS68470_ILEDCTL_ENA;
++		break;
++	case TPS68470_ILED_B:
++		value = value & TPS68470_ILEDCTL_ENB;
++		break;
++	}
++
++	return value ? LED_ON : LED_OFF;
++}
++
++
++static int tps68470_ledb_current_init(struct platform_device *pdev,
++				      struct tps68470_device *tps68470)
++{
++	int ret = 0;
++	unsigned int curr;
++
++	/* configure LEDB current if the properties can be got */
++	if (!device_property_read_u32(&pdev->dev, "ti,ledb-current", &curr)) {
++		if (curr > CTRLB_16MA) {
++			dev_err(&pdev->dev,
++				"Invalid LEDB current value: %d\n",
++				curr);
++			return -EINVAL;
++		}
++		ret = regmap_update_bits(tps68470->regmap, TPS68470_REG_ILEDCTL,
++					 TPS68470_ILEDCTL_CTRLB, curr);
++	}
++	return ret;
++}
++
++static int tps68470_leds_probe(struct platform_device *pdev)
++{
++	int i = 0;
++	int ret = 0;
++	struct tps68470_device *tps68470;
++	struct tps68470_led *led;
++	struct led_classdev *lcdev;
++
++	tps68470 = devm_kzalloc(&pdev->dev, sizeof(struct tps68470_device),
++				GFP_KERNEL);
++	if (!tps68470)
++		return -ENOMEM;
++
++	tps68470->dev = &pdev->dev;
++	tps68470->regmap = dev_get_drvdata(pdev->dev.parent);
++
++	for (i = 0; i < TPS68470_NUM_LEDS; i++) {
++		led = &tps68470->leds[i];
++		lcdev = &led->lcdev;
++
++		led->led_id = i;
++
++		lcdev->name = devm_kasprintf(tps68470->dev, GFP_KERNEL, "%s::%s",
++					     tps68470_led_names[i], LED_FUNCTION_INDICATOR);
++		if (!lcdev->name)
++			return -ENOMEM;
++
++		lcdev->max_brightness = 1;
++		lcdev->brightness = 0;
++		lcdev->brightness_set_blocking = tps68470_brightness_set;
++		lcdev->brightness_get = tps68470_brightness_get;
++		lcdev->dev = &pdev->dev;
++
++		ret = devm_led_classdev_register(tps68470->dev, lcdev);
++		if (ret) {
++			dev_err_probe(tps68470->dev, ret,
++				      "error registering led\n");
++			goto err_exit;
++		}
++
++		if (i == TPS68470_ILED_B) {
++			ret = tps68470_ledb_current_init(pdev, tps68470);
++			if (ret)
++				goto err_exit;
++		}
++	}
++
++err_exit:
++	if (ret) {
++		for (i = 0; i < TPS68470_NUM_LEDS; i++) {
++			if (tps68470->leds[i].lcdev.name)
++				devm_led_classdev_unregister(&pdev->dev,
++							     &tps68470->leds[i].lcdev);
++		}
++	}
++
++	return ret;
++}
++static struct platform_driver tps68470_led_driver = {
++	.driver = {
++		   .name = "tps68470-led",
++	},
++	.probe = tps68470_leds_probe,
++};
++
++module_platform_driver(tps68470_led_driver);
++
++MODULE_ALIAS("platform:tps68470-led");
++MODULE_DESCRIPTION("LED driver for TPS68470 PMIC");
++MODULE_LICENSE("GPL v2");
+-- 
+2.53.0
+
+From b581a619711c71600e9f083e3f8d3a36092cb11f Mon Sep 17 00:00:00 2001
+From: mojyack <mojyack@gmail.com>
+Date: Tue, 26 Mar 2024 05:55:44 +0900
+Subject: [PATCH] media: i2c: dw9719: fix probe error on surface go 2
+
+On surface go 2, sometimes probing dw9719 fails with "dw9719: probe of i2c-INT347A:00-VCM failed with error -121".
+The -121(-EREMOTEIO) is came from drivers/i2c/busses/i2c-designware-common.c:575, and indicates the initialize occurs too early.
+So just add some delay.
+There is no exact reason for this 10000us, but 100us failed.
+
+Patchset: cameras
+---
+ drivers/media/i2c/dw9719.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/media/i2c/dw9719.c b/drivers/media/i2c/dw9719.c
+index 595583359..b89765521 100644
+--- a/drivers/media/i2c/dw9719.c
++++ b/drivers/media/i2c/dw9719.c
+@@ -121,6 +121,9 @@ static int dw9719_power_up(struct dw9719_device *dw9719, bool detect)
+ 	if (ret)
+ 		return ret;
+ 
++	/* Wait for device to be acknowledged */
++	fsleep(10000);
++
+ 	/*
+ 	 * Need 100us to transition from SHUTDOWN to STANDBY.
+ 	 * Jiggle the SCL pin to wake up the device (even when the regulator is
+-- 
+2.53.0
+
+From b1dc230fffb35a88809f6c7877416887c1fb3d20 Mon Sep 17 00:00:00 2001
+From: Tooraj Taraz <tooraj.taraz@yahoo.com>
+Date: Wed, 31 Dec 2025 00:35:50 +0100
+Subject: [PATCH] Add camera support for Surface Pro 9
+
+Experimental camera support for the Surface Pro 9.
+
+Link: https://github.com/linux-surface/linux-surface/pull/1867
+Patchset: cameras
+---
+ drivers/media/i2c/ov13858.c                   | 158 +++++++++++++++++-
+ drivers/media/i2c/ov5693.c                    |   1 +
+ drivers/media/pci/intel/ipu-bridge.c          |   4 +
+ drivers/platform/x86/intel/int3472/discrete.c |  23 +++
+ 4 files changed, 184 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/i2c/ov13858.c b/drivers/media/i2c/ov13858.c
+index 162b49046..85cd0c98a 100644
+--- a/drivers/media/i2c/ov13858.c
++++ b/drivers/media/i2c/ov13858.c
+@@ -2,6 +2,7 @@
+ // Copyright (c) 2017 Intel Corporation.
+ 
+ #include <linux/acpi.h>
++#include <linux/delay.h>
+ #include <linux/clk.h>
+ #include <linux/i2c.h>
+ #include <linux/module.h>
+@@ -119,6 +120,14 @@ struct ov13858_mode {
+ 	struct ov13858_reg_list reg_list;
+ };
+ 
++// Or use standard names that might be more correct:
++static const char * const ov13858_supply_names[] = {
++	"avdd",    // Analog voltage
++	"pwr1",    // Digital core voltage
++};
++
++#define OV13858_NUM_SUPPLIES ARRAY_SIZE(ov13858_supply_names)
++
+ /* 4224x3136 needs 1080Mbps/lane, 4 lanes */
+ static const struct ov13858_reg mipi_data_rate_1080mbps[] = {
+ 	/* PLL1 registers */
+@@ -1046,12 +1055,126 @@ struct ov13858 {
+ 	/* Current mode */
+ 	const struct ov13858_mode *cur_mode;
+ 
++	struct regulator_bulk_data supplies[OV13858_NUM_SUPPLIES];
++	struct gpio_desc *reset;
++	struct clk *xvclk;
++
+ 	/* Mutex for serialized access */
+ 	struct mutex mutex;
+ };
+ 
+ #define to_ov13858(_sd)	container_of(_sd, struct ov13858, sd)
+ 
++
++static int ov13858_get_regulators(struct ov13858 *ov13858)
++{
++	unsigned int i;
++
++	for (i = 0; i < OV13858_NUM_SUPPLIES; i++)
++		ov13858->supplies[i].supply = ov13858_supply_names[i];
++
++	return devm_regulator_bulk_get(ov13858->dev, OV13858_NUM_SUPPLIES,
++				       ov13858->supplies);
++}
++
++static int ov13858_sensor_powerup(struct ov13858 *ov13858)
++{
++	int ret;
++
++	dev_info(ov13858->dev, "Powering up sensor\n");
++
++	/* Assert reset */
++	gpiod_set_value_cansleep(ov13858->reset, 1);
++
++	/* Enable clock FIRST - sensor needs clock to communicate */
++	ret = clk_prepare_enable(ov13858->xvclk);
++	if (ret) {
++		dev_err(ov13858->dev, "Failed to enable clock: %d\n", ret);
++		return ret;
++	}
++	dev_info(ov13858->dev, "Clock enabled\n");
++
++	/* Enable regulators */
++	ret = regulator_bulk_enable(OV13858_NUM_SUPPLIES, ov13858->supplies);
++	if (ret) {
++		dev_err(ov13858->dev, "Failed to enable regulators: %d\n", ret);
++		clk_disable_unprepare(ov13858->xvclk);
++		return ret;
++	}
++
++	dev_info(ov13858->dev, "Regulators enabled\n");
++
++	/* Wait for power to stabilize */
++	usleep_range(5000, 10000);
++
++	/* De-assert reset */
++	gpiod_set_value_cansleep(ov13858->reset, 0);
++
++	/* Wait for sensor to boot */
++	msleep(20);
++
++	dev_info(ov13858->dev, "Reset de-asserted, sensor should be ready\n");
++
++	return 0;
++}
++
++static void ov13858_sensor_powerdown(struct ov13858 *ov13858)
++{
++	dev_info(ov13858->dev, "Powering down sensor\n");
++
++	/* Assert reset to put sensor in reset state */
++	gpiod_set_value_cansleep(ov13858->reset, 1);
++
++	/* Disable regulators */
++	regulator_bulk_disable(OV13858_NUM_SUPPLIES, ov13858->supplies);
++	dev_info(ov13858->dev, "Regulators disabled\n");
++
++	/* Disable clock */
++	clk_disable_unprepare(ov13858->xvclk);
++	dev_info(ov13858->dev, "Clock disabled\n");
++}
++
++static int __maybe_unused ov13858_suspend(struct device *dev)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct v4l2_subdev *sd = i2c_get_clientdata(client);
++	struct ov13858 *ov13858 = to_ov13858(sd);
++
++	ov13858_sensor_powerdown(ov13858);
++
++	return 0;
++}
++
++static int __maybe_unused ov13858_resume(struct device *dev)
++{
++	struct i2c_client *client = to_i2c_client(dev);
++	struct v4l2_subdev *sd = i2c_get_clientdata(client);
++	struct ov13858 *ov13858 = to_ov13858(sd);
++	int ret;
++
++	ret = ov13858_sensor_powerup(ov13858);
++	if (ret)
++		return ret;
++
++	return 0;
++}
++
++static const struct dev_pm_ops ov13858_pm_ops = {
++	SET_RUNTIME_PM_OPS(ov13858_suspend, ov13858_resume, NULL)
++};
++
++static int ov13858_get_gpios(struct ov13858 *ov13858)
++{
++	ov13858->reset = devm_gpiod_get_optional(ov13858->dev, "reset",
++	                                         GPIOD_OUT_HIGH);
++	if (IS_ERR(ov13858->reset)) {
++		dev_err(ov13858->dev, "Error fetching reset GPIO\n");
++		return PTR_ERR(ov13858->reset);
++	}
++
++	return 0;
++}
++
+ /* Read registers up to 4 at a time */
+ static int ov13858_read_reg(struct ov13858 *ov13858, u16 reg, u32 len,
+ 			    u32 *val)
+@@ -1498,8 +1621,11 @@ static int ov13858_identify_module(struct ov13858 *ov13858)
+ 	int ret;
+ 	u32 val;
+ 
++	dev_info(ov13858->dev, "Attempting to read chip ID from register 0x300a\n");
+ 	ret = ov13858_read_reg(ov13858, OV13858_REG_CHIP_ID,
+ 			       OV13858_REG_VALUE_24BIT, &val);
++	dev_info(ov13858->dev, "Chip ID read result: ret=%d, val=0x%06x (expected 0x%06x)\n",
++	         ret, val, OV13858_CHIP_ID);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -1509,6 +1635,7 @@ static int ov13858_identify_module(struct ov13858 *ov13858)
+ 		return -EIO;
+ 	}
+ 
++	dev_info(ov13858->dev, "Chip ID verified successfully!\n");
+ 	return 0;
+ }
+ 
+@@ -1678,14 +1805,33 @@ static int ov13858_probe(struct i2c_client *client)
+ 				     "external clock %lu is not supported\n",
+ 				     freq);
+ 
++	/* Get the external clock */
++	ov13858->xvclk = devm_clk_get_optional(ov13858->dev, "xvclk");
++	if (IS_ERR(ov13858->xvclk))
++		return dev_err_probe(ov13858->dev, PTR_ERR(ov13858->xvclk),
++		       "failed to get xvclk\n");
++
+ 	/* Initialize subdev */
+ 	v4l2_i2c_subdev_init(&ov13858->sd, client, &ov13858_subdev_ops);
+ 
++	ret = ov13858_get_regulators(ov13858);
++	if (ret)
++		return dev_err_probe(ov13858->dev, ret,
++		       "Error fetching regulators\n");
++
++	ret = ov13858_get_gpios(ov13858);
++	if (ret)
++		return ret;
++
++	ret = ov13858_sensor_powerup(ov13858);
++	if (ret)
++		return ret;  // No cleanup needed yet, devm handles GPIOs/regulators
++
+ 	/* Check module identity */
+ 	ret = ov13858_identify_module(ov13858);
+ 	if (ret) {
+ 		dev_err(ov13858->dev, "failed to find sensor: %d\n", ret);
+-		return ret;
++		goto error_power_off;  // Now we need to power down
+ 	}
+ 
+ 	/* Set default mode to max resolution */
+@@ -1693,7 +1839,7 @@ static int ov13858_probe(struct i2c_client *client)
+ 
+ 	ret = ov13858_init_controls(ov13858);
+ 	if (ret)
+-		return ret;
++		goto error_power_off;
+ 
+ 	/* Initialize subdev */
+ 	ov13858->sd.internal_ops = &ov13858_internal_ops;
+@@ -1729,6 +1875,10 @@ static int ov13858_probe(struct i2c_client *client)
+ 
+ error_handler_free:
+ 	ov13858_free_controls(ov13858);
++
++error_power_off:
++	ov13858_sensor_powerdown(ov13858);
++
+ 	dev_err(ov13858->dev, "%s failed:%d\n", __func__, ret);
+ 
+ 	return ret;
+@@ -1744,6 +1894,9 @@ static void ov13858_remove(struct i2c_client *client)
+ 	ov13858_free_controls(ov13858);
+ 
+ 	pm_runtime_disable(ov13858->dev);
++	if (!pm_runtime_status_suspended(ov13858->dev))
++		ov13858_sensor_powerdown(ov13858);
++	pm_runtime_set_suspended(ov13858->dev);
+ }
+ 
+ static const struct i2c_device_id ov13858_id_table[] = {
+@@ -1765,6 +1918,7 @@ MODULE_DEVICE_TABLE(acpi, ov13858_acpi_ids);
+ static struct i2c_driver ov13858_i2c_driver = {
+ 	.driver = {
+ 		.name = "ov13858",
++		.pm = &ov13858_pm_ops,
+ 		.acpi_match_table = ACPI_PTR(ov13858_acpi_ids),
+ 	},
+ 	.probe = ov13858_probe,
+diff --git a/drivers/media/i2c/ov5693.c b/drivers/media/i2c/ov5693.c
+index 4cc796bbe..02236f3db 100644
+--- a/drivers/media/i2c/ov5693.c
++++ b/drivers/media/i2c/ov5693.c
+@@ -1396,6 +1396,7 @@ static const struct dev_pm_ops ov5693_pm_ops = {
+ 
+ static const struct acpi_device_id ov5693_acpi_match[] = {
+ 	{"INT33BE"},
++	{"OVTI5693"},
+ 	{},
+ };
+ MODULE_DEVICE_TABLE(acpi, ov5693_acpi_match);
+diff --git a/drivers/media/pci/intel/ipu-bridge.c b/drivers/media/pci/intel/ipu-bridge.c
+index b2b710094..f5456330b 100644
+--- a/drivers/media/pci/intel/ipu-bridge.c
++++ b/drivers/media/pci/intel/ipu-bridge.c
+@@ -61,6 +61,10 @@ static const struct ipu_sensor_config ipu_supported_sensors[] = {
+ 	IPU_SENSOR_CONFIG("INT33BE", 1, 419200000),
+ 	/* Onsemi MT9M114 */
+ 	IPU_SENSOR_CONFIG("INT33F0", 1, 384000000),
++	/* Omnivision OV5693 - Surface Pro 9 */
++	IPU_SENSOR_CONFIG("OVTI5693", 1, 419200000),
++	/* Omnivision OV13858 - Surface Pro 9 */
++	IPU_SENSOR_CONFIG("OVTID858", 4, 540000000),
+ 	/* Omnivision OV2740 */
+ 	IPU_SENSOR_CONFIG("INT3474", 1, 180000000),
+ 	/* Omnivision OV5670 */
+diff --git a/drivers/platform/x86/intel/int3472/discrete.c b/drivers/platform/x86/intel/int3472/discrete.c
+index 1505fc3ef..20962e8ac 100644
+--- a/drivers/platform/x86/intel/int3472/discrete.c
++++ b/drivers/platform/x86/intel/int3472/discrete.c
+@@ -229,6 +229,14 @@ static void int3472_get_con_id_and_polarity(struct int3472_discrete_device *int3
+ 		/* Setups using a handshake pin need 25 ms enable delay */
+ 		*enable_time_us = 25 * USEC_PER_MSEC;
+ 		break;
++	case 0x08:  /* Surface Pro 9 - additional power rail */
++		*con_id = "pwr1";
++		*gpio_flags = GPIO_ACTIVE_HIGH;
++		break;
++	case 0x10:  /* Surface Pro 9 - secondary power rail */
++		*con_id = "pwr2";
++		*gpio_flags = GPIO_ACTIVE_HIGH;
++		break;
+ 	default:
+ 		*con_id = "unknown";
+ 		*gpio_flags = GPIO_ACTIVE_HIGH;
+@@ -333,6 +341,8 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
+ 	case INT3472_GPIO_TYPE_PRIVACY_LED:
+ 	case INT3472_GPIO_TYPE_POWER_ENABLE:
+ 	case INT3472_GPIO_TYPE_HANDSHAKE:
++	case 0x08:  /* Surface Pro 9 power rails */
++	case 0x10:
+ 		gpio = skl_int3472_gpiod_get_from_temp_lookup(int3472, agpio, con_id, gpio_flags);
+ 		if (IS_ERR(gpio)) {
+ 			ret = PTR_ERR(gpio);
+@@ -363,6 +373,19 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
+ 				err_msg = "Failed to register regulator\n";
+ 
+ 			break;
++		case 0x08:  /* Surface Pro 9 - treat as power*/
++		    dev_info(int3472->dev, "GPIO type 0x%02x detected on pin 0x%02x\n", type, agpio->pin_table[0]);
++		    dev_info(int3472->dev, "  con_id=%s, flags=0x%x\n", con_id, gpio_flags);
++		    ret = skl_int3472_register_regulator(int3472, gpio,
++			 GPIO_REGULATOR_ENABLE_TIME,
++			 con_id, NULL);
++		    dev_info(int3472->dev, "  register_regulator returned: %d\n", ret);
++		    if (ret) {
++			dev_err(int3472->dev, "Failed to register type 0x02x: %d\n", type, ret);
++		    }
++		    break;
++		case 0x10:
++		    break;
+ 		default: /* Never reached */
+ 			ret = -EINVAL;
+ 			break;
+-- 
+2.53.0
+
+From f51a44f59234d641cd068c4c1ba7c643dfe4c0ef Mon Sep 17 00:00:00 2001
+From: gabrielstedman <gabrielstedman@users.noreply.github.com>
+Date: Fri, 13 Mar 2026 08:52:07 +0000
+Subject: [PATCH] media: ipu-bridge: Add front camera rotation quirks for
+ Surface Pro 8 and 9
+
+On the Surface Pro 8 and 9, camera rotation in `ssdb.degree` is `0` (no
+rotation) but should be `180`. Add these devices to the respective quirk
+list.
+
+Link: https://github.com/linux-surface/kernel/pull/160
+Patchset: cameras
+---
+ drivers/media/pci/intel/ipu-bridge.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/drivers/media/pci/intel/ipu-bridge.c b/drivers/media/pci/intel/ipu-bridge.c
+index f5456330b..3418ff475 100644
+--- a/drivers/media/pci/intel/ipu-bridge.c
++++ b/drivers/media/pci/intel/ipu-bridge.c
+@@ -122,6 +122,20 @@ static const struct dmi_system_id upside_down_sensor_dmi_ids[] = {
+ 		},
+ 		.driver_data = "OVTI02C1",
+ 	},
++	{
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "Surface Pro 8"),
++		},
++		.driver_data = "INT33BE",
++	},
++	{
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "Surface Pro 9"),
++		},
++		.driver_data = "OVTI5693",
++	},
+ 	{} /* Terminating entry */
+ };
+ 
+-- 
+2.53.0
+
+From 96812b7d52c84c3e4d3d710d4faa6669dc28c609 Mon Sep 17 00:00:00 2001
+From: "D.J. Mulder" <djmulder@example.com>
+Date: Fri, 29 May 2026 15:28:15 +0200
+Subject: [PATCH 1/5] media: i2c: Add Sony IMX681 sensor driver for Surface Pro
+ 10/11
+
+Add V4L2 sensor driver for the Sony IMX681 CMOS image sensor, used as
+the front camera on Microsoft Surface Pro 10 (Meteor Lake) and Surface
+Pro 11 (Lunar Lake).
+
+The driver supports both platforms with platform-specific PLL register
+sequences selected at stream-on time based on the negotiated link
+frequency:
+- Surface Pro 10 (MTL): 380.8 MHz, C-PHY, 2-lane CSI-2
+- Surface Pro 11 (LNL): 969.6 MHz, D-PHY, 2-lane CSI-2
+
+Register sequences reverse-engineered from Windows I2C traces.
+Uses H-flip (reg 0x0101=0x01) to convert native RGGB Bayer to GRBG
+matching the Windows AIQB calibration data.
+
+Patchset: cameras
+---
+ drivers/media/i2c/imx681.c | 924 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 924 insertions(+)
+ create mode 100644 drivers/media/i2c/imx681.c
+
+diff --git a/drivers/media/i2c/imx681.c b/drivers/media/i2c/imx681.c
+new file mode 100644
+index 0000000..f559d53
+--- /dev/null
++++ b/drivers/media/i2c/imx681.c
+@@ -0,0 +1,924 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Sony IMX681 CMOS Image Sensor Driver
++ *
++ * Front camera on Surface Pro 10 (Intel/Meteor Lake) and Surface Pro 11 (Intel/Lunar Lake).
++ * Register sequences reverse-engineered from Windows I2C traces.
++ *
++ * Copyright (C) 2025
++ */
++
++#include <linux/clk.h>
++#include <linux/delay.h>
++#include <linux/gpio/consumer.h>
++#include <linux/i2c.h>
++#include <linux/module.h>
++#include <linux/pm_runtime.h>
++#include <linux/property.h>
++#include <linux/regulator/consumer.h>
++
++#include <media/v4l2-cci.h>
++#include <media/v4l2-ctrls.h>
++#include <media/v4l2-device.h>
++#include <media/v4l2-fwnode.h>
++
++/* Chip ID register and expected value */
++#define IMX681_REG_CHIP_ID		CCI_REG16(0x0016)
++#define IMX681_CHIP_ID			0x0681
++
++/* Mode select */
++#define IMX681_REG_MODE_SELECT		CCI_REG8(0x0100)
++#define IMX681_MODE_STANDBY		0x00
++#define IMX681_MODE_STREAMING		0x01
++
++/* Group parameter hold */
++#define IMX681_REG_GROUP_HOLD		CCI_REG8(0x0104)
++
++/* Exposure (coarse integration time, 24-bit) */
++#define IMX681_REG_EXPOSURE		CCI_REG24(0x0229)
++#define IMX681_EXPOSURE_MIN		4
++#define IMX681_EXPOSURE_MAX		3173	/* frame_length - 4 */
++#define IMX681_EXPOSURE_OFFSET		4	/* frame_length - exposure_max */
++#define IMX681_EXPOSURE_DEFAULT		1907	/* from Windows trace */
++
++/* Analog gain */
++#define IMX681_REG_ANALOG_GAIN		CCI_REG16(0x0204)
++#define IMX681_ANA_GAIN_MIN		0
++#define IMX681_ANA_GAIN_MAX		1020	/* combined analog+digital */
++#define IMX681_ANA_GAIN_DEFAULT		0
++
++/* Digital gain */
++#define IMX681_REG_DIGITAL_GAIN		CCI_REG16(0x020E)
++#define IMX681_DIG_GAIN_MIN		0x0100	/* 1.0x */
++#define IMX681_DIG_GAIN_MAX		0x0FFF
++#define IMX681_DIG_GAIN_DEFAULT		0x0100
++
++/* Test pattern */
++#define IMX681_REG_TEST_PATTERN		CCI_REG16(0x0600)
++
++/* Frame length (24-bit, for streaming updates) */
++#define IMX681_REG_FRAME_LENGTH		CCI_REG24(0x033D)
++
++/* Image dimensions — native sensor output */
++#define IMX681_WIDTH			3844
++#define IMX681_HEIGHT			2640
++#define IMX681_LINE_LENGTH_PCK		7552	/* 0x1D80 */
++#define IMX681_FRAME_LENGTH_LINES	3177	/* 0x0C69 */
++#define IMX681_FRAME_LENGTH_MAX		0xFFFF	/* 24-bit reg, limit to 16-bit */
++
++/* MIPI lanes */
++#define IMX681_NUM_LANES		2
++
++#define IMX681_LINK_FREQ_MTL    380800000LL  /* Meteor Lake (SP10), C-PHY */
++#define IMX681_LINK_FREQ_LNL    969600000LL  /* Lunar Lake (SP11), D-PHY */
++
++/* Pixel rate = link_freq * 2 (DDR) * num_lanes / bpp */
++#define IMX681_PIXEL_RATE_MTL	(IMX681_LINK_FREQ_MTL * 2 * IMX681_NUM_LANES / 10)
++#define IMX681_PIXEL_RATE_LNL	(IMX681_LINK_FREQ_LNL * 2 * IMX681_NUM_LANES / 10)
++
++/* Power-on delay after reset deassert */
++#define IMX681_RESET_DELAY_US		1000
++#define IMX681_RESET_DELAY_RANGE_US	1000
++
++/* Post-standby-cancel stabilisation delays */
++#define IMX681_INIT_DELAY_US		10000
++
++#define IMAGE_PAD			0
++
++static const s64 imx681_link_frequencies[] = {
++	IMX681_LINK_FREQ_MTL,
++	IMX681_LINK_FREQ_LNL,
++};
++
++/*
++ * Sensor init register sequence, captured from Windows I2C traces.
++ * This configures the sensor for 3844x2640 RAW10 output at ~30fps
++ * with 2-lane MIPI CSI-2, 19.2MHz input clock.
++ */
++static const struct cci_reg_sequence imx681_init_regs[] = {
++	/* Software standby */
++	{ CCI_REG8(0x0100),  0x00 },
++	/* External clock frequency = 19.2 MHz (encoded as MHz * 256) */
++	{ CCI_REG16(0x0136), 0x1333 },
++	/* Vendor specific configuration */
++	{ CCI_REG16(0x002C), 0x0505 },
++	/* CSI-2 signaling mode */
++	{ CCI_REG8(0x0111),  0x02 },
++	/* Image orientation: H-flip to match Windows AIQB (RGGB native → GRBG) */
++	{ CCI_REG8(0x0101),  0x01 },
++	/* Vendor access unlock sequence */
++	{ CCI_REG8(0x30EB),  0x05 },
++	{ CCI_REG8(0x30EB),  0x0C },
++	/* Vendor specific */
++	{ CCI_REG16(0x300A), 0xFFFF },
++	{ CCI_REG16(0x3532), 0xFFFF },
++	/* LINE_LENGTH_PCK = 7552 */
++	{ CCI_REG16(0x0342), 0x1D80 },
++	/* Frame length = 3177 */
++	{ CCI_REG16(0x033E), 0x0C69 },
++	/* Crop window start: X_ADD_STA[7:0]=100, Y_ADD_STA=256 */
++	{ CCI_REG24(0x0345), 0x640100 },
++	/* Crop window end: X_ADD_END[7:0]=103, Y_ADD_END=2895 */
++	{ CCI_REG24(0x0349), 0x670B4F },
++	/* Digital crop / vendor config */
++	{ CCI_REG24(0x040D), 0x040A50 },
++	/* X_OUTPUT_SIZE=3844, Y_OUTPUT_SIZE=2640 */
++	{ CCI_REG32(0x034C), 0x0F040A50 },
++	/* Frame duration initial */
++	{ CCI_REG16(0x022A), 0x0C61 },
++	/* Vendor specific registers */
++	{ CCI_REG8(0x7E9B),  0x02 },
++	{ CCI_REG8(0x0368),  0x00 },
++	{ CCI_REG8(0xD383),  0x01 },
++};
++
++/* SP10: Meteor Lake, C-PHY, 380.8 MHz */
++static const struct cci_reg_sequence imx681_pll_regs_mtl[] = {
++	{ CCI_REG8(0x0307),  0x77 },      /* PLL multiplier = 119 */
++	{ CCI_REG24(0x030D), 0x030077 },  /* PLL2: pre_div=3, mul=119 */
++};
++
++/* SP11: Lunar Lake, D-PHY, 969.6 MHz */
++static const struct cci_reg_sequence imx681_pll_regs_lnl[] = {
++	{ CCI_REG8(0x0307),  0xE1 },      /* PLL multiplier = 225 */
++	{ CCI_REG24(0x030D), 0x03012F },  /* PLL2: pre_div=3, mul=303 */
++};
++
++/*
++ * First exposure settings applied before stream-on.
++ * Uses group parameter hold to ensure atomic update.
++ */
++static const struct cci_reg_sequence imx681_first_exposure[] = {
++	{ CCI_REG8(0x0104),  0x01 },		/* Group hold ON */
++	{ CCI_REG24(0x033D), 0x000C69 },	/* Frame length = 3177 */
++	{ CCI_REG24(0x0229), 0x000773 },	/* Exposure = 1907 lines */
++	{ CCI_REG16(0x0204), 0x0000 },		/* Analog gain = 0 (1x) */
++	{ CCI_REG16(0x020E), 0x0100 },		/* Digital gain = 1.0x */
++	{ CCI_REG8(0x0104),  0x00 },		/* Group hold OFF */
++};
++
++static const char * const imx681_test_pattern_menu[] = {
++	"Disabled",
++	"Solid Colour",
++	"Eight Vertical Colour Bars",
++	"Colour Bars With Fade to Grey",
++	"Pseudorandom Sequence (PN9)",
++};
++
++static const u32 imx681_mbus_codes[] = {
++	MEDIA_BUS_FMT_SGRBG10_1X10,
++};
++
++/* Regulator supplies */
++static const char * const imx681_supply_names[] = {
++	"avdd",		/* Analog 2.8V */
++	"dvdd",		/* Digital 1.05V */
++	"dovdd",	/* I/O 1.8V */
++};
++
++#define IMX681_NUM_SUPPLIES ARRAY_SIZE(imx681_supply_names)
++
++struct imx681 {
++	struct device *dev;
++	struct regmap *cci;
++
++	struct v4l2_subdev sd;
++	struct media_pad pad;
++
++	struct clk *xclk;
++	struct gpio_desc *reset_gpio;
++	struct regulator_bulk_data supplies[IMX681_NUM_SUPPLIES];
++
++	/* V4L2 Controls */
++	struct v4l2_ctrl_handler ctrl_handler;
++	struct v4l2_ctrl *exposure;
++	struct v4l2_ctrl *vblank;
++	struct v4l2_ctrl *hblank;
++
++	unsigned long link_freq_bitmap;
++};
++
++static inline struct imx681 *to_imx681(struct v4l2_subdev *sd)
++{
++	return container_of_const(sd, struct imx681, sd);
++}
++
++static int imx681_set_ctrl(struct v4l2_ctrl *ctrl)
++{
++	struct imx681 *imx681 = container_of(ctrl->handler, struct imx681,
++					     ctrl_handler);
++	s64 exposure_max;
++	int ret = 0;
++
++	/* Update exposure max when VBLANK changes (even when not streaming) */
++	if (ctrl->id == V4L2_CID_VBLANK) {
++		exposure_max = IMX681_HEIGHT + ctrl->val - IMX681_EXPOSURE_OFFSET;
++		__v4l2_ctrl_modify_range(imx681->exposure,
++					 IMX681_EXPOSURE_MIN, exposure_max,
++					 1, IMX681_EXPOSURE_DEFAULT);
++	}
++
++	/* Only apply controls to hardware when streaming */
++	if (!pm_runtime_get_if_active(imx681->dev))
++		return 0;
++
++	switch (ctrl->id) {
++	case V4L2_CID_VBLANK:
++		cci_write(imx681->cci, IMX681_REG_GROUP_HOLD, 0x01, &ret);
++		cci_write(imx681->cci, IMX681_REG_FRAME_LENGTH,
++			  IMX681_HEIGHT + ctrl->val, &ret);
++		cci_write(imx681->cci, IMX681_REG_GROUP_HOLD, 0x00, &ret);
++		dev_dbg(imx681->dev, "set frame_length: %d, ret=%d\n",
++			IMX681_HEIGHT + ctrl->val, ret);
++		break;
++
++	case V4L2_CID_EXPOSURE:
++		cci_write(imx681->cci, IMX681_REG_GROUP_HOLD, 0x01, &ret);
++		cci_write(imx681->cci, IMX681_REG_EXPOSURE, ctrl->val, &ret);
++		cci_write(imx681->cci, IMX681_REG_GROUP_HOLD, 0x00, &ret);
++		dev_dbg(imx681->dev, "set exposure: %d, ret=%d\n",
++			ctrl->val, ret);
++		break;
++
++	case V4L2_CID_ANALOGUE_GAIN: {
++		/*
++		 * Gain formula: gain = 1024/(1024-code).
++		 * Analog max is code 960 (16x). For codes above 960,
++		 * set analog to max and use digital gain for the rest.
++		 * Digital gain register: 0x0100 = 1.0x, value = gain * 256.
++		 */
++		int ana_code = min(ctrl->val, 960);
++		int dig_reg = IMX681_DIG_GAIN_MIN; /* 0x0100 = 1.0x */
++
++		if (ctrl->val > 960) {
++			/*
++			 * digital = total_gain / analog_gain
++			 *         = (1024/(1024-code)) / (1024/64)
++			 *         = 64 / (1024-code)
++			 * dig_reg = digital * 256 = 16384 / (1024-code)
++			 */
++			dig_reg = 16384 / (1024 - ctrl->val);
++			dig_reg = clamp(dig_reg, (int)IMX681_DIG_GAIN_MIN,
++					(int)IMX681_DIG_GAIN_MAX);
++		}
++
++		cci_write(imx681->cci, IMX681_REG_GROUP_HOLD, 0x01, &ret);
++		cci_write(imx681->cci, IMX681_REG_ANALOG_GAIN, ana_code,
++			  &ret);
++		cci_write(imx681->cci, IMX681_REG_DIGITAL_GAIN, dig_reg,
++			  &ret);
++		cci_write(imx681->cci, IMX681_REG_GROUP_HOLD, 0x00, &ret);
++		dev_dbg(imx681->dev, "set gain code %d: analog=%d digital=0x%x, ret=%d\n",
++			ctrl->val, ana_code, dig_reg, ret);
++		break;
++	}
++
++	case V4L2_CID_DIGITAL_GAIN:
++		cci_write(imx681->cci, IMX681_REG_GROUP_HOLD, 0x01, &ret);
++		cci_write(imx681->cci, IMX681_REG_DIGITAL_GAIN, ctrl->val,
++			  &ret);
++		cci_write(imx681->cci, IMX681_REG_GROUP_HOLD, 0x00, &ret);
++		dev_dbg(imx681->dev, "set digital gain: %d, ret=%d\n",
++			ctrl->val, ret);
++		break;
++
++	case V4L2_CID_TEST_PATTERN:
++		ret = cci_write(imx681->cci, IMX681_REG_TEST_PATTERN,
++				ctrl->val, NULL);
++		break;
++
++	default:
++		dev_dbg(imx681->dev, "unhandled ctrl id: 0x%x val: 0x%x\n",
++			ctrl->id, ctrl->val);
++		break;
++	}
++
++	pm_runtime_put(imx681->dev);
++	return ret;
++}
++
++static const struct v4l2_ctrl_ops imx681_ctrl_ops = {
++	.s_ctrl = imx681_set_ctrl,
++};
++
++static int imx681_enum_mbus_code(struct v4l2_subdev *sd,
++				 struct v4l2_subdev_state *state,
++				 struct v4l2_subdev_mbus_code_enum *code)
++{
++	if (code->index >= ARRAY_SIZE(imx681_mbus_codes))
++		return -EINVAL;
++
++	code->code = imx681_mbus_codes[code->index];
++	return 0;
++}
++
++static bool imx681_is_valid_mbus_code(u32 code)
++{
++	unsigned int i;
++
++	for (i = 0; i < ARRAY_SIZE(imx681_mbus_codes); i++)
++		if (imx681_mbus_codes[i] == code)
++			return true;
++	return false;
++}
++
++static int imx681_enum_frame_size(struct v4l2_subdev *sd,
++				  struct v4l2_subdev_state *state,
++				  struct v4l2_subdev_frame_size_enum *fse)
++{
++	if (fse->index > 0)
++		return -EINVAL;
++
++	if (!imx681_is_valid_mbus_code(fse->code))
++		return -EINVAL;
++
++	fse->min_width = IMX681_WIDTH;
++	fse->max_width = IMX681_WIDTH;
++	fse->min_height = IMX681_HEIGHT;
++	fse->max_height = IMX681_HEIGHT;
++
++	return 0;
++}
++
++static int imx681_init_state(struct v4l2_subdev *sd,
++			     struct v4l2_subdev_state *state)
++{
++	struct v4l2_mbus_framefmt *format;
++
++	format = v4l2_subdev_state_get_format(state, IMAGE_PAD);
++	format->width = IMX681_WIDTH;
++	format->height = IMX681_HEIGHT;
++	format->code = MEDIA_BUS_FMT_SGRBG10_1X10;
++	format->field = V4L2_FIELD_NONE;
++	format->colorspace = V4L2_COLORSPACE_RAW;
++	format->ycbcr_enc = V4L2_YCBCR_ENC_601;
++	format->quantization = V4L2_QUANTIZATION_FULL_RANGE;
++	format->xfer_func = V4L2_XFER_FUNC_NONE;
++
++	return 0;
++}
++
++static int imx681_set_pad_format(struct v4l2_subdev *sd,
++				 struct v4l2_subdev_state *state,
++				 struct v4l2_subdev_format *fmt)
++{
++	struct v4l2_mbus_framefmt *format;
++
++	/* Fixed resolution, fixed Bayer order */
++	fmt->format.width = IMX681_WIDTH;
++	fmt->format.height = IMX681_HEIGHT;
++	if (!imx681_is_valid_mbus_code(fmt->format.code))
++		fmt->format.code = imx681_mbus_codes[0];
++	fmt->format.field = V4L2_FIELD_NONE;
++	fmt->format.colorspace = V4L2_COLORSPACE_RAW;
++	fmt->format.ycbcr_enc = V4L2_YCBCR_ENC_601;
++	fmt->format.quantization = V4L2_QUANTIZATION_FULL_RANGE;
++	fmt->format.xfer_func = V4L2_XFER_FUNC_NONE;
++
++	format = v4l2_subdev_state_get_format(state, fmt->pad);
++	*format = fmt->format;
++
++	return 0;
++}
++
++static int imx681_get_selection(struct v4l2_subdev *sd,
++				struct v4l2_subdev_state *state,
++				struct v4l2_subdev_selection *sel)
++{
++	switch (sel->target) {
++	case V4L2_SEL_TGT_CROP:
++	case V4L2_SEL_TGT_CROP_DEFAULT:
++	case V4L2_SEL_TGT_CROP_BOUNDS:
++	case V4L2_SEL_TGT_NATIVE_SIZE:
++		sel->r.top = 0;
++		sel->r.left = 0;
++		sel->r.width = IMX681_WIDTH;
++		sel->r.height = IMX681_HEIGHT;
++		return 0;
++	default:
++		return -EINVAL;
++	}
++}
++
++static int imx681_start_streaming(struct imx681 *imx681)
++{
++	int ret;
++
++	dev_info(imx681->dev, "starting stream: %dx%d RAW10 2-lane\n",
++		IMX681_WIDTH, IMX681_HEIGHT);
++
++	/* Write init register sequence */
++	ret = cci_multi_reg_write(imx681->cci, imx681_init_regs,
++				  ARRAY_SIZE(imx681_init_regs), NULL);
++	if (ret) {
++		dev_err(imx681->dev, "failed to write init regs: %d\n", ret);
++		return ret;
++	}
++
++	/* Select PLL registers based on negotiated link frequency */
++	if (imx681->link_freq_bitmap & BIT(0)) {
++		/* MTL / SP10: 380.8 MHz C-PHY */
++		ret = cci_multi_reg_write(imx681->cci, imx681_pll_regs_mtl,
++					  ARRAY_SIZE(imx681_pll_regs_mtl), NULL);
++	} else {
++		/* LNL / SP11: 969.6 MHz D-PHY */
++		ret = cci_multi_reg_write(imx681->cci, imx681_pll_regs_lnl,
++					  ARRAY_SIZE(imx681_pll_regs_lnl), NULL);
++	}
++	if (ret) {
++		dev_err(imx681->dev, "failed to write PLL regs: %d\n", ret);
++		return ret;
++	}
++
++	dev_dbg(imx681->dev, "init registers written successfully\n");
++
++	/* Wait for sensor to stabilise after configuration */
++	usleep_range(IMX681_INIT_DELAY_US, IMX681_INIT_DELAY_US + 1000);
++
++	/* Apply first exposure settings with group hold */
++	ret = cci_multi_reg_write(imx681->cci, imx681_first_exposure,
++				  ARRAY_SIZE(imx681_first_exposure), NULL);
++	if (ret) {
++		dev_err(imx681->dev, "failed to write exposure: %d\n", ret);
++		return ret;
++	}
++
++	/* Apply any pending V4L2 control values */
++	ret = __v4l2_ctrl_handler_setup(imx681->sd.ctrl_handler);
++	if (ret) {
++		dev_err(imx681->dev, "failed to apply controls: %d\n", ret);
++		return ret;
++	}
++
++	/* Start streaming */
++	ret = cci_write(imx681->cci, IMX681_REG_MODE_SELECT,
++			IMX681_MODE_STREAMING, NULL);
++	if (ret) {
++		dev_err(imx681->dev, "failed to start streaming: %d\n", ret);
++		return ret;
++	}
++
++	dev_info(imx681->dev, "streaming started\n");
++	return 0;
++}
++
++static int imx681_stop_streaming(struct imx681 *imx681)
++{
++	int ret;
++
++	ret = cci_write(imx681->cci, IMX681_REG_MODE_SELECT,
++			IMX681_MODE_STANDBY, NULL);
++	if (ret)
++		dev_err(imx681->dev, "failed to stop streaming: %d\n", ret);
++
++	return ret;
++}
++
++static int imx681_enable_streams(struct v4l2_subdev *sd,
++				 struct v4l2_subdev_state *state,
++				 u32 pad, u64 streams_mask)
++{
++	dev_info(sd->dev, "enable_streams called pad=%d mask=0x%llx\n", pad, streams_mask);
++	struct imx681 *imx681 = to_imx681(sd);
++	int ret;
++
++	if (pad != IMAGE_PAD)
++		return -EINVAL;
++
++	ret = pm_runtime_get_sync(imx681->dev);
++	if (ret < 0) {
++		pm_runtime_put_noidle(imx681->dev);
++		return ret;
++	}
++
++	ret = imx681_start_streaming(imx681);
++	dev_info(sd->dev, "start_streaming returned %d\n", ret);
++	if (ret)
++		pm_runtime_put_autosuspend(imx681->dev);
++
++	return ret;
++}
++
++static int imx681_disable_streams(struct v4l2_subdev *sd,
++				  struct v4l2_subdev_state *state,
++				  u32 pad, u64 streams_mask)
++{
++	struct imx681 *imx681 = to_imx681(sd);
++
++	if (pad != IMAGE_PAD)
++		return -EINVAL;
++
++	imx681_stop_streaming(imx681);
++	pm_runtime_put_autosuspend(imx681->dev);
++
++	return 0;
++}
++
++static const struct v4l2_subdev_video_ops imx681_video_ops = {
++	.s_stream = v4l2_subdev_s_stream_helper,
++};
++
++static const struct v4l2_subdev_pad_ops imx681_pad_ops = {
++	.enum_mbus_code = imx681_enum_mbus_code,
++	.get_fmt = v4l2_subdev_get_fmt,
++	.set_fmt = imx681_set_pad_format,
++	.get_selection = imx681_get_selection,
++	.enum_frame_size = imx681_enum_frame_size,
++	.enable_streams = imx681_enable_streams,
++	.disable_streams = imx681_disable_streams,
++};
++
++static const struct v4l2_subdev_ops imx681_subdev_ops = {
++	.video = &imx681_video_ops,
++	.pad = &imx681_pad_ops,
++};
++
++static const struct v4l2_subdev_internal_ops imx681_internal_ops = {
++	.init_state = imx681_init_state,
++};
++
++/* Power management */
++static int imx681_power_on(struct device *dev)
++{
++	struct v4l2_subdev *sd = dev_get_drvdata(dev);
++	struct imx681 *imx681 = to_imx681(sd);
++	int ret;
++
++	dev_dbg(imx681->dev, "power on\n");
++
++	ret = regulator_bulk_enable(IMX681_NUM_SUPPLIES, imx681->supplies);
++	if (ret) {
++		dev_err(imx681->dev, "failed to enable regulators: %d\n", ret);
++		return ret;
++	}
++
++	ret = clk_prepare_enable(imx681->xclk);
++	if (ret) {
++		dev_err(imx681->dev, "failed to enable clock: %d\n", ret);
++		goto err_reg_disable;
++	}
++
++	/* Deassert reset (active low) */
++	gpiod_set_value_cansleep(imx681->reset_gpio, 0);
++
++	usleep_range(IMX681_RESET_DELAY_US,
++		     IMX681_RESET_DELAY_US + IMX681_RESET_DELAY_RANGE_US);
++
++	return 0;
++
++err_reg_disable:
++	regulator_bulk_disable(IMX681_NUM_SUPPLIES, imx681->supplies);
++	return ret;
++}
++
++static int imx681_power_off(struct device *dev)
++{
++	struct v4l2_subdev *sd = dev_get_drvdata(dev);
++	struct imx681 *imx681 = to_imx681(sd);
++
++	dev_dbg(imx681->dev, "power off\n");
++
++	/* Assert reset */
++	gpiod_set_value_cansleep(imx681->reset_gpio, 1);
++	clk_disable_unprepare(imx681->xclk);
++	regulator_bulk_disable(IMX681_NUM_SUPPLIES, imx681->supplies);
++
++	return 0;
++}
++
++static int imx681_identify_module(struct imx681 *imx681)
++{
++	u64 val;
++	int ret;
++
++	ret = cci_read(imx681->cci, IMX681_REG_CHIP_ID, &val, NULL);
++	if (ret) {
++		dev_err(imx681->dev,
++			"failed to read chip ID register 0x0016: %d\n", ret);
++		return ret;
++	}
++
++	if (val != IMX681_CHIP_ID) {
++		dev_err(imx681->dev, "chip ID mismatch: 0x%04llx != 0x%04x\n",
++			val, IMX681_CHIP_ID);
++		return -EIO;
++	}
++
++	return 0;
++}
++
++static int imx681_init_controls(struct imx681 *imx681)
++{
++	struct v4l2_ctrl_handler *ctrl_hdlr = &imx681->ctrl_handler;
++	struct v4l2_fwnode_device_properties props;
++	struct v4l2_ctrl *link_freq;
++	s64 hblank, vblank;
++	u64 pixel_rate;
++	int ret;
++
++	ret = v4l2_ctrl_handler_init(ctrl_hdlr, 9);
++	if (ret)
++		return ret;
++
++	/* Pixel rate (read-only) — depends on platform link frequency */
++	pixel_rate = (imx681->link_freq_bitmap & BIT(0)) ?
++			 IMX681_PIXEL_RATE_MTL : IMX681_PIXEL_RATE_LNL;
++	v4l2_ctrl_new_std(ctrl_hdlr, &imx681_ctrl_ops,
++			  V4L2_CID_PIXEL_RATE, pixel_rate,
++			  pixel_rate, 1, pixel_rate);
++
++	/* Link frequency (read-only) */
++	link_freq = v4l2_ctrl_new_int_menu(ctrl_hdlr, &imx681_ctrl_ops,
++					   V4L2_CID_LINK_FREQ,
++					   __fls(imx681->link_freq_bitmap),
++					   __ffs(imx681->link_freq_bitmap),
++					   imx681_link_frequencies);
++	if (link_freq)
++		link_freq->flags |= V4L2_CTRL_FLAG_READ_ONLY;
++
++	/* Horizontal blanking (read-only, fixed) */
++	hblank = IMX681_LINE_LENGTH_PCK - IMX681_WIDTH;
++	imx681->hblank = v4l2_ctrl_new_std(ctrl_hdlr, &imx681_ctrl_ops,
++					    V4L2_CID_HBLANK, hblank, hblank,
++					    1, hblank);
++	if (imx681->hblank)
++		imx681->hblank->flags |= V4L2_CTRL_FLAG_READ_ONLY;
++
++	/* Vertical blanking (writable to allow longer exposures) */
++	vblank = IMX681_FRAME_LENGTH_LINES - IMX681_HEIGHT;
++	imx681->vblank = v4l2_ctrl_new_std(ctrl_hdlr, &imx681_ctrl_ops,
++					    V4L2_CID_VBLANK, vblank,
++					    IMX681_FRAME_LENGTH_MAX - IMX681_HEIGHT,
++					    1, vblank);
++
++	/* Exposure */
++	imx681->exposure = v4l2_ctrl_new_std(ctrl_hdlr, &imx681_ctrl_ops,
++					     V4L2_CID_EXPOSURE,
++					     IMX681_EXPOSURE_MIN,
++					     IMX681_EXPOSURE_MAX, 1,
++					     IMX681_EXPOSURE_DEFAULT);
++
++	/* Analog gain */
++	v4l2_ctrl_new_std(ctrl_hdlr, &imx681_ctrl_ops, V4L2_CID_ANALOGUE_GAIN,
++			  IMX681_ANA_GAIN_MIN, IMX681_ANA_GAIN_MAX, 1,
++			  IMX681_ANA_GAIN_DEFAULT);
++
++	/* Digital gain */
++	v4l2_ctrl_new_std(ctrl_hdlr, &imx681_ctrl_ops, V4L2_CID_DIGITAL_GAIN,
++			  IMX681_DIG_GAIN_MIN, IMX681_DIG_GAIN_MAX, 1,
++			  IMX681_DIG_GAIN_DEFAULT);
++
++	/* Test pattern */
++	v4l2_ctrl_new_std_menu_items(ctrl_hdlr, &imx681_ctrl_ops,
++				     V4L2_CID_TEST_PATTERN,
++				     ARRAY_SIZE(imx681_test_pattern_menu) - 1,
++				     0, 0, imx681_test_pattern_menu);
++
++	if (ctrl_hdlr->error) {
++		ret = ctrl_hdlr->error;
++		dev_err(imx681->dev, "control init failed: %d\n", ret);
++		goto error;
++	}
++
++	ret = v4l2_fwnode_device_parse(imx681->dev, &props);
++	if (ret)
++		goto error;
++
++	ret = v4l2_ctrl_new_fwnode_properties(ctrl_hdlr, &imx681_ctrl_ops,
++					      &props);
++	if (ret)
++		goto error;
++
++	imx681->sd.ctrl_handler = ctrl_hdlr;
++	return 0;
++
++error:
++	v4l2_ctrl_handler_free(ctrl_hdlr);
++	return ret;
++}
++
++static int imx681_parse_endpoint(struct imx681 *imx681)
++{
++	struct fwnode_handle *fwnode = dev_fwnode(imx681->dev);
++	struct v4l2_fwnode_endpoint bus_cfg = {
++		.bus_type = V4L2_MBUS_UNKNOWN,
++	};
++	struct fwnode_handle *ep;
++	int ret;
++
++	ep = fwnode_graph_get_next_endpoint(fwnode, NULL);
++	if (!ep) {
++		dev_err(imx681->dev, "no endpoint found in firmware node\n");
++		return -EPROBE_DEFER;
++	}
++
++	ret = v4l2_fwnode_endpoint_alloc_parse(ep, &bus_cfg);
++	fwnode_handle_put(ep);
++	if (ret) {
++		dev_dbg(imx681->dev, "endpoint parse failed (%d), deferring\n", ret);
++		return EPROBE_DEFER;
++	}
++
++	if (bus_cfg.bus.mipi_csi2.num_data_lanes != IMX681_NUM_LANES) {
++		dev_err(imx681->dev,
++			"expected %d data lanes, got %d\n",
++			IMX681_NUM_LANES,
++			bus_cfg.bus.mipi_csi2.num_data_lanes);
++		ret = -EINVAL;
++		goto done;
++	}
++
++	ret = v4l2_link_freq_to_bitmap(imx681->dev,
++				       bus_cfg.link_frequencies,
++				       bus_cfg.nr_of_link_frequencies,
++				       imx681_link_frequencies,
++				       ARRAY_SIZE(imx681_link_frequencies),
++				       &imx681->link_freq_bitmap);
++	if (ret)
++		dev_err(imx681->dev, "link frequency mismatch: %d\n", ret);
++
++done:
++	v4l2_fwnode_endpoint_free(&bus_cfg);
++	return ret;
++}
++
++static int imx681_probe(struct i2c_client *client)
++{
++	struct imx681 *imx681;
++	unsigned int i;
++	int ret;
++
++	imx681 = devm_kzalloc(&client->dev, sizeof(*imx681), GFP_KERNEL);
++	if (!imx681)
++		return -ENOMEM;
++
++	imx681->dev = &client->dev;
++
++	/* Initialise V4L2 subdev */
++	v4l2_i2c_subdev_init(&imx681->sd, client, &imx681_subdev_ops);
++
++	/* Initialise CCI regmap for 16-bit register addresses */
++	imx681->cci = devm_cci_regmap_init_i2c(client, 16);
++	if (IS_ERR(imx681->cci)) {
++		ret = PTR_ERR(imx681->cci);
++		dev_err(imx681->dev, "failed to init CCI: %d\n", ret);
++		return ret;
++	}
++
++	/* Get clock (optional - INT3472 provides it on Surface devices) */
++	imx681->xclk = devm_clk_get_optional(imx681->dev, NULL);
++	if (IS_ERR(imx681->xclk))
++		return dev_err_probe(imx681->dev, PTR_ERR(imx681->xclk),
++				     "failed to get clock\n");
++
++	if (imx681->xclk)
++		dev_dbg(imx681->dev, "clock rate: %lu Hz\n",
++			clk_get_rate(imx681->xclk));
++
++	/* Get regulators (optional) */
++	for (i = 0; i < IMX681_NUM_SUPPLIES; i++)
++		imx681->supplies[i].supply = imx681_supply_names[i];
++
++	ret = devm_regulator_bulk_get(imx681->dev, IMX681_NUM_SUPPLIES,
++				      imx681->supplies);
++	if (ret) {
++		dev_dbg(imx681->dev,
++			"regulators not available (expected on ACPI): %d\n",
++			ret);
++		/* Continue without regulators - INT3472 may handle power */
++	}
++
++	/* Get reset GPIO (optional) */
++	imx681->reset_gpio = devm_gpiod_get_optional(imx681->dev, "reset",
++						      GPIOD_OUT_HIGH);
++	if (IS_ERR(imx681->reset_gpio))
++		return dev_err_probe(imx681->dev,
++				     PTR_ERR(imx681->reset_gpio),
++				     "failed to get reset GPIO\n");
++
++	/* Parse CSI-2 endpoint */
++	ret = imx681_parse_endpoint(imx681);
++	if (ret) {
++		dev_err(imx681->dev, "endpoint parse failed: %d\n", ret);
++		return ret;
++	}
++
++	/* Power on and verify chip ID */
++	ret = imx681_power_on(imx681->dev);
++	if (ret) {
++		dev_err(imx681->dev, "power on failed: %d\n", ret);
++		return ret;
++	}
++
++	ret = imx681_identify_module(imx681);
++	if (ret)
++		goto error_power_off;
++
++	/* Enable runtime PM */
++	pm_runtime_set_active(imx681->dev);
++	pm_runtime_get_noresume(imx681->dev);
++	pm_runtime_enable(imx681->dev);
++	pm_runtime_set_autosuspend_delay(imx681->dev, 1000);
++	pm_runtime_use_autosuspend(imx681->dev);
++
++	/* Init V4L2 controls */
++	ret = imx681_init_controls(imx681);
++	if (ret)
++		goto error_pm;
++
++	/* Setup subdev */
++	imx681->sd.flags |= V4L2_SUBDEV_FL_HAS_DEVNODE;
++	imx681->sd.entity.function = MEDIA_ENT_F_CAM_SENSOR;
++	imx681->sd.internal_ops = &imx681_internal_ops;
++
++	/* Init media entity */
++	imx681->pad.flags = MEDIA_PAD_FL_SOURCE;
++	ret = media_entity_pads_init(&imx681->sd.entity, 1, &imx681->pad);
++	if (ret) {
++		dev_err(imx681->dev, "media entity init failed: %d\n", ret);
++		goto error_handler_free;
++	}
++
++	imx681->sd.state_lock = imx681->ctrl_handler.lock;
++	ret = v4l2_subdev_init_finalize(&imx681->sd);
++	if (ret < 0) {
++		dev_err(imx681->dev, "subdev init finalize failed: %d\n", ret);
++		goto error_media_entity;
++	}
++
++	ret = v4l2_async_register_subdev_sensor(&imx681->sd);
++	if (ret < 0) {
++		dev_err(imx681->dev,
++			"async register subdev failed: %d\n", ret);
++		goto error_subdev_cleanup;
++	}
++
++	pm_runtime_put_autosuspend(imx681->dev);
++
++	dev_info(imx681->dev,
++		 "IMX681 probed successfully: %dx%d\n",
++		 IMX681_WIDTH, IMX681_HEIGHT);
++	return 0;
++
++error_subdev_cleanup:
++	v4l2_subdev_cleanup(&imx681->sd);
++error_media_entity:
++	media_entity_cleanup(&imx681->sd.entity);
++error_handler_free:
++	v4l2_ctrl_handler_free(imx681->sd.ctrl_handler);
++error_pm:
++	pm_runtime_disable(imx681->dev);
++	pm_runtime_set_suspended(imx681->dev);
++error_power_off:
++	imx681_power_off(imx681->dev);
++	return ret;
++}
++
++static void imx681_remove(struct i2c_client *client)
++{
++	struct v4l2_subdev *sd = i2c_get_clientdata(client);
++	struct imx681 *imx681 = to_imx681(sd);
++
++	v4l2_async_unregister_subdev(sd);
++	v4l2_subdev_cleanup(&imx681->sd);
++	media_entity_cleanup(&sd->entity);
++	v4l2_ctrl_handler_free(imx681->sd.ctrl_handler);
++
++	pm_runtime_disable(imx681->dev);
++	if (!pm_runtime_status_suspended(imx681->dev))
++		imx681_power_off(imx681->dev);
++	pm_runtime_set_suspended(imx681->dev);
++}
++
++static DEFINE_RUNTIME_DEV_PM_OPS(imx681_pm_ops, imx681_power_off,
++				 imx681_power_on, NULL);
++
++#ifdef CONFIG_ACPI
++static const struct acpi_device_id imx681_acpi_ids[] = {
++	{ "SONY0681" },
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(acpi, imx681_acpi_ids);
++#endif
++
++static const struct of_device_id imx681_dt_ids[] = {
++	{ .compatible = "sony,imx681" },
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(of, imx681_dt_ids);
++
++static struct i2c_driver imx681_i2c_driver = {
++	.driver = {
++		.name = "imx681",
++		.pm = pm_ptr(&imx681_pm_ops),
++		.acpi_match_table = ACPI_PTR(imx681_acpi_ids),
++		.of_match_table = imx681_dt_ids,
++	},
++	.probe = imx681_probe,
++	.remove = imx681_remove,
++};
++module_i2c_driver(imx681_i2c_driver);
++
++MODULE_DESCRIPTION("Sony IMX681 CMOS Image Sensor Driver");
++MODULE_AUTHOR("Andre Gilerson <andre.gilerson@gmail.com>");
++MODULE_LICENSE("GPL");
+-- 
+2.53.0
+
+
+From 929c24b59a5066c83593634105c830c887588509 Mon Sep 17 00:00:00 2001
+From: "D.J. Mulder" <djmulder@example.com>
+Date: Fri, 29 May 2026 15:28:53 +0200
+Subject: [PATCH 2/5] media: ipu-bridge: Add Surface Pro 10 camera sensor
+ support
+
+Add sensor table entries and support for cameras on the Microsoft
+Surface Pro 10 (Meteor Lake / IPU6EP-MTL):
+
+- Add SONY0681 (IMX681 front camera) with C-PHY bus type and dual
+  link frequencies (380.8 MHz for SP10/MTL, 969.6 MHz for SP11/LNL)
+- Add OVTID858 (OV13858 rear camera) with 4-lane D-PHY at 540 MHz
+- Add OVTI5675 sensor entry
+- Add device_reprobe() call after fwnode attachment to fix probe
+  ordering race condition
+- Add C-PHY bus type selection via IPU_SENSOR_CONFIG_CPHY macro
+- Add DMI quirk entries for XPS 13 9340 and XPS 14 9440
+
+Patchset: cameras
+---
+ drivers/media/pci/intel/ipu-bridge.c | 80 +++++++++++++++++++++++++---
+ 1 file changed, 72 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/media/pci/intel/ipu-bridge.c b/drivers/media/pci/intel/ipu-bridge.c
+index a986e30..fb17d20 100644
+--- a/drivers/media/pci/intel/ipu-bridge.c
++++ b/drivers/media/pci/intel/ipu-bridge.c
+@@ -5,6 +5,7 @@
+ #include <acpi/acpi_bus.h>
+ #include <linux/cleanup.h>
+ #include <linux/device.h>
++#include <linux/dmi.h>
+ #include <linux/i2c.h>
+ #include <linux/mei_cl_bus.h>
+ #include <linux/platform_device.h>
+@@ -55,17 +56,23 @@ static const struct ipu_sensor_config ipu_supported_sensors[] = {
+ 	/* Himax HM2172 */
+ 	IPU_SENSOR_CONFIG("HIMX2172", 1, 384000000),
+ 	/* GalaxyCore GC0310 */
+-	IPU_SENSOR_CONFIG("INT0310", 0),
++	IPU_SENSOR_CONFIG("INT0310", 1, 55692000),
+ 	/* Omnivision OV5693 */
+ 	IPU_SENSOR_CONFIG("INT33BE", 1, 419200000),
++	/* Onsemi MT9M114 */
++	IPU_SENSOR_CONFIG("INT33F0", 1, 384000000),
+ 	/* Omnivision OV2740 */
+ 	IPU_SENSOR_CONFIG("INT3474", 1, 180000000),
++	/* Omnivision OV5670 */
++	IPU_SENSOR_CONFIG("INT3479", 1, 422400000),
+ 	/* Omnivision OV8865 */
+ 	IPU_SENSOR_CONFIG("INT347A", 1, 360000000),
+ 	/* Omnivision OV7251 */
+ 	IPU_SENSOR_CONFIG("INT347E", 1, 319200000),
+ 	/* Hynix Hi-556 */
+ 	IPU_SENSOR_CONFIG("INT3537", 1, 437000000),
++	/* Lontium lt6911uxe */
++	IPU_SENSOR_CONFIG("INTC10C5", 0),
+ 	/* Omnivision OV01A10 / OV01A1S */
+ 	IPU_SENSOR_CONFIG("OVTI01A0", 1, 400000000),
+ 	IPU_SENSOR_CONFIG("OVTI01AS", 1, 400000000),
+@@ -84,10 +91,54 @@ static const struct ipu_sensor_config ipu_supported_sensors[] = {
+ 	IPU_SENSOR_CONFIG("OVTIDB10", 1, 560000000),
+ 	/* Omnivision OV2680 */
+ 	IPU_SENSOR_CONFIG("OVTI2680", 1, 331200000),
++	/* Omnivision OV5675 */
++	IPU_SENSOR_CONFIG("OVTI5675", 1, 450000000),
+ 	/* Omnivision OV8856 */
+ 	IPU_SENSOR_CONFIG("OVTI8856", 3, 180000000, 360000000, 720000000),
+ 	/* Sony IMX471 */
+ 	IPU_SENSOR_CONFIG("SONY471A", 1, 200000000),
++	/* Toshiba T4KA3 */
++	IPU_SENSOR_CONFIG("XMCC0003", 1, 321468000),
++	/* OmniVision OV13858 - Microsoft Surface Pro 10 rear camera */
++	IPU_SENSOR_CONFIG("OVTID858", 4, 540000000),
++	/* Sony IMX681 - Surface Pro 10 */
++        IPU_SENSOR_CONFIG_CPHY("SONY0681", 1, 380800000),
++};
++
++/*
++ * DMI matches for laptops which have their sensor mounted upside-down
++ * without reporting a rotation of 180° in neither the SSDB nor the _PLD.
++ */
++static const struct dmi_system_id upside_down_sensor_dmi_ids[] = {
++	{
++		.matches = {
++			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
++			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "XPS 13 9340"),
++		},
++		.driver_data = "OVTI02C1",
++	},
++	{
++		.matches = {
++			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
++			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "XPS 13 9350"),
++		},
++		.driver_data = "OVTI02C1",
++	},
++	{
++		.matches = {
++			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
++			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "XPS 14 9440"),
++		},
++		.driver_data = "OVTI02C1",
++	},
++	{
++		.matches = {
++			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
++			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "XPS 16 9640"),
++		},
++		.driver_data = "OVTI02C1",
++	},
++	{} /* Terminating entry */
+ };
+ 
+ static const struct ipu_property_names prop_names = {
+@@ -240,6 +291,12 @@ out_free_buff:
+ static u32 ipu_bridge_parse_rotation(struct acpi_device *adev,
+ 				     struct ipu_sensor_ssdb *ssdb)
+ {
++	const struct dmi_system_id *dmi_id;
++
++	dmi_id = dmi_first_match(upside_down_sensor_dmi_ids);
++	if (dmi_id && acpi_dev_hid_match(adev, dmi_id->driver_data))
++		return 180;
++
+ 	switch (ssdb->degree) {
+ 	case IPU_SENSOR_ROTATION_NORMAL:
+ 		return 0;
+@@ -384,8 +441,9 @@ static void ipu_bridge_create_fwnode_properties(
+ 	}
+ 
+ 	sensor->ep_properties[0] = PROPERTY_ENTRY_U32(
+-					sensor->prop_names.bus_type,
+-					V4L2_FWNODE_BUS_TYPE_CSI2_DPHY);
++				sensor->prop_names.bus_type,
++				cfg->cphy ? V4L2_FWNODE_BUS_TYPE_CSI2_CPHY :
++					    V4L2_FWNODE_BUS_TYPE_CSI2_DPHY);
+ 	sensor->ep_properties[1] = PROPERTY_ENTRY_U32_ARRAY_LEN(
+ 					sensor->prop_names.data_lanes,
+ 					bridge->data_lanes, sensor->lanes);
+@@ -559,8 +617,8 @@ static void ipu_bridge_instantiate_vcm_work(struct work_struct *work)
+ 	vcm_client = i2c_acpi_new_device_by_fwnode(acpi_fwnode_handle(adev),
+ 						   1, &data->board_info);
+ 	if (IS_ERR(vcm_client)) {
+-		dev_err(data->sensor, "Error instantiating VCM client: %ld\n",
+-			PTR_ERR(vcm_client));
++		dev_err(data->sensor, "Error instantiating VCM client: %pe\n",
++			vcm_client);
+ 		goto out_pm_put;
+ 	}
+ 
+@@ -601,7 +659,7 @@ int ipu_bridge_instantiate_vcm(struct device *sensor)
+ 		return 0;
+ 	}
+ 
+-	data = kzalloc(sizeof(*data), GFP_KERNEL);
++	data = kzalloc_obj(*data);
+ 	if (!data) {
+ 		fwnode_handle_put(vcm_fwnode);
+ 		return -ENOMEM;
+@@ -664,6 +722,7 @@ static int ipu_bridge_connect_sensor(const struct ipu_sensor_config *cfg,
+ 	int ret;
+ 
+ 	for_each_acpi_dev_match(adev, cfg->hid, NULL, -1) {
++		dev_info(bridge->dev, "Trying to connect sensor %s\n", cfg->hid);
+ 		if (!ACPI_PTR(adev->status.enabled))
+ 			continue;
+ 
+@@ -705,6 +764,10 @@ static int ipu_bridge_connect_sensor(const struct ipu_sensor_config *cfg,
+ 		primary = acpi_fwnode_handle(adev);
+ 		primary->secondary = fwnode;
+ 
++		struct device *sensor_dev = acpi_get_first_physical_node(adev);
++		if (sensor_dev)
++    			device_reprobe(sensor_dev);
++
+ 		ret = ipu_bridge_instantiate_ivsc(sensor);
+ 		if (ret)
+ 			goto err_free_swnodes;
+@@ -811,9 +874,10 @@ int ipu_bridge_init(struct device *dev,
+ 		return 0;
+ 
+ 	if (!ipu_bridge_ivsc_is_ready())
+-		return -EPROBE_DEFER;
++		return dev_err_probe(dev, -EPROBE_DEFER,
++				     "waiting for IVSC to become ready\n");
+ 
+-	bridge = kzalloc(sizeof(*bridge), GFP_KERNEL);
++	bridge = kzalloc_obj(*bridge);
+ 	if (!bridge)
+ 		return -ENOMEM;
+ 
+-- 
+2.53.0
+
+
+From 200de783ce8201f1f9d679141c65c1bc4e6e94ff Mon Sep 17 00:00:00 2001
+From: "D.J. Mulder" <djmulder@example.com>
+Date: Fri, 29 May 2026 15:29:18 +0200
+Subject: [PATCH 3/5] platform/x86: int3472: Add GPIO type 0x08 (DVDD) and 0x10
+ (DOVDD) support
+
+Add proper handling for GPIO types seen on Microsoft Surface Pro 10
+cameras that were previously unknown to the driver:
+
+- GPIO type 0x08: DVDD secondary digital core voltage, mapped to
+  'dvdd2' consumer ID via new INT3472_GPIO_TYPE_DVDD constant
+- GPIO type 0x10: DOVDD digital I/O voltage, already handled by
+  existing INT3472_GPIO_TYPE_DOVDD but previously not reached due
+  to missing case in switch statement
+
+Without this fix, int3472-discrete logs 'GPIO type 0x08 unknown'
+and the sensor may not receive correct power sequencing.
+
+Replaces the Surface Pro 9 workaround which used raw magic numbers
+(0x08, 0x10) with proper named constants.
+
+Patchset: cameras
+---
+ drivers/platform/x86/intel/int3472/discrete.c | 156 +++++++++++++-----
+ 1 file changed, 117 insertions(+), 39 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/int3472/discrete.c b/drivers/platform/x86/intel/int3472/discrete.c
+index fee7e56..e2562b3 100644
+--- a/drivers/platform/x86/intel/int3472/discrete.c
++++ b/drivers/platform/x86/intel/int3472/discrete.c
+@@ -5,18 +5,18 @@
+ #include <linux/array_size.h>
+ #include <linux/bitfield.h>
+ #include <linux/device.h>
++#include <linux/dmi.h>
+ #include <linux/gpio/consumer.h>
+ #include <linux/gpio/machine.h>
+ #include <linux/i2c.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/overflow.h>
++#include <linux/platform_data/x86/int3472.h>
+ #include <linux/platform_device.h>
+ #include <linux/string_choices.h>
+ #include <linux/uuid.h>
+ 
+-#include "common.h"
+-
+ /*
+  * 79234640-9e10-4fea-a5c1-b5aa8b19756f
+  * This _DSM GUID returns information about the GPIO lines mapped to a
+@@ -56,7 +56,7 @@ static void skl_int3472_log_sensor_module_name(struct int3472_discrete_device *i
+ 
+ static int skl_int3472_fill_gpiod_lookup(struct gpiod_lookup *table_entry,
+ 					 struct acpi_resource_gpio *agpio,
+-					 const char *func, unsigned long gpio_flags)
++					 const char *con_id, unsigned long gpio_flags)
+ {
+ 	char *path = agpio->resource_source.string_ptr;
+ 	struct acpi_device *adev;
+@@ -71,24 +71,26 @@ static int skl_int3472_fill_gpiod_lookup(struct gpiod_lookup *table_entry,
+ 	if (!adev)
+ 		return -ENODEV;
+ 
+-	*table_entry = GPIO_LOOKUP(acpi_dev_name(adev), agpio->pin_table[0], func, gpio_flags);
++	*table_entry = GPIO_LOOKUP(acpi_dev_name(adev), agpio->pin_table[0], con_id, gpio_flags);
+ 
+ 	return 0;
+ }
+ 
+ static int skl_int3472_map_gpio_to_sensor(struct int3472_discrete_device *int3472,
+ 					  struct acpi_resource_gpio *agpio,
+-					  const char *func, unsigned long gpio_flags)
++					  const char *con_id, unsigned long gpio_flags)
+ {
+ 	int ret;
+ 
++	dev_info(int3472->dev, "Mapping GPIO pin %d to sensor as %s (sensor gpio %d/%d)\n",
++         	agpio->pin_table[0], con_id, int3472->n_sensor_gpios, INT3472_MAX_SENSOR_GPIOS);
+ 	if (int3472->n_sensor_gpios >= INT3472_MAX_SENSOR_GPIOS) {
+ 		dev_warn(int3472->dev, "Too many GPIOs mapped\n");
+ 		return -EINVAL;
+ 	}
+ 
+ 	ret = skl_int3472_fill_gpiod_lookup(&int3472->gpios.table[int3472->n_sensor_gpios],
+-					    agpio, func, gpio_flags);
++					    agpio, con_id, gpio_flags);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -101,23 +103,23 @@ static int skl_int3472_map_gpio_to_sensor(struct int3472_discrete_device *int347
+ static struct gpio_desc *
+ skl_int3472_gpiod_get_from_temp_lookup(struct int3472_discrete_device *int3472,
+ 				       struct acpi_resource_gpio *agpio,
+-				       const char *func, unsigned long gpio_flags)
++				       const char *con_id, unsigned long gpio_flags)
+ {
+ 	struct gpio_desc *desc;
+ 	int ret;
+ 
+ 	struct gpiod_lookup_table *lookup __free(kfree) =
+-			kzalloc(struct_size(lookup, table, 2), GFP_KERNEL);
++			kzalloc_flex(*lookup, table, 2);
+ 	if (!lookup)
+ 		return ERR_PTR(-ENOMEM);
+ 
+ 	lookup->dev_id = dev_name(int3472->dev);
+-	ret = skl_int3472_fill_gpiod_lookup(&lookup->table[0], agpio, func, gpio_flags);
++	ret = skl_int3472_fill_gpiod_lookup(&lookup->table[0], agpio, con_id, gpio_flags);
+ 	if (ret)
+ 		return ERR_PTR(ret);
+ 
+ 	gpiod_add_lookup_table(lookup);
+-	desc = devm_gpiod_get(int3472->dev, func, GPIOD_OUT_LOW);
++	desc = gpiod_get(int3472->dev, con_id, GPIOD_OUT_LOW);
+ 	gpiod_remove_lookup_table(lookup);
+ 
+ 	return desc;
+@@ -129,7 +131,8 @@ skl_int3472_gpiod_get_from_temp_lookup(struct int3472_discrete_device *int3472,
+  * @hid: The ACPI HID of the device without the instance number e.g. INT347E
+  * @type_from: The GPIO type from ACPI ?SDT
+  * @type_to: The assigned GPIO type, typically same as @type_from
+- * @func: The function, e.g. "enable"
++ * @enable_time_us: Enable time in usec for GPIOs mapped to regulators
++ * @con_id: The name of the GPIO for the device
+  * @polarity_low: GPIO_ACTIVE_LOW true if the @polarity_low is true,
+  * GPIO_ACTIVE_HIGH otherwise
+  */
+@@ -138,16 +141,38 @@ struct int3472_gpio_map {
+ 	u8 type_from;
+ 	u8 type_to;
+ 	bool polarity_low;
+-	const char *func;
++	unsigned int enable_time_us;
++	const char *con_id;
+ };
+ 
+ static const struct int3472_gpio_map int3472_gpio_map[] = {
+-	{ "INT347E", INT3472_GPIO_TYPE_RESET, INT3472_GPIO_TYPE_RESET, false, "enable" },
++	{	/* mt9m114 designs declare a powerdown pin which controls the regulators */
++		.hid = "INT33F0",
++		.type_from = INT3472_GPIO_TYPE_POWERDOWN,
++		.type_to = INT3472_GPIO_TYPE_POWER_ENABLE,
++		.con_id = "vdd",
++		.enable_time_us = GPIO_REGULATOR_ENABLE_TIME,
++	},
++	{	/* ov7251 driver / DT-bindings expect "enable" as con_id for reset */
++		.hid = "INT347E",
++		.type_from = INT3472_GPIO_TYPE_RESET,
++		.type_to = INT3472_GPIO_TYPE_RESET,
++		.con_id = "enable",
++	},
++	{	/* ov08x40's handshake pin needs a 45 ms delay on some HP laptops */
++		.hid = "OVTI08F4",
++		.type_from = INT3472_GPIO_TYPE_HANDSHAKE,
++		.type_to = INT3472_GPIO_TYPE_HANDSHAKE,
++		.con_id = "dvdd",
++		.enable_time_us = 45 * USEC_PER_MSEC,
++	},
+ };
+ 
+-static void int3472_get_func_and_polarity(struct acpi_device *adev, u8 *type,
+-					  const char **func, unsigned long *gpio_flags)
++static void int3472_get_con_id_and_polarity(struct int3472_discrete_device *int3472, u8 *type,
++					    const char **con_id, unsigned long *gpio_flags,
++					    unsigned int *enable_time_us)
+ {
++	struct acpi_device *adev = int3472->sensor;
+ 	unsigned int i;
+ 
+ 	for (i = 0; i < ARRAY_SIZE(int3472_gpio_map); i++) {
+@@ -162,40 +187,60 @@ static void int3472_get_func_and_polarity(struct acpi_device *adev, u8 *type,
+ 		if (!acpi_dev_hid_uid_match(adev, int3472_gpio_map[i].hid, NULL))
+ 			continue;
+ 
++		dev_dbg(int3472->dev, "mapping type 0x%02x pin to 0x%02x %s\n",
++			*type, int3472_gpio_map[i].type_to, int3472_gpio_map[i].con_id);
++
+ 		*type = int3472_gpio_map[i].type_to;
+ 		*gpio_flags = int3472_gpio_map[i].polarity_low ?
+ 			      GPIO_ACTIVE_LOW : GPIO_ACTIVE_HIGH;
+-		*func = int3472_gpio_map[i].func;
++		*con_id = int3472_gpio_map[i].con_id;
++		*enable_time_us = int3472_gpio_map[i].enable_time_us;
+ 		return;
+ 	}
+ 
++	*enable_time_us = GPIO_REGULATOR_ENABLE_TIME;
++
+ 	switch (*type) {
+ 	case INT3472_GPIO_TYPE_RESET:
+-		*func = "reset";
++		*con_id = "reset";
+ 		*gpio_flags = GPIO_ACTIVE_LOW;
+ 		break;
+ 	case INT3472_GPIO_TYPE_POWERDOWN:
+-		*func = "powerdown";
++		*con_id = "powerdown";
+ 		*gpio_flags = GPIO_ACTIVE_LOW;
+ 		break;
+ 	case INT3472_GPIO_TYPE_CLK_ENABLE:
+-		*func = "clk-enable";
++		*con_id = "clk-enable";
+ 		*gpio_flags = GPIO_ACTIVE_HIGH;
+ 		break;
+ 	case INT3472_GPIO_TYPE_PRIVACY_LED:
+-		*func = "privacy-led";
++		*con_id = "privacy-led";
++		*gpio_flags = GPIO_ACTIVE_HIGH;
++		break;
++	case INT3472_GPIO_TYPE_HOTPLUG_DETECT:
++		*con_id = "hpd";
+ 		*gpio_flags = GPIO_ACTIVE_HIGH;
+ 		break;
+ 	case INT3472_GPIO_TYPE_POWER_ENABLE:
+-		*func = "power-enable";
++		*con_id = "avdd";
++		*gpio_flags = GPIO_ACTIVE_HIGH;
++		break;
++	case INT3472_GPIO_TYPE_DVDD:
++		*con_id = "dvdd2";
++		*gpio_flags = GPIO_ACTIVE_HIGH;
++		break;
++	case INT3472_GPIO_TYPE_DOVDD:
++		*con_id = "dovdd";
+ 		*gpio_flags = GPIO_ACTIVE_HIGH;
+ 		break;
+ 	case INT3472_GPIO_TYPE_HANDSHAKE:
+-		*func = "handshake";
++		*con_id = "dvdd";
+ 		*gpio_flags = GPIO_ACTIVE_HIGH;
++		/* Setups using a handshake pin need 25 ms enable delay */
++		*enable_time_us = 25 * USEC_PER_MSEC;
+ 		break;
+ 	default:
+-		*func = "unknown";
++		*con_id = "unknown";
+ 		*gpio_flags = GPIO_ACTIVE_HIGH;
+ 		break;
+ 	}
+@@ -216,6 +261,8 @@ static void int3472_get_func_and_polarity(struct acpi_device *adev, u8 *type,
+  * 0x0b Power enable
+  * 0x0c Clock enable
+  * 0x0d Privacy LED
++ * 0x10 DOVDD (digital I/O voltage)
++ * 0x13 Hotplug detect
+  *
+  * There are some known platform specific quirks where that does not quite
+  * hold up; for example where a pin with type 0x01 (Power down) is mapped to
+@@ -237,13 +284,15 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
+ 					     void *data)
+ {
+ 	struct int3472_discrete_device *int3472 = data;
++	const char *second_sensor = NULL;
+ 	struct acpi_resource_gpio *agpio;
++	unsigned int enable_time_us;
+ 	u8 active_value, pin, type;
++	unsigned long gpio_flags;
+ 	union acpi_object *obj;
+ 	struct gpio_desc *gpio;
+ 	const char *err_msg;
+-	const char *func;
+-	unsigned long gpio_flags;
++	const char *con_id;
+ 	int ret;
+ 
+ 	if (!acpi_gpio_get_io_resource(ares, &agpio))
+@@ -266,27 +315,28 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
+ 
+ 	type = FIELD_GET(INT3472_GPIO_DSM_TYPE, obj->integer.value);
+ 
+-	int3472_get_func_and_polarity(int3472->sensor, &type, &func, &gpio_flags);
+-
++	int3472_get_con_id_and_polarity(int3472, &type, &con_id, &gpio_flags, &enable_time_us);
++	dev_info(int3472->dev, "Processing GPIO pin %d type 0x%02x con_id %s\n",
++        	agpio->pin_table[0], type, con_id);
+ 	pin = FIELD_GET(INT3472_GPIO_DSM_PIN, obj->integer.value);
+ 	/* Pin field is not really used under Windows and wraps around at 8 bits */
+ 	if (pin != (agpio->pin_table[0] & 0xff))
+ 		dev_dbg(int3472->dev, FW_BUG "%s %s pin number mismatch _DSM %d resource %d\n",
+-			func, agpio->resource_source.string_ptr, pin, agpio->pin_table[0]);
++			con_id, agpio->resource_source.string_ptr, pin, agpio->pin_table[0]);
+ 
+ 	active_value = FIELD_GET(INT3472_GPIO_DSM_SENSOR_ON_VAL, obj->integer.value);
+ 	if (!active_value)
+ 		gpio_flags ^= GPIO_ACTIVE_LOW;
+ 
+-	dev_dbg(int3472->dev, "%s %s pin %d active-%s\n", func,
++	dev_dbg(int3472->dev, "%s %s pin %d active-%s\n", con_id,
+ 		agpio->resource_source.string_ptr, agpio->pin_table[0],
+ 		str_high_low(gpio_flags == GPIO_ACTIVE_HIGH));
+ 
+ 	switch (type) {
+ 	case INT3472_GPIO_TYPE_RESET:
+ 	case INT3472_GPIO_TYPE_POWERDOWN:
+-	case INT3472_GPIO_TYPE_HANDSHAKE:
+-		ret = skl_int3472_map_gpio_to_sensor(int3472, agpio, func, gpio_flags);
++	case INT3472_GPIO_TYPE_HOTPLUG_DETECT:
++		ret = skl_int3472_map_gpio_to_sensor(int3472, agpio, con_id, gpio_flags);
+ 		if (ret)
+ 			err_msg = "Failed to map GPIO pin to sensor\n";
+ 
+@@ -294,7 +344,10 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
+ 	case INT3472_GPIO_TYPE_CLK_ENABLE:
+ 	case INT3472_GPIO_TYPE_PRIVACY_LED:
+ 	case INT3472_GPIO_TYPE_POWER_ENABLE:
+-		gpio = skl_int3472_gpiod_get_from_temp_lookup(int3472, agpio, func, gpio_flags);
++	case INT3472_GPIO_TYPE_DVDD:
++	case INT3472_GPIO_TYPE_DOVDD:
++	case INT3472_GPIO_TYPE_HANDSHAKE:
++		gpio = skl_int3472_gpiod_get_from_temp_lookup(int3472, agpio, con_id, gpio_flags);
+ 		if (IS_ERR(gpio)) {
+ 			ret = PTR_ERR(gpio);
+ 			err_msg = "Failed to get GPIO\n";
+@@ -315,15 +368,25 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
+ 
+ 			break;
+ 		case INT3472_GPIO_TYPE_POWER_ENABLE:
+-			ret = skl_int3472_register_regulator(int3472, gpio);
++			second_sensor = int3472->quirks.avdd_second_sensor;
++			fallthrough;
++		case INT3472_GPIO_TYPE_DVDD:
++		case INT3472_GPIO_TYPE_DOVDD:
++		case INT3472_GPIO_TYPE_HANDSHAKE:
++			ret = skl_int3472_register_regulator(int3472, gpio, enable_time_us,
++							     con_id, second_sensor);
+ 			if (ret)
+-				err_msg = "Failed to map regulator to sensor\n";
++				err_msg = "Failed to register regulator\n";
+ 
+ 			break;
+ 		default: /* Never reached */
+ 			ret = -EINVAL;
+ 			break;
+ 		}
++
++		if (ret)
++			gpiod_put(gpio);
++
+ 		break;
+ 	default:
+ 		dev_warn(int3472->dev,
+@@ -343,7 +406,7 @@ static int skl_int3472_handle_gpio_resources(struct acpi_resource *ares,
+ 	return 1;
+ }
+ 
+-static int skl_int3472_parse_crs(struct int3472_discrete_device *int3472)
++int int3472_discrete_parse_crs(struct int3472_discrete_device *int3472)
+ {
+ 	LIST_HEAD(resource_list);
+ 	int ret;
+@@ -368,28 +431,39 @@ static int skl_int3472_parse_crs(struct int3472_discrete_device *int3472)
+ 
+ 	return 0;
+ }
++EXPORT_SYMBOL_NS_GPL(int3472_discrete_parse_crs, "INTEL_INT3472_DISCRETE");
+ 
+-static void skl_int3472_discrete_remove(struct platform_device *pdev)
++void int3472_discrete_cleanup(struct int3472_discrete_device *int3472)
+ {
+-	struct int3472_discrete_device *int3472 = platform_get_drvdata(pdev);
+-
+ 	gpiod_remove_lookup_table(&int3472->gpios);
+ 
+ 	skl_int3472_unregister_clock(int3472);
+ 	skl_int3472_unregister_pled(int3472);
+ 	skl_int3472_unregister_regulator(int3472);
+ }
++EXPORT_SYMBOL_NS_GPL(int3472_discrete_cleanup, "INTEL_INT3472_DISCRETE");
++
++static void skl_int3472_discrete_remove(struct platform_device *pdev)
++{
++	int3472_discrete_cleanup(platform_get_drvdata(pdev));
++}
+ 
+ static int skl_int3472_discrete_probe(struct platform_device *pdev)
+ {
+ 	struct acpi_device *adev = ACPI_COMPANION(&pdev->dev);
++	const struct int3472_discrete_quirks *quirks = NULL;
+ 	struct int3472_discrete_device *int3472;
++	const struct dmi_system_id *id;
+ 	struct int3472_cldb cldb;
+ 	int ret;
+ 
+ 	if (!adev)
+ 		return -ENODEV;
+ 
++	id = dmi_first_match(skl_int3472_discrete_quirks);
++	if (id)
++		quirks = id->driver_data;
++
+ 	ret = skl_int3472_fill_cldb(adev, &cldb);
+ 	if (ret) {
+ 		dev_err(&pdev->dev, "Couldn't fill CLDB structure\n");
+@@ -413,6 +487,9 @@ static int skl_int3472_discrete_probe(struct platform_device *pdev)
+ 	platform_set_drvdata(pdev, int3472);
+ 	int3472->clock.imgclk_index = cldb.clock_source;
+ 
++	if (quirks)
++		int3472->quirks = *quirks;
++
+ 	ret = skl_int3472_get_sensor_adev_and_name(&pdev->dev, &int3472->sensor,
+ 						   &int3472->sensor_name);
+ 	if (ret)
+@@ -424,7 +501,7 @@ static int skl_int3472_discrete_probe(struct platform_device *pdev)
+ 	 */
+ 	INIT_LIST_HEAD(&int3472->gpios.list);
+ 
+-	ret = skl_int3472_parse_crs(int3472);
++	ret = int3472_discrete_parse_crs(int3472);
+ 	if (ret) {
+ 		skl_int3472_discrete_remove(pdev);
+ 		return ret;
+@@ -453,3 +530,4 @@ module_platform_driver(int3472_discrete);
+ MODULE_DESCRIPTION("Intel SkyLake INT3472 ACPI Discrete Device Driver");
+ MODULE_AUTHOR("Daniel Scally <djrscally@gmail.com>");
+ MODULE_LICENSE("GPL v2");
++MODULE_IMPORT_NS("INTEL_INT3472");
+-- 
+2.53.0
+
+
+From 856ae2750ccc39b53ee4cd98e77ffb5ff1c9ef10 Mon Sep 17 00:00:00 2001
+From: "D.J. Mulder" <djmulder@example.com>
+Date: Fri, 29 May 2026 15:29:38 +0200
+Subject: [PATCH 4/5] platform/x86: int3472: Mark clock critical and regulators
+ always-on for SP10
+
+On Microsoft Surface Pro 10, the INT3472 clock and regulators must
+remain active across probe sequences to avoid camera sensor failures:
+
+- Add CLK_IS_CRITICAL flag to prevent the clock framework from
+  disabling the sensor clock during probe/reprobe cycles
+- Set boot_on and always_on constraints on regulators to ensure
+  power rails are maintained during device_reprobe()
+
+Without these changes, the OV13858 rear camera fails to probe when
+device_reprobe() is called after ipu-bridge attaches the fwnode,
+as the clock and power rails are disabled between probe attempts.
+
+Patchset: cameras
+---
+ .../x86/intel/int3472/clk_and_regulator.c     | 176 ++++++------------
+ 1 file changed, 60 insertions(+), 116 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/int3472/clk_and_regulator.c b/drivers/platform/x86/intel/int3472/clk_and_regulator.c
+index 16e36ac..3f280ef 100644
+--- a/drivers/platform/x86/intel/int3472/clk_and_regulator.c
++++ b/drivers/platform/x86/intel/int3472/clk_and_regulator.c
+@@ -5,13 +5,11 @@
+ #include <linux/clkdev.h>
+ #include <linux/clk-provider.h>
+ #include <linux/device.h>
+-#include <linux/dmi.h>
+ #include <linux/gpio/consumer.h>
++#include <linux/platform_data/x86/int3472.h>
+ #include <linux/regulator/driver.h>
+ #include <linux/slab.h>
+ 
+-#include "common.h"
+-
+ /*
+  * 82c0d13a-78c5-4244-9bb1-eb8b539a8d11
+  * This _DSM GUID allows controlling the sensor clk when it is not controlled
+@@ -118,21 +116,15 @@ static const struct clk_ops skl_int3472_clock_ops = {
+ 	.recalc_rate = skl_int3472_clk_recalc_rate,
+ };
+ 
+-int skl_int3472_register_dsm_clock(struct int3472_discrete_device *int3472)
++static int skl_int3472_register_clock(struct int3472_discrete_device *int3472)
+ {
+ 	struct acpi_device *adev = int3472->adev;
+ 	struct clk_init_data init = {
+-		.ops = &skl_int3472_clock_ops,
+-		.flags = CLK_GET_RATE_NOCACHE,
++  	  .ops = &skl_int3472_clock_ops,
++    	  .flags = CLK_GET_RATE_NOCACHE | CLK_IS_CRITICAL,
+ 	};
+ 	int ret;
+ 
+-	if (int3472->clock.cl)
+-		return 0; /* A GPIO controlled clk has already been registered */
+-
+-	if (!acpi_check_dsm(adev->handle, &img_clk_guid, 0, BIT(1)))
+-		return 0; /* DSM clock control is not available */
+-
+ 	init.name = kasprintf(GFP_KERNEL, "%s-clk", acpi_dev_name(adev));
+ 	if (!init.name)
+ 		return -ENOMEM;
+@@ -161,51 +153,26 @@ out_free_init_name:
+ 	return ret;
+ }
+ 
++int skl_int3472_register_dsm_clock(struct int3472_discrete_device *int3472)
++{
++	if (int3472->clock.cl)
++		return 0; /* A GPIO controlled clk has already been registered */
++
++	if (!acpi_check_dsm(int3472->adev->handle, &img_clk_guid, 0, BIT(1)))
++		return 0; /* DSM clock control is not available */
++
++	return skl_int3472_register_clock(int3472);
++}
++
+ int skl_int3472_register_gpio_clock(struct int3472_discrete_device *int3472,
+ 				    struct gpio_desc *gpio)
+ {
+-	struct clk_init_data init = {
+-		.ops = &skl_int3472_clock_ops,
+-		.flags = CLK_GET_RATE_NOCACHE,
+-	};
+-	int ret;
+-
+ 	if (int3472->clock.cl)
+ 		return -EBUSY;
+ 
+ 	int3472->clock.ena_gpio = gpio;
+ 
+-	init.name = kasprintf(GFP_KERNEL, "%s-clk",
+-			      acpi_dev_name(int3472->adev));
+-	if (!init.name)
+-		return -ENOMEM;
+-
+-	int3472->clock.frequency = skl_int3472_get_clk_frequency(int3472);
+-
+-	int3472->clock.clk_hw.init = &init;
+-	int3472->clock.clk = clk_register(&int3472->adev->dev,
+-					  &int3472->clock.clk_hw);
+-	if (IS_ERR(int3472->clock.clk)) {
+-		ret = PTR_ERR(int3472->clock.clk);
+-		goto out_free_init_name;
+-	}
+-
+-	int3472->clock.cl = clkdev_create(int3472->clock.clk, NULL,
+-					  int3472->sensor_name);
+-	if (!int3472->clock.cl) {
+-		ret = -ENOMEM;
+-		goto err_unregister_clk;
+-	}
+-
+-	kfree(init.name);
+-	return 0;
+-
+-err_unregister_clk:
+-	clk_unregister(int3472->clock.clk);
+-out_free_init_name:
+-	kfree(init.name);
+-
+-	return ret;
++	return skl_int3472_register_clock(int3472);
+ }
+ 
+ void skl_int3472_unregister_clock(struct int3472_discrete_device *int3472)
+@@ -215,100 +182,77 @@ void skl_int3472_unregister_clock(struct int3472_discrete_device *int3472)
+ 
+ 	clkdev_drop(int3472->clock.cl);
+ 	clk_unregister(int3472->clock.clk);
++	gpiod_put(int3472->clock.ena_gpio);
+ }
+ 
+-/*
+- * The INT3472 device is going to be the only supplier of a regulator for
+- * the sensor device. But unlike the clk framework the regulator framework
+- * does not allow matching by consumer-device-name only.
+- *
+- * Ideally all sensor drivers would use "avdd" as supply-id. But for drivers
+- * where this cannot be changed because another supply-id is already used in
+- * e.g. DeviceTree files an alias for the other supply-id can be added here.
+- *
+- * Do not forget to update GPIO_REGULATOR_SUPPLY_MAP_COUNT when changing this.
+- */
+-static const char * const skl_int3472_regulator_map_supplies[] = {
+-	"avdd",
+-	"AVDD",
+-};
+-
+-static_assert(ARRAY_SIZE(skl_int3472_regulator_map_supplies) ==
+-	      GPIO_REGULATOR_SUPPLY_MAP_COUNT);
+-
+-/*
+- * On some models there is a single GPIO regulator which is shared between
+- * sensors and only listed in the ACPI resources of one sensor.
+- * This DMI table contains the name of the second sensor. This is used to add
+- * entries for the second sensor to the supply_map.
+- */
+-static const struct dmi_system_id skl_int3472_regulator_second_sensor[] = {
+-	{
+-		/* Lenovo Miix 510-12IKB */
+-		.matches = {
+-			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+-			DMI_MATCH(DMI_PRODUCT_VERSION, "MIIX 510-12IKB"),
+-		},
+-		.driver_data = "i2c-OVTI2680:00",
+-	},
+-	{ }
+-};
+-
+ int skl_int3472_register_regulator(struct int3472_discrete_device *int3472,
+-				   struct gpio_desc *gpio)
++				   struct gpio_desc *gpio,
++				   unsigned int enable_time,
++				   const char *supply_name,
++				   const char *second_sensor)
+ {
+ 	struct regulator_init_data init_data = { };
++	struct int3472_gpio_regulator *regulator;
+ 	struct regulator_config cfg = { };
+-	const char *second_sensor = NULL;
+-	const struct dmi_system_id *id;
+ 	int i, j;
+ 
+-	id = dmi_first_match(skl_int3472_regulator_second_sensor);
+-	if (id)
+-		second_sensor = id->driver_data;
++	if (int3472->n_regulator_gpios >= INT3472_MAX_REGULATORS) {
++		dev_err(int3472->dev, "Too many regulators mapped\n");
++		return -EINVAL;
++	}
+ 
+-	for (i = 0, j = 0; i < ARRAY_SIZE(skl_int3472_regulator_map_supplies); i++) {
+-		int3472->regulator.supply_map[j].supply = skl_int3472_regulator_map_supplies[i];
+-		int3472->regulator.supply_map[j].dev_name = int3472->sensor_name;
++	if (strlen(supply_name) >= GPIO_SUPPLY_NAME_LENGTH) {
++		dev_err(int3472->dev, "supply-name '%s' length too long\n", supply_name);
++		return -E2BIG;
++	}
++
++	regulator = &int3472->regulators[int3472->n_regulator_gpios];
++	string_upper(regulator->supply_name_upper, supply_name);
++
++	/* The below code assume that map-count is 2 (upper- and lower-case) */
++	static_assert(GPIO_REGULATOR_SUPPLY_MAP_COUNT == 2);
++
++	for (i = 0, j = 0; i < GPIO_REGULATOR_SUPPLY_MAP_COUNT; i++) {
++		const char *supply = i ? regulator->supply_name_upper : supply_name;
++
++		regulator->supply_map[j].supply = supply;
++		regulator->supply_map[j].dev_name = int3472->sensor_name;
+ 		j++;
+ 
+ 		if (second_sensor) {
+-			int3472->regulator.supply_map[j].supply =
+-				skl_int3472_regulator_map_supplies[i];
+-			int3472->regulator.supply_map[j].dev_name = second_sensor;
++			regulator->supply_map[j].supply = supply;
++			regulator->supply_map[j].dev_name = second_sensor;
+ 			j++;
+ 		}
+ 	}
+ 
+ 	init_data.constraints.valid_ops_mask = REGULATOR_CHANGE_STATUS;
+-	init_data.consumer_supplies = int3472->regulator.supply_map;
++	init_data.constraints.boot_on = 1;
++	init_data.constraints.always_on = 1;
++	init_data.consumer_supplies = regulator->supply_map;
+ 	init_data.num_consumer_supplies = j;
+ 
+-	snprintf(int3472->regulator.regulator_name,
+-		 sizeof(int3472->regulator.regulator_name), "%s-regulator",
+-		 acpi_dev_name(int3472->adev));
+-	snprintf(int3472->regulator.supply_name,
+-		 GPIO_REGULATOR_SUPPLY_NAME_LENGTH, "supply-0");
+-
+-	int3472->regulator.rdesc = INT3472_REGULATOR(
+-						int3472->regulator.regulator_name,
+-						int3472->regulator.supply_name,
+-						&int3472_gpio_regulator_ops);
++	snprintf(regulator->regulator_name, sizeof(regulator->regulator_name), "%s-%s",
++		 acpi_dev_name(int3472->adev), supply_name);
+ 
+-	int3472->regulator.gpio = gpio;
++	regulator->rdesc = INT3472_REGULATOR(regulator->regulator_name,
++					     &int3472_gpio_regulator_ops,
++					     enable_time, GPIO_REGULATOR_OFF_ON_DELAY);
+ 
+ 	cfg.dev = &int3472->adev->dev;
+ 	cfg.init_data = &init_data;
+-	cfg.ena_gpiod = int3472->regulator.gpio;
++	cfg.ena_gpiod = gpio;
+ 
+-	int3472->regulator.rdev = regulator_register(int3472->dev,
+-						     &int3472->regulator.rdesc,
+-						     &cfg);
++	regulator->rdev = regulator_register(int3472->dev, &regulator->rdesc, &cfg);
++	if (IS_ERR(regulator->rdev))
++		return PTR_ERR(regulator->rdev);
+ 
+-	return PTR_ERR_OR_ZERO(int3472->regulator.rdev);
++	int3472->n_regulator_gpios++;
++	return 0;
+ }
+ 
+ void skl_int3472_unregister_regulator(struct int3472_discrete_device *int3472)
+ {
+-	regulator_unregister(int3472->regulator.rdev);
++	for (int i = 0; i < int3472->n_regulator_gpios; i++)
++		regulator_unregister(int3472->regulators[i].rdev);
+ }
+-- 
+2.53.0
+
+
+From 07977dd74206fd7459896f6fe144f2e0e5f9b5eb Mon Sep 17 00:00:00 2001
+From: "D.J. Mulder" <djmulder@example.com>
+Date: Fri, 29 May 2026 15:30:00 +0200
+Subject: [PATCH 5/5] media: i2c: ov13858: Add reset GPIO handling for Surface
+ Pro 10
+
+The OV13858 rear camera on Microsoft Surface Pro 10 requires explicit
+reset GPIO toggling during probe to bring the sensor out of hardware
+reset before register access is attempted.
+
+- Add reset GPIO acquisition via devm_gpiod_get_optional()
+- Toggle reset high for 20ms then low with 50ms stabilisation delay
+- Enable clock before reset sequence as required by sensor datasheet
+- Add linux/gpio/consumer.h and linux/delay.h includes
+
+Without this fix the sensor remains in reset and all I2C register
+reads return 0xFF, causing probe to fail with -EIO on chip ID check.
+
+Patchset: cameras
+---
+ drivers/media/i2c/ov13858.c | 94 +++++++++++++++++++++++++------------
+ 1 file changed, 63 insertions(+), 31 deletions(-)
+
+diff --git a/drivers/media/i2c/ov13858.c b/drivers/media/i2c/ov13858.c
+index 7a3fc1d..f4e8493 100644
+--- a/drivers/media/i2c/ov13858.c
++++ b/drivers/media/i2c/ov13858.c
+@@ -2,9 +2,12 @@
+ // Copyright (c) 2017 Intel Corporation.
+ 
+ #include <linux/acpi.h>
++#include <linux/clk.h>
++#include <linux/delay.h>
+ #include <linux/i2c.h>
+ #include <linux/module.h>
+ #include <linux/pm_runtime.h>
++#include <linux/gpio/consumer.h>
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-event.h>
+@@ -1028,6 +1031,10 @@ static const struct ov13858_mode supported_modes[] = {
+ };
+ 
+ struct ov13858 {
++	struct device *dev;
++	struct clk *clk;
++        struct gpio_desc *reset_gpio;
++
+ 	struct v4l2_subdev sd;
+ 	struct media_pad pad;
+ 
+@@ -1117,7 +1124,6 @@ static int ov13858_write_reg(struct ov13858 *ov13858, u16 reg, u32 len,
+ static int ov13858_write_regs(struct ov13858 *ov13858,
+ 			      const struct ov13858_reg *regs, u32 len)
+ {
+-	struct i2c_client *client = v4l2_get_subdevdata(&ov13858->sd);
+ 	int ret;
+ 	u32 i;
+ 
+@@ -1126,7 +1132,7 @@ static int ov13858_write_regs(struct ov13858 *ov13858,
+ 					regs[i].val);
+ 		if (ret) {
+ 			dev_err_ratelimited(
+-				&client->dev,
++				ov13858->dev,
+ 				"Failed to write reg 0x%4.4x. error = %d\n",
+ 				regs[i].address, ret);
+ 
+@@ -1209,7 +1215,6 @@ static int ov13858_set_ctrl(struct v4l2_ctrl *ctrl)
+ {
+ 	struct ov13858 *ov13858 = container_of(ctrl->handler,
+ 					       struct ov13858, ctrl_handler);
+-	struct i2c_client *client = v4l2_get_subdevdata(&ov13858->sd);
+ 	s64 max;
+ 	int ret;
+ 
+@@ -1228,7 +1233,7 @@ static int ov13858_set_ctrl(struct v4l2_ctrl *ctrl)
+ 	 * Applying V4L2 control value only happens
+ 	 * when power is up for streaming
+ 	 */
+-	if (!pm_runtime_get_if_in_use(&client->dev))
++	if (!pm_runtime_get_if_in_use(ov13858->dev))
+ 		return 0;
+ 
+ 	ret = 0;
+@@ -1256,13 +1261,13 @@ static int ov13858_set_ctrl(struct v4l2_ctrl *ctrl)
+ 		ret = ov13858_enable_test_pattern(ov13858, ctrl->val);
+ 		break;
+ 	default:
+-		dev_info(&client->dev,
++		dev_info(ov13858->dev,
+ 			 "ctrl(id:0x%x,val:0x%x) is not handled\n",
+ 			 ctrl->id, ctrl->val);
+ 		break;
+ 	}
+ 
+-	pm_runtime_put(&client->dev);
++	pm_runtime_put(ov13858->dev);
+ 
+ 	return ret;
+ }
+@@ -1408,7 +1413,6 @@ static int ov13858_get_skip_frames(struct v4l2_subdev *sd, u32 *frames)
+ /* Start streaming */
+ static int ov13858_start_streaming(struct ov13858 *ov13858)
+ {
+-	struct i2c_client *client = v4l2_get_subdevdata(&ov13858->sd);
+ 	const struct ov13858_reg_list *reg_list;
+ 	int ret, link_freq_index;
+ 
+@@ -1416,7 +1420,7 @@ static int ov13858_start_streaming(struct ov13858 *ov13858)
+ 	ret = ov13858_write_reg(ov13858, OV13858_REG_SOFTWARE_RST,
+ 				OV13858_REG_VALUE_08BIT, OV13858_SOFTWARE_RST);
+ 	if (ret) {
+-		dev_err(&client->dev, "%s failed to set powerup registers\n",
++		dev_err(ov13858->dev, "%s failed to set powerup registers\n",
+ 			__func__);
+ 		return ret;
+ 	}
+@@ -1426,7 +1430,7 @@ static int ov13858_start_streaming(struct ov13858 *ov13858)
+ 	reg_list = &link_freq_configs[link_freq_index].reg_list;
+ 	ret = ov13858_write_reg_list(ov13858, reg_list);
+ 	if (ret) {
+-		dev_err(&client->dev, "%s failed to set plls\n", __func__);
++		dev_err(ov13858->dev, "%s failed to set plls\n", __func__);
+ 		return ret;
+ 	}
+ 
+@@ -1434,7 +1438,7 @@ static int ov13858_start_streaming(struct ov13858 *ov13858)
+ 	reg_list = &ov13858->cur_mode->reg_list;
+ 	ret = ov13858_write_reg_list(ov13858, reg_list);
+ 	if (ret) {
+-		dev_err(&client->dev, "%s failed to set mode\n", __func__);
++		dev_err(ov13858->dev, "%s failed to set mode\n", __func__);
+ 		return ret;
+ 	}
+ 
+@@ -1458,13 +1462,12 @@ static int ov13858_stop_streaming(struct ov13858 *ov13858)
+ static int ov13858_set_stream(struct v4l2_subdev *sd, int enable)
+ {
+ 	struct ov13858 *ov13858 = to_ov13858(sd);
+-	struct i2c_client *client = v4l2_get_subdevdata(sd);
+ 	int ret = 0;
+ 
+ 	mutex_lock(&ov13858->mutex);
+ 
+ 	if (enable) {
+-		ret = pm_runtime_resume_and_get(&client->dev);
++		ret = pm_runtime_resume_and_get(ov13858->dev);
+ 		if (ret < 0)
+ 			goto err_unlock;
+ 
+@@ -1477,7 +1480,7 @@ static int ov13858_set_stream(struct v4l2_subdev *sd, int enable)
+ 			goto err_rpm_put;
+ 	} else {
+ 		ov13858_stop_streaming(ov13858);
+-		pm_runtime_put(&client->dev);
++		pm_runtime_put(ov13858->dev);
+ 	}
+ 
+ 	mutex_unlock(&ov13858->mutex);
+@@ -1485,7 +1488,7 @@ static int ov13858_set_stream(struct v4l2_subdev *sd, int enable)
+ 	return ret;
+ 
+ err_rpm_put:
+-	pm_runtime_put(&client->dev);
++	pm_runtime_put(ov13858->dev);
+ err_unlock:
+ 	mutex_unlock(&ov13858->mutex);
+ 
+@@ -1495,7 +1498,6 @@ err_unlock:
+ /* Verify chip ID */
+ static int ov13858_identify_module(struct ov13858 *ov13858)
+ {
+-	struct i2c_client *client = v4l2_get_subdevdata(&ov13858->sd);
+ 	int ret;
+ 	u32 val;
+ 
+@@ -1505,7 +1507,7 @@ static int ov13858_identify_module(struct ov13858 *ov13858)
+ 		return ret;
+ 
+ 	if (val != OV13858_CHIP_ID) {
+-		dev_err(&client->dev, "chip id mismatch: %x!=%x\n",
++		dev_err(ov13858->dev, "chip id mismatch: %x!=%x\n",
+ 			OV13858_CHIP_ID, val);
+ 		return -EIO;
+ 	}
+@@ -1552,7 +1554,6 @@ static const struct v4l2_subdev_internal_ops ov13858_internal_ops = {
+ /* Initialize control handlers */
+ static int ov13858_init_controls(struct ov13858 *ov13858)
+ {
+-	struct i2c_client *client = v4l2_get_subdevdata(&ov13858->sd);
+ 	struct v4l2_fwnode_device_properties props;
+ 	struct v4l2_ctrl_handler *ctrl_hdlr;
+ 	s64 exposure_max;
+@@ -1626,12 +1627,12 @@ static int ov13858_init_controls(struct ov13858 *ov13858)
+ 				     0, 0, ov13858_test_pattern_menu);
+ 	if (ctrl_hdlr->error) {
+ 		ret = ctrl_hdlr->error;
+-		dev_err(&client->dev, "%s control init failed (%d)\n",
++		dev_err(ov13858->dev, "%s control init failed (%d)\n",
+ 			__func__, ret);
+ 		goto error;
+ 	}
+ 
+-	ret = v4l2_fwnode_device_parse(&client->dev, &props);
++	ret = v4l2_fwnode_device_parse(ov13858->dev, &props);
+ 	if (ret)
+ 		goto error;
+ 
+@@ -1660,24 +1661,55 @@ static void ov13858_free_controls(struct ov13858 *ov13858)
+ static int ov13858_probe(struct i2c_client *client)
+ {
+ 	struct ov13858 *ov13858;
++	unsigned long freq;
+ 	int ret;
+-	u32 val = 0;
+-
+-	device_property_read_u32(&client->dev, "clock-frequency", &val);
+-	if (val != 19200000)
+-		return -EINVAL;
+ 
+ 	ov13858 = devm_kzalloc(&client->dev, sizeof(*ov13858), GFP_KERNEL);
+ 	if (!ov13858)
+ 		return -ENOMEM;
+ 
++	ov13858->dev = &client->dev;
++
++	ov13858->clk = devm_v4l2_sensor_clk_get(ov13858->dev, NULL);
++	if (IS_ERR(ov13858->clk))
++		return dev_err_probe(ov13858->dev, PTR_ERR(ov13858->clk),
++				     "failed to get clock\n");
++
++	freq = clk_get_rate(ov13858->clk);
++	if (freq != 19200000)
++		return dev_err_probe(ov13858->dev, -EINVAL,
++				     "external clock %lu is not supported\n",
++				     freq);
++
++	/* Enable clock before reset sequence */
++	ret = clk_prepare_enable(ov13858->clk);
++	if (ret)
++		return dev_err_probe(ov13858->dev, ret, "failed to enable clock\n");
++
++	/* Take sensor out of reset */
++	ov13858->reset_gpio = devm_gpiod_get_optional(ov13858->dev, "reset", GPIOD_OUT_HIGH);
++	dev_info(ov13858->dev, "reset_gpio = %p, IS_ERR=%d\n",
++		 ov13858->reset_gpio, IS_ERR(ov13858->reset_gpio));
++	if (IS_ERR(ov13858->reset_gpio))
++		return dev_err_probe(ov13858->dev, PTR_ERR(ov13858->reset_gpio),
++				     "failed to get reset GPIO\n");
++	if (ov13858->reset_gpio) {
++		dev_info(ov13858->dev, "Toggling reset GPIO\n");
++		gpiod_set_value_cansleep(ov13858->reset_gpio, 1);
++		msleep(20);
++		gpiod_set_value_cansleep(ov13858->reset_gpio, 0);
++		msleep(50);
++	} else {
++		dev_info(ov13858->dev, "No reset GPIO found\n");
++	}
++
+ 	/* Initialize subdev */
+ 	v4l2_i2c_subdev_init(&ov13858->sd, client, &ov13858_subdev_ops);
+ 
+ 	/* Check module identity */
+ 	ret = ov13858_identify_module(ov13858);
+ 	if (ret) {
+-		dev_err(&client->dev, "failed to find sensor: %d\n", ret);
++		dev_err(ov13858->dev, "failed to find sensor: %d\n", ret);
+ 		return ret;
+ 	}
+ 
+@@ -1699,7 +1731,7 @@ static int ov13858_probe(struct i2c_client *client)
+ 	ov13858->pad.flags = MEDIA_PAD_FL_SOURCE;
+ 	ret = media_entity_pads_init(&ov13858->sd.entity, 1, &ov13858->pad);
+ 	if (ret) {
+-		dev_err(&client->dev, "%s failed:%d\n", __func__, ret);
++		dev_err(ov13858->dev, "%s failed:%d\n", __func__, ret);
+ 		goto error_handler_free;
+ 	}
+ 
+@@ -1711,9 +1743,9 @@ static int ov13858_probe(struct i2c_client *client)
+ 	 * Device is already turned on by i2c-core with ACPI domain PM.
+ 	 * Enable runtime PM and turn off the device.
+ 	 */
+-	pm_runtime_set_active(&client->dev);
+-	pm_runtime_enable(&client->dev);
+-	pm_runtime_idle(&client->dev);
++	pm_runtime_set_active(ov13858->dev);
++	pm_runtime_enable(ov13858->dev);
++	pm_runtime_idle(ov13858->dev);
+ 
+ 	return 0;
+ 
+@@ -1722,7 +1754,7 @@ error_media_entity:
+ 
+ error_handler_free:
+ 	ov13858_free_controls(ov13858);
+-	dev_err(&client->dev, "%s failed:%d\n", __func__, ret);
++	dev_err(ov13858->dev, "%s failed:%d\n", __func__, ret);
+ 
+ 	return ret;
+ }
+@@ -1736,7 +1768,7 @@ static void ov13858_remove(struct i2c_client *client)
+ 	media_entity_cleanup(&sd->entity);
+ 	ov13858_free_controls(ov13858);
+ 
+-	pm_runtime_disable(&client->dev);
++	pm_runtime_disable(ov13858->dev);
+ }
+ 
+ static const struct i2c_device_id ov13858_id_table[] = {
+-- 
+2.53.0
+

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1062,6 +1062,13 @@ index f5456330b..3418ff475 100644
 +		},
 +		.driver_data = "OVTID858",
 +	},
++	{
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "Surface Pro 10 for Business"),
++		},
++		.driver_data = "SONY0681",
++	},
  	{} /* Terminating entry */
  };
  
@@ -1700,6 +1707,11 @@ new file mode 100644
 +	}
 +
 +	if (val != IMX681_CHIP_ID) {
++		/* If sensor returns 0, it's not powered yet — defer probe */
++		if (val == 0) {
++			dev_dbg(imx681->dev, "chip ID 0x0000, sensor not ready, deferring\n");
++			return -EPROBE_DEFER;
++		}
 +		dev_err(imx681->dev, "chip ID mismatch: 0x%04llx != 0x%04x\n",
 +			val, IMX681_CHIP_ID);
 +		return -EIO;
@@ -2119,9 +2131,12 @@ index a986e30..3aaea3b 100644
  {
 +	const struct dmi_system_id *dmi_id;
 +
-+	dmi_id = dmi_first_match(upside_down_sensor_dmi_ids);
-+	if (dmi_id && acpi_dev_hid_match(adev, dmi_id->driver_data))
-+		return 180;
++	for (dmi_id = upside_down_sensor_dmi_ids; dmi_id->matches[0].slot; dmi_id++) {
++		if (dmi_match(dmi_id->matches[0].slot, dmi_id->matches[0].substr) &&
++		    dmi_match(dmi_id->matches[1].slot, dmi_id->matches[1].substr) &&
++		    acpi_dev_hid_match(adev, dmi_id->driver_data))
++			return 180;
++	}
 +
  	switch (ssdb->degree) {
  	case IPU_SENSOR_ROTATION_NORMAL:
@@ -2133,8 +2148,7 @@ index a986e30..3aaea3b 100644
 -					sensor->prop_names.bus_type,
 -					V4L2_FWNODE_BUS_TYPE_CSI2_DPHY);
 +				sensor->prop_names.bus_type,
-+				cfg->cphy ? V4L2_FWNODE_BUS_TYPE_CSI2_CPHY :
-+					    V4L2_FWNODE_BUS_TYPE_CSI2_DPHY);
++				V4L2_FWNODE_BUS_TYPE_CSI2_DPHY);
  	sensor->ep_properties[1] = PROPERTY_ENTRY_U32_ARRAY_LEN(
  					sensor->prop_names.data_lanes,
  					bridge->data_lanes, sensor->lanes);
@@ -2251,6 +2265,9 @@ index fee7e56..b0c8da3 100644
  #include <linux/module.h>
  #include <linux/overflow.h>
 +#include <linux/platform_data/x86/int3472.h>
++
++/* GPIO type 0x08 = DVDD, not yet in upstream int3472.h */
++#define INT3472_GPIO_TYPE_DVDD 0x08
  #include <linux/platform_device.h>
  #include <linux/string_choices.h>
  #include <linux/uuid.h>

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1229,14 +1229,14 @@ new file mode 100644
 +	{ CCI_REG16(0x033E), 0x0C69 },
 +	/* Frame length = 3177 — CCS-standard register (was 0, sensor may use this for MIPI timing) */
 +	{ CCI_REG16(0x0340), 0x0C69 }, /* Frame length = 3177 */
-+	/* Crop window start: X_ADD_STA[7:0]=100, Y_ADD_STA=256 */
++	/* Crop window start: X_ADD_STA=100, Y_ADD_STA=256 */
 +	{ CCI_REG24(0x0345), 0x640100 },
-+	/* Crop window end: X_ADD_END[7:0]=103, Y_ADD_END=2895 */
-+	{ CCI_REG24(0x0349), 0x670B4F }, /* Crop window end: X_ADD_END[7:0]=103, Y_ADD_END=2895 */
++	/* Crop window end: X_ADD_END=3943, Y_ADD_END=2895 */
++	{ CCI_REG24(0x0349), 0x670B4F }, /* Crop window end: X_ADD_END=3943, Y_ADD_END=2895 */
 +	/* Digital crop / vendor config */
 +	/* Digital crop: explicit write of all 8 registers to known-good values */
 +	{ CCI_REG8(0x0408),  0x03 }, /* DIG_CROP_X_OFFSET high = 0x03 */
-+	{ CCI_REG8(0x0409),  0xC2 }, /* DIG_CROP_X_OFFSET low = 0xC2 (962 = center crop) */
++	{ CCI_REG8(0x0409),  0xC2 }, /* DIG_CROP_X_OFFSET low = 0xC2 (962 = center) */
 +	{ CCI_REG8(0x040A),  0x00 }, /* DIG_CROP_Y_OFFSET high = 0 */
 +	{ CCI_REG8(0x040B),  0x00 }, /* DIG_CROP_Y_OFFSET low  = 0 */
 +	{ CCI_REG8(0x040C),  0x07 }, /* DIG_CROP_WIDTH high = 0x07 */
@@ -1247,7 +1247,7 @@ new file mode 100644
 +	{ CCI_REG8(0x0900),  0x01 }, /* BINNING_MODE = 1 (enable) */
 +	{ CCI_REG8(0x0901),  0x22 }, /* BINNING_TYPE = 0x22 (2x2) */
 +	/* X_OUTPUT_SIZE=3844, Y_OUTPUT_SIZE=2640 */
-+	{ CCI_REG32(0x034C), 0x07800528 }, /* X_OUTPUT_SIZE=1920, Y=1320 (2x2 binned) */
++	{ CCI_REG32(0x034C), 0x07800528 }, /* X_OUTPUT_SIZE=1920, Y=1320 */
 +	/* PLL multiplier = 225 */
 +	{ CCI_REG8(0x0307),  0x77 },
 +	/* PLL2: pre_div=3, multiplier=303 (0x012F) */

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1055,6 +1055,13 @@ index f5456330b..3418ff475 100644
 +		},
 +		.driver_data = "OVTI5693",
 +	},
++	{
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "Surface Pro 10 for Business"),
++		},
++		.driver_data = "OVTID858",
++	},
  	{} /* Terminating entry */
  };
  

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1216,7 +1216,7 @@ new file mode 100644
 +	/* CSI lane mode: 2 lanes */
 +	{ CCI_REG8(0x0114),  0x01 },
 +	/* Image orientation: H-flip to match Windows AIQB (RGGB native → GRBG) */
-+	{ CCI_REG8(0x0101),  0x03 },
++	{ CCI_REG8(0x0101),  0x01 },
 +	/* Vendor access unlock sequence */
 +	{ CCI_REG8(0x30EB),  0x05 },
 +	{ CCI_REG8(0x30EB),  0x0C },
@@ -1235,8 +1235,8 @@ new file mode 100644
 +	{ CCI_REG24(0x0349), 0x670B4F }, /* Crop window end: X_ADD_END[7:0]=103, Y_ADD_END=2895 */
 +	/* Digital crop / vendor config */
 +	/* Digital crop: explicit write of all 8 registers to known-good values */
-+	{ CCI_REG8(0x0408),  0x00 }, /* DIG_CROP_X_OFFSET high = 0 */
-+	{ CCI_REG8(0x0409),  0x00 }, /* DIG_CROP_X_OFFSET low  = 0 */
++	{ CCI_REG8(0x0408),  0x03 }, /* DIG_CROP_X_OFFSET high = 0x03 */
++	{ CCI_REG8(0x0409),  0xC2 }, /* DIG_CROP_X_OFFSET low = 0xC2 (962 = center crop) */
 +	{ CCI_REG8(0x040A),  0x00 }, /* DIG_CROP_Y_OFFSET high = 0 */
 +	{ CCI_REG8(0x040B),  0x00 }, /* DIG_CROP_Y_OFFSET low  = 0 */
 +	{ CCI_REG8(0x040C),  0x07 }, /* DIG_CROP_WIDTH high = 0x07 */
@@ -1253,7 +1253,7 @@ new file mode 100644
 +	/* PLL2: pre_div=3, multiplier=303 (0x012F) */
 +	{ CCI_REG24(0x030D), 0x030077 },
 +	/* Frame duration initial */
-+	{ CCI_REG16(0x022A), 0x01F4 },
++	{ CCI_REG16(0x022A), 0x05DC },
 +	/* Vendor specific registers */
 +	{ CCI_REG8(0x7E9B),  0x02 },
 +	{ CCI_REG8(0x0368),  0x00 },
@@ -1267,8 +1267,8 @@ new file mode 100644
 +static const struct cci_reg_sequence imx681_first_exposure[] = {
 +	{ CCI_REG8(0x0104),  0x01 },		/* Group hold ON */
 +	{ CCI_REG24(0x033D), 0x000C69 },	/* Frame length = 3177 */
-+	{ CCI_REG24(0x0229), 0x0001F4 },	/* Exposure = 500 lines */
-+	{ CCI_REG16(0x0204), 0x0020 },		/* Analog gain = 32 (low) */
++	{ CCI_REG24(0x0229), 0x0005DC },	/* Exposure = 1500 lines */
++	{ CCI_REG16(0x0204), 0x0080 },		/* Analog gain = 128 */
 +	{ CCI_REG16(0x020E), 0x0400 },		/* Digital gain = 4.0x */
 +	{ CCI_REG8(0x0104),  0x00 },		/* Group hold OFF */
 +};
@@ -1282,7 +1282,7 @@ new file mode 100644
 +};
 +
 +static const u32 imx681_mbus_codes[] = {
-+	MEDIA_BUS_FMT_SRGGB10_1X10,
++	MEDIA_BUS_FMT_SGRBG10_1X10,
 +};
 +
 +/* Regulator supplies */
@@ -1464,7 +1464,7 @@ new file mode 100644
 +	format = v4l2_subdev_state_get_format(state, IMAGE_PAD);
 +	format->width = IMX681_WIDTH;
 +	format->height = IMX681_HEIGHT;
-+	format->code = MEDIA_BUS_FMT_SRGGB10_1X10;
++	format->code = MEDIA_BUS_FMT_SGRBG10_1X10;
 +	format->field = V4L2_FIELD_NONE;
 +	format->colorspace = V4L2_COLORSPACE_RAW;
 +	format->ycbcr_enc = V4L2_YCBCR_ENC_601;

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1103,7 +1103,7 @@ diff --git a/drivers/media/i2c/imx681.c b/drivers/media/i2c/imx681.c
 new file mode 100644
 --- /dev/null
 +++ b/drivers/media/i2c/imx681.c
-@@ -0,0 +1,918 @@
+@@ -0,0 +1,920 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Sony IMX681 CMOS Image Sensor Driver
@@ -1167,7 +1167,7 @@ new file mode 100644
 +
 +/* Image dimensions — native sensor output */
 +#define IMX681_WIDTH			1920
-+#define IMX681_HEIGHT			1320
++#define IMX681_HEIGHT			1136
 +#define IMX681_LINE_LENGTH_PCK		7552	/* 0x1D80 */
 +#define IMX681_FRAME_LENGTH_LINES	3177	/* 0x0C69 */
 +#define IMX681_FRAME_LENGTH_MAX		0xFFFF	/* 24-bit reg, limit to 16-bit */
@@ -1216,7 +1216,7 @@ new file mode 100644
 +	/* CSI lane mode: 2 lanes */
 +	{ CCI_REG8(0x0114),  0x01 },
 +	/* Image orientation: H-flip to match Windows AIQB (RGGB native → GRBG) */
-+	{ CCI_REG8(0x0101),  0x01 },
++	{ CCI_REG8(0x0101),  0x03 },
 +	/* Vendor access unlock sequence */
 +	{ CCI_REG8(0x30EB),  0x05 },
 +	{ CCI_REG8(0x30EB),  0x0C },
@@ -1228,35 +1228,34 @@ new file mode 100644
 +	/* Frame length = 3177 — Sony vendor register */
 +	{ CCI_REG16(0x033E), 0x0C69 },
 +	/* Frame length = 3177 — CCS-standard register (was 0, sensor may use this for MIPI timing) */
-+	{ CCI_REG16(0x0340), 0x0C69 }, /* Frame length = 3177 */
 +	/* Crop window start: X_ADD_STA=100, Y_ADD_STA=256 */
-+	{ CCI_REG24(0x0345), 0x640100 },
++	{ CCI_REG24(0x0345), 0x640178 },
 +	/* Crop window end: X_ADD_END=3943, Y_ADD_END=2895 */
-+	{ CCI_REG24(0x0349), 0x670B4F }, /* Crop window end: X_ADD_END=3943, Y_ADD_END=2895 */
++	{ CCI_REG24(0x0349), 0x670A57 }, /* Crop window end: X_ADD_END=3943, Y_ADD_END=2895 */
 +	/* Digital crop / vendor config */
 +	/* Digital crop: explicit write of all 8 registers to known-good values */
-+	{ CCI_REG8(0x0408),  0x00 }, /* DIG_CROP_X_OFFSET high = 0 */
-+	{ CCI_REG8(0x0409),  0x01 }, /* DIG_CROP_X_OFFSET low = 1 (center 1922→1920) */
++	{ CCI_REG8(0x0408),  0x03 }, /* DIG_CROP_X_OFFSET high = 0x03 */
++	{ CCI_REG8(0x0409),  0xC2 }, /* DIG_CROP_X_OFFSET low = 0xC2 (962 center) */
 +	{ CCI_REG8(0x040A),  0x00 }, /* DIG_CROP_Y_OFFSET high = 0 */
 +	{ CCI_REG8(0x040B),  0x00 }, /* DIG_CROP_Y_OFFSET low  = 0 */
 +	{ CCI_REG8(0x040C),  0x07 }, /* DIG_CROP_WIDTH high = 0x07 */
 +	{ CCI_REG8(0x040D),  0x80 }, /* DIG_CROP_WIDTH low = 0x80 (1920) */
-+	{ CCI_REG8(0x040E),  0x05 }, /* DIG_CROP_HEIGHT high = 0x05 */
-+	{ CCI_REG8(0x040F),  0x28 }, /* DIG_CROP_HEIGHT low = 0x28 (1320) */
++	{ CCI_REG8(0x040E),  0x04 }, /* DIG_CROP_HEIGHT high = 0x04 */
++	{ CCI_REG8(0x040F),  0x70 }, /* DIG_CROP_HEIGHT low = 0x70 (1136) */
 +	/* 2x2 binning */
 +	{ CCI_REG8(0x0900),  0x01 }, /* BINNING_MODE = 1 (enable) */
 +	{ CCI_REG8(0x0901),  0x22 }, /* BINNING_TYPE = 0x22 (2x2) */
-+	{ CCI_REG8(0x0401),  0x01 }, /* SCALE_MODE = 1 (enabled) */
-+	{ CCI_REG16(0x0404), 0x0020 }, /* SCALE_M = 32 (16/32 = 0.5x horizontal) */
++	{ CCI_REG8(0x0401),  0x00 }, /* SCALE_MODE = 0 (disabled — incompatible with v_flip) */
++	{ CCI_REG16(0x0404), 0x0020 }, /* SCALE_M = 32 (0.5x horizontal) */
 +	{ CCI_REG8(0x0902),  0x08 }, /* BINNING_WEIGHTING */
 +	/* X_OUTPUT_SIZE=3844, Y_OUTPUT_SIZE=2640 */
-+	{ CCI_REG32(0x034C), 0x07800528 }, /* X_OUTPUT_SIZE=1920, Y=1320 */
++	{ CCI_REG32(0x034C), 0x07800470 }, /* X_OUTPUT_SIZE=1920, Y=1136 */
 +	/* PLL multiplier = 225 */
 +	{ CCI_REG8(0x0307),  0x77 },
 +	/* PLL2: pre_div=3, multiplier=303 (0x012F) */
 +	{ CCI_REG24(0x030D), 0x030077 },
 +	/* Frame duration initial */
-+	{ CCI_REG16(0x022A), 0x05DC },
++	{ CCI_REG16(0x022A), 0x0C61 },
 +	/* Vendor specific registers */
 +	{ CCI_REG8(0x7E9B),  0x02 },
 +	{ CCI_REG8(0x0368),  0x00 },
@@ -1270,8 +1269,8 @@ new file mode 100644
 +static const struct cci_reg_sequence imx681_first_exposure[] = {
 +	{ CCI_REG8(0x0104),  0x01 },		/* Group hold ON */
 +	{ CCI_REG24(0x033D), 0x000C69 },	/* Frame length = 3177 */
-+	{ CCI_REG24(0x0229), 0x0005DC },	/* Exposure = 1500 lines */
-+	{ CCI_REG16(0x0204), 0x0080 },		/* Analog gain = 128 */
++	{ CCI_REG24(0x0229), 0x000C61 },	/* Exposure = 3169 lines */
++	{ CCI_REG16(0x0204), 0x0060 },		/* Analog gain = 96 */
 +	{ CCI_REG16(0x020E), 0x0400 },		/* Digital gain = 4.0x */
 +	{ CCI_REG8(0x0104),  0x00 },		/* Group hold OFF */
 +};
@@ -1285,7 +1284,7 @@ new file mode 100644
 +};
 +
 +static const u32 imx681_mbus_codes[] = {
-+	MEDIA_BUS_FMT_SGRBG10_1X10,
++	MEDIA_BUS_FMT_SBGGR10_1X10,
 +};
 +
 +/* Regulator supplies */
@@ -1467,7 +1466,7 @@ new file mode 100644
 +	format = v4l2_subdev_state_get_format(state, IMAGE_PAD);
 +	format->width = IMX681_WIDTH;
 +	format->height = IMX681_HEIGHT;
-+	format->code = MEDIA_BUS_FMT_SGRBG10_1X10;
++	format->code = MEDIA_BUS_FMT_SBGGR10_1X10;
 +	format->field = V4L2_FIELD_NONE;
 +	format->colorspace = V4L2_COLORSPACE_RAW;
 +	format->ycbcr_enc = V4L2_YCBCR_ENC_601;
@@ -1562,6 +1561,9 @@ new file mode 100644
 +		dev_err(imx681->dev, "failed to start streaming: %d\n", ret);
 +		return ret;
 +	}
++	/* CCS FLL must be written separately after streaming when v_flip is active */
++	cci_write(imx681->cci, CCI_REG16(0x0340), 3177, NULL);
++	msleep(50);
 +	return 0;
 +}
 +

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1103,7 +1103,7 @@ diff --git a/drivers/media/i2c/imx681.c b/drivers/media/i2c/imx681.c
 new file mode 100644
 --- /dev/null
 +++ b/drivers/media/i2c/imx681.c
-@@ -0,0 +1,920 @@
+@@ -0,0 +1,917 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Sony IMX681 CMOS Image Sensor Driver
@@ -1522,8 +1522,6 @@ new file mode 100644
 +{
 +	int ret;
 +
-+	dev_info(imx681->dev, "starting stream: %dx%d RAW10 2-lane\n",
-+		IMX681_WIDTH, IMX681_HEIGHT);
 +
 +	/* Write init register sequence */
 +	ret = cci_multi_reg_write(imx681->cci, imx681_init_regs,
@@ -1596,7 +1594,6 @@ new file mode 100644
 +	}
 +
 +	ret = imx681_start_streaming(imx681);
-+	dev_info(sd->dev, "start_streaming returned %d\n", ret);
 +	if (ret)
 +		pm_runtime_put_autosuspend(imx681->dev);
 +

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1101,15 +1101,14 @@ Patchset: cameras
 
 diff --git a/drivers/media/i2c/imx681.c b/drivers/media/i2c/imx681.c
 new file mode 100644
-index 0000000..0459085
 --- /dev/null
 +++ b/drivers/media/i2c/imx681.c
-@@ -0,0 +1,895 @@
+@@ -0,0 +1,1073 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Sony IMX681 CMOS Image Sensor Driver
 + *
-+ * Front camera on Surface Pro 10 (Intel/Meteor Lake) and Surface Pro 11 (Intel/Lunar Lake).
++ * Front camera on Surface Pro 11 Business (Intel/Lunar Lake).
 + * Register sequences reverse-engineered from Windows I2C traces.
 + *
 + * Copyright (C) 2025
@@ -1167,8 +1166,8 @@ index 0000000..0459085
 +#define IMX681_REG_FRAME_LENGTH		CCI_REG24(0x033D)
 +
 +/* Image dimensions — native sensor output */
-+#define IMX681_WIDTH			3844
-+#define IMX681_HEIGHT			2640
++#define IMX681_WIDTH			1920
++#define IMX681_HEIGHT			1320
 +#define IMX681_LINE_LENGTH_PCK		7552	/* 0x1D80 */
 +#define IMX681_FRAME_LENGTH_LINES	3177	/* 0x0C69 */
 +#define IMX681_FRAME_LENGTH_MAX		0xFFFF	/* 24-bit reg, limit to 16-bit */
@@ -1211,9 +1210,13 @@ index 0000000..0459085
 +	/* Vendor specific configuration */
 +	{ CCI_REG16(0x002C), 0x0505 },
 +	/* CSI-2 signaling mode */
-+	{ CCI_REG8(0x0111),  0x02 },
++	{ CCI_REG8(0x0111),  0x02 }, /* CSI-2 D-PHY signalling mode */
++	/* CSI data format: RAW10 */
++	{ CCI_REG16(0x0112), 0x0A0A },
++	/* CSI lane mode: 2 lanes */
++	{ CCI_REG8(0x0114),  0x01 },
 +	/* Image orientation: H-flip to match Windows AIQB (RGGB native → GRBG) */
-+	{ CCI_REG8(0x0101),  0x01 },
++	{ CCI_REG8(0x0101),  0x00 },
 +	/* Vendor access unlock sequence */
 +	{ CCI_REG8(0x30EB),  0x05 },
 +	{ CCI_REG8(0x30EB),  0x0C },
@@ -1222,22 +1225,35 @@ index 0000000..0459085
 +	{ CCI_REG16(0x3532), 0xFFFF },
 +	/* LINE_LENGTH_PCK = 7552 */
 +	{ CCI_REG16(0x0342), 0x1D80 },
-+	/* Frame length = 3177 */
++	/* Frame length = 3177 — Sony vendor register */
 +	{ CCI_REG16(0x033E), 0x0C69 },
++	/* Frame length = 3177 — CCS-standard register (was 0, sensor may use this for MIPI timing) */
++	{ CCI_REG16(0x0340), 0x0C69 }, /* Frame length = 3177 */
 +	/* Crop window start: X_ADD_STA[7:0]=100, Y_ADD_STA=256 */
 +	{ CCI_REG24(0x0345), 0x640100 },
 +	/* Crop window end: X_ADD_END[7:0]=103, Y_ADD_END=2895 */
-+	{ CCI_REG24(0x0349), 0x670B4F },
++	{ CCI_REG24(0x0349), 0x670B4F }, /* Crop window end: X_ADD_END[7:0]=103, Y_ADD_END=2895 */
 +	/* Digital crop / vendor config */
-+	{ CCI_REG24(0x040D), 0x040A50 },
++	/* Digital crop: explicit write of all 8 registers to known-good values */
++	{ CCI_REG8(0x0408),  0x00 }, /* DIG_CROP_X_OFFSET high = 0 */
++	{ CCI_REG8(0x0409),  0x00 }, /* DIG_CROP_X_OFFSET low  = 0 */
++	{ CCI_REG8(0x040A),  0x00 }, /* DIG_CROP_Y_OFFSET high = 0 */
++	{ CCI_REG8(0x040B),  0x00 }, /* DIG_CROP_Y_OFFSET low  = 0 */
++	{ CCI_REG8(0x040C),  0x07 }, /* DIG_CROP_WIDTH high = 0x07 */
++	{ CCI_REG8(0x040D),  0x80 }, /* DIG_CROP_WIDTH low = 0x80 (1920) */
++	{ CCI_REG8(0x040E),  0x05 }, /* DIG_CROP_HEIGHT high = 0x05 */
++	{ CCI_REG8(0x040F),  0x28 }, /* DIG_CROP_HEIGHT low = 0x28 (1320) */
++	/* 2x2 binning */
++	{ CCI_REG8(0x0900),  0x01 }, /* BINNING_MODE = 1 (enable) */
++	{ CCI_REG8(0x0901),  0x22 }, /* BINNING_TYPE = 0x22 (2x2) */
 +	/* X_OUTPUT_SIZE=3844, Y_OUTPUT_SIZE=2640 */
-+	{ CCI_REG32(0x034C), 0x0F040A50 },
++	{ CCI_REG32(0x034C), 0x07800528 }, /* X_OUTPUT_SIZE=1920, Y=1320 (2x2 binned) */
 +	/* PLL multiplier = 225 */
 +	{ CCI_REG8(0x0307),  0x77 },
 +	/* PLL2: pre_div=3, multiplier=303 (0x012F) */
 +	{ CCI_REG24(0x030D), 0x030077 },
 +	/* Frame duration initial */
-+	{ CCI_REG16(0x022A), 0x0C61 },
++	{ CCI_REG16(0x022A), 0x01F4 },
 +	/* Vendor specific registers */
 +	{ CCI_REG8(0x7E9B),  0x02 },
 +	{ CCI_REG8(0x0368),  0x00 },
@@ -1251,9 +1267,9 @@ index 0000000..0459085
 +static const struct cci_reg_sequence imx681_first_exposure[] = {
 +	{ CCI_REG8(0x0104),  0x01 },		/* Group hold ON */
 +	{ CCI_REG24(0x033D), 0x000C69 },	/* Frame length = 3177 */
-+	{ CCI_REG24(0x0229), 0x000773 },	/* Exposure = 1907 lines */
-+	{ CCI_REG16(0x0204), 0x0000 },		/* Analog gain = 0 (1x) */
-+	{ CCI_REG16(0x020E), 0x0100 },		/* Digital gain = 1.0x */
++	{ CCI_REG24(0x0229), 0x0001F4 },	/* Exposure = 500 lines */
++	{ CCI_REG16(0x0204), 0x0020 },		/* Analog gain = 32 (low) */
++	{ CCI_REG16(0x020E), 0x0400 },		/* Digital gain = 4.0x */
 +	{ CCI_REG8(0x0104),  0x00 },		/* Group hold OFF */
 +};
 +
@@ -1266,7 +1282,7 @@ index 0000000..0459085
 +};
 +
 +static const u32 imx681_mbus_codes[] = {
-+	MEDIA_BUS_FMT_SGRBG10_1X10,
++	MEDIA_BUS_FMT_SRGGB10_1X10,
 +};
 +
 +/* Regulator supplies */
@@ -1448,7 +1464,7 @@ index 0000000..0459085
 +	format = v4l2_subdev_state_get_format(state, IMAGE_PAD);
 +	format->width = IMX681_WIDTH;
 +	format->height = IMX681_HEIGHT;
-+	format->code = MEDIA_BUS_FMT_SGRBG10_1X10;
++	format->code = MEDIA_BUS_FMT_SRGGB10_1X10;
 +	format->field = V4L2_FIELD_NONE;
 +	format->colorspace = V4L2_COLORSPACE_RAW;
 +	format->ycbcr_enc = V4L2_YCBCR_ENC_601;
@@ -1504,6 +1520,8 @@ index 0000000..0459085
 +{
 +	int ret;
 +
++	dev_info(imx681->dev, "starting stream: %dx%d RAW10 2-lane\n",
++		IMX681_WIDTH, IMX681_HEIGHT);
 +
 +	/* Write init register sequence */
 +	ret = cci_multi_reg_write(imx681->cci, imx681_init_regs,
@@ -1514,6 +1532,72 @@ index 0000000..0459085
 +	}
 +
 +	dev_dbg(imx681->dev, "init registers written successfully\n");
++
++	/* DIAGNOSTIC: read CHIP_ID, CSI mode, and all frame geometry registers */
++	{
++		u64 id_msb = 0, id_lsb = 0, csi_mode = 0;
++		u64 y_sta_h = 0, y_sta_l = 0, y_end_h = 0, y_end_l = 0;
++		u64 x_out_h = 0, x_out_l = 0, y_out_h = 0, y_out_l = 0, fll_h = 0, fll_l = 0;
++		u64 llp_h = 0, llp_l = 0;
++		u64 dc_w_h = 0, dc_w_l = 0, dc_h_h = 0, dc_h_l = 0;
++		u64 v300a_h = 0, v300a_l = 0, v3532_h = 0, v3532_l = 0;
++		u64 reg0368_h = 0, reg0368_l = 0;
++		int rc;
++		rc  = cci_read(imx681->cci, CCI_REG8(0x0016), &id_msb, NULL);
++		rc |= cci_read(imx681->cci, CCI_REG8(0x0017), &id_lsb, NULL);
++		rc |= cci_read(imx681->cci, CCI_REG8(0x0111), &csi_mode, NULL);
++		dev_info(imx681->dev, "imx681 CHIP_ID=0x%02llx%02llx CSI_SIGNALLING_MODE=0x%02llx (rc=%d)\n",
++			 id_msb, id_lsb, csi_mode, rc);
++		/* Frame geometry readback */
++		cci_read(imx681->cci, CCI_REG8(0x0346), &y_sta_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0347), &y_sta_l, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x034A), &y_end_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x034B), &y_end_l, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x034C), &x_out_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x034D), &x_out_l, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x034E), &y_out_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x034F), &y_out_l, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0340), &fll_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0341), &fll_l, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0342), &llp_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0343), &llp_l, NULL);
++		dev_info(imx681->dev,
++			 "imx681 Y_ADDR_START=0x%02llx%02llx Y_ADDR_END=0x%02llx%02llx X_OUT=0x%02llx%02llx Y_OUT=0x%02llx%02llx FLL=0x%02llx%02llx LLP=0x%02llx%02llx\n",
++			 y_sta_h, y_sta_l, y_end_h, y_end_l,
++			 x_out_h, x_out_l, y_out_h, y_out_l, fll_h, fll_l, llp_h, llp_l);
++		/* Digital crop registers */
++		u64 dc_y_off_h = 0, dc_y_off_l = 0;
++		cci_read(imx681->cci, CCI_REG8(0x040A), &dc_y_off_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x040B), &dc_y_off_l, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x040C), &dc_w_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x040D), &dc_w_l, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x040E), &dc_h_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x040F), &dc_h_l, NULL);
++		u64 d00=0, d01=0, d02=0, d03=0, d04=0, d05=0, d06=0, d07=0;
++		cci_read(imx681->cci, CCI_REG8(0x0D00), &d00, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0D01), &d01, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0D02), &d02, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0D03), &d03, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0D04), &d04, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0D05), &d05, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0D06), &d06, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0D07), &d07, NULL);
++		dev_info(imx681->dev,
++			 "imx681 0x0D00-07: %02llx %02llx %02llx %02llx %02llx %02llx %02llx %02llx\n",
++			 d00, d01, d02, d03, d04, d05, d06, d07);
++		/* Vendor-specific registers */
++		cci_read(imx681->cci, CCI_REG8(0x300A), &v300a_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x300B), &v300a_l, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x3532), &v3532_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x3533), &v3532_l, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0368), &reg0368_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0369), &reg0368_l, NULL);
++		dev_info(imx681->dev,
++			 "imx681 DIG_CROP_Y_OFF=0x%02llx%02llx DIG_CROP_W=0x%02llx%02llx DIG_CROP_H=0x%02llx%02llx 0x300A=0x%02llx%02llx 0x3532=0x%02llx%02llx 0x0368=0x%02llx%02llx\n",
++			 dc_y_off_h, dc_y_off_l, dc_w_h, dc_w_l, dc_h_h, dc_h_l,
++			 v300a_h, v300a_l, v3532_h, v3532_l,
++			 reg0368_h, reg0368_l);
++	}
 +
 +	/* Wait for sensor to stabilise after configuration */
 +	usleep_range(IMX681_INIT_DELAY_US, IMX681_INIT_DELAY_US + 1000);
@@ -1533,6 +1617,17 @@ index 0000000..0459085
 +		return ret;
 +	}
 +
++	/* FORCE high exposure+gain with group hold, try both 0x0229 and CCS 0x0202 */
++	{
++		int fret = 0;
++		cci_write(imx681->cci, IMX681_REG_GROUP_HOLD, 0x01, NULL);
++		fret |= cci_write(imx681->cci, CCI_REG16(0x0340), 3177, NULL); /* CCS FLL */
++		fret |= cci_write(imx681->cci, IMX681_REG_EXPOSURE, 500, NULL);
++		fret |= cci_write(imx681->cci, IMX681_REG_ANALOG_GAIN, 0x0020, NULL); /* low gain */
++		fret |= cci_write(imx681->cci, IMX681_REG_DIGITAL_GAIN, 0x0100, NULL); /* 1x dgain */
++		cci_write(imx681->cci, IMX681_REG_GROUP_HOLD, 0x00, NULL);
++		dev_info(imx681->dev, "forced FLL=3177 exp=500 gain=0x20 ret=%d\n", fret);
++	}
 +	/* Start streaming */
 +	ret = cci_write(imx681->cci, IMX681_REG_MODE_SELECT,
 +			IMX681_MODE_STREAMING, NULL);
@@ -1541,6 +1636,86 @@ index 0000000..0459085
 +		return ret;
 +	}
 +
++	/* DIAGNOSTIC: read embedded data and MIPI config registers */
++	{
++		u64 ebd_0=0,ebd_1=0,ebd_2=0,ebd_3=0,ebd_4=0,ebd_5=0;
++		u64 r3002=0,r3004=0,r3006=0,r0114=0,r0112=0;
++		cci_read(imx681->cci, CCI_REG8(0x3A00), &ebd_0, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x3A01), &ebd_1, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x3A02), &ebd_2, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x3A03), &ebd_3, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x3A04), &ebd_4, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x3A05), &ebd_5, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x3002), &r3002, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x3004), &r3004, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x3006), &r3006, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0112), &r0112, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0114), &r0114, NULL);
++		dev_info(imx681->dev, "EBD: 0x3A00-05=%02llx %02llx %02llx %02llx %02llx %02llx 0x3002=%02llx 0x3004=%02llx 0x3006=%02llx CSI_DT=0x%02llx LANES=0x%02llx\n",
++			ebd_0,ebd_1,ebd_2,ebd_3,ebd_4,ebd_5,r3002,r3004,r3006,r0112,r0114);
++	}
++	/* DIAGNOSTIC: binning and array geometry */
++	{
++		u64 xas_h=0,xas_l=0,xae_h=0,xae_l=0,bm=0,bt=0,ss_mode=0;
++		cci_read(imx681->cci, CCI_REG8(0x0344), &xas_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0345), &xas_l, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0348), &xae_h, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0349), &xae_l, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0900), &bm, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0901), &bt, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0390), &ss_mode, NULL);
++		dev_info(imx681->dev, "ARRAY: X_START=0x%02llx%02llx X_END=0x%02llx%02llx BINNING_MODE=0x%02llx BINNING_TYPE=0x%02llx SUB_SAMPLE=0x%02llx\n",
++			xas_h,xas_l,xae_h,xae_l,bm,bt,ss_mode);
++	}
++	dev_info(imx681->dev, "streaming started\n");
++
++	/* DIAGNOSTIC: read back exposure/gain registers to verify writes stuck */
++	{
++		u64 exp_hi=0, exp_mid=0, exp_lo=0, gain=0, gain_alt=0, dgain=0;
++		u64 exp_ccs_hi=0, exp_ccs_mid=0;
++		cci_read(imx681->cci, CCI_REG8(0x0229), &exp_hi, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x022A), &exp_mid, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x022B), &exp_lo, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0202), &exp_ccs_hi, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0203), &exp_ccs_mid, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0204), &gain, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x0205), &gain_alt, NULL);
++		cci_read(imx681->cci, CCI_REG8(0x020E), &dgain, NULL);
++		dev_info(imx681->dev,
++			 "regcheck: 0x0229=%02llx%02llx%02llx 0x0202=%02llx%02llx gain=0x%02llx%02llx dgain=0x%02llx\n",
++			 exp_hi, exp_mid, exp_lo, exp_ccs_hi, exp_ccs_mid, gain, gain_alt, dgain);
++		{
++			u64 p0=0,p1=0,p2=0,p3=0,p4=0,p5=0,p6=0,p7=0,p8=0;
++			cci_read(imx681->cci, CCI_REG8(0x0301), &p0, NULL); /* IVTPXCK_DIV */
++			cci_read(imx681->cci, CCI_REG8(0x0303), &p1, NULL); /* IVTSYCK_DIV */
++			cci_read(imx681->cci, CCI_REG8(0x0305), &p2, NULL); /* PREPLLCK_VT_DIV */
++			cci_read(imx681->cci, CCI_REG8(0x0306), &p3, NULL); /* PLL_VT_MPY hi */
++			cci_read(imx681->cci, CCI_REG8(0x0307), &p4, NULL); /* PLL_VT_MPY lo */
++			cci_read(imx681->cci, CCI_REG8(0x030B), &p5, NULL); /* IOPPXCK_DIV */
++			cci_read(imx681->cci, CCI_REG8(0x030D), &p6, NULL); /* PREPLLCK_OP_DIV */
++			cci_read(imx681->cci, CCI_REG8(0x030E), &p7, NULL); /* PLL_OP_MPY hi */
++			cci_read(imx681->cci, CCI_REG8(0x030F), &p8, NULL); /* PLL_OP_MPY lo */
++			dev_info(imx681->dev,
++				 "pll: 0301=%02llx 0303=%02llx 0305=%02llx 0306=%02llx 0307=%02llx 030B=%02llx 030D=%02llx 030E=%02llx 030F=%02llx\n",
++				 p0,p1,p2,p3,p4,p5,p6,p7,p8);
++		}
++	}
++	/* DIAGNOSTIC: confirm streaming command stuck and sensor is emitting frames */
++	{
++		u64 mode = 0, fcnt0 = 0, fcnt1 = 0;
++		int rc;
++		rc = cci_read(imx681->cci, CCI_REG8(0x0100), &mode, NULL);
++		rc |= cci_read(imx681->cci, CCI_REG8(0x0005), &fcnt0, NULL);
++		msleep(200);
++		rc |= cci_read(imx681->cci, CCI_REG8(0x0005), &fcnt1, NULL);
++		msleep(500);
++		{
++			u64 fcnt2 = 0;
++			cci_read(imx681->cci, CCI_REG8(0x0005), &fcnt2, NULL);
++			dev_info(imx681->dev, "imx681 MODE_SEL=0x%02llx FRAME_CNT t=0:0x%02llx t=200ms:0x%02llx t=700ms:0x%02llx (rc=%d)\n",
++				 mode, fcnt0, fcnt1, fcnt2, rc);
++		}
++	}
 +	return 0;
 +}
 +
@@ -1560,6 +1735,7 @@ index 0000000..0459085
 +				 struct v4l2_subdev_state *state,
 +				 u32 pad, u64 streams_mask)
 +{
++	dev_info(sd->dev, "enable_streams called pad=%d mask=0x%llx\n", pad, streams_mask);
 +	struct imx681 *imx681 = to_imx681(sd);
 +	int ret;
 +
@@ -1573,6 +1749,7 @@ index 0000000..0459085
 +	}
 +
 +	ret = imx681_start_streaming(imx681);
++	dev_info(sd->dev, "start_streaming returned %d\n", ret);
 +	if (ret)
 +		pm_runtime_put_autosuspend(imx681->dev);
 +
@@ -1778,7 +1955,7 @@ index 0000000..0459085
 +{
 +	struct fwnode_handle *fwnode = dev_fwnode(imx681->dev);
 +	struct v4l2_fwnode_endpoint bus_cfg = {
-+		.bus_type = V4L2_MBUS_CSI2_CPHY,
++		.bus_type = V4L2_MBUS_CSI2_DPHY,
 +	};
 +	struct fwnode_handle *ep;
 +	int ret;
@@ -1786,14 +1963,14 @@ index 0000000..0459085
 +	ep = fwnode_graph_get_next_endpoint(fwnode, NULL);
 +	if (!ep) {
 +		dev_err(imx681->dev, "no endpoint found in firmware node\n");
-+		return -EPROBE_DEFER;
++		return -ENXIO;
 +	}
 +
 +	ret = v4l2_fwnode_endpoint_alloc_parse(ep, &bus_cfg);
 +	fwnode_handle_put(ep);
 +	if (ret) {
-+		dev_dbg(imx681->dev, "endpoint parse failed (%d), deferring\n", ret);
-+		return EPROBE_DEFER;
++		dev_err(imx681->dev, "failed to parse endpoint: %d\n", ret);
++		return ret;
 +	}
 +
 +	if (bus_cfg.bus.mipi_csi2.num_data_lanes != IMX681_NUM_LANES) {
@@ -2000,33 +2177,6 @@ index 0000000..0459085
 +MODULE_DESCRIPTION("Sony IMX681 CMOS Image Sensor Driver");
 +MODULE_AUTHOR("Andre Gilerson <andre.gilerson@gmail.com>");
 +MODULE_LICENSE("GPL");
--- 
-2.53.0
-
-
-From 6d3417b5fff9e0d6a8aabf260756bf2ae5daa5d1 Mon Sep 17 00:00:00 2001
-From: "D.J. Mulder" <djmulder@example.com>
-Date: Fri, 29 May 2026 15:57:33 +0200
-Subject: [PATCH 2/5] media: ipu-bridge: Add Surface Pro 10 camera sensor
- support
-
-Add sensor table entries and support for cameras on the Microsoft
-Surface Pro 10 (Meteor Lake / IPU6EP-MTL):
-
-- Add SONY0681 (IMX681 front camera) with C-PHY bus type and dual
-  link frequencies (380.8 MHz for SP10/MTL, 969.6 MHz for SP11/LNL)
-- Add OVTID858 (OV13858 rear camera) with 4-lane D-PHY at 540 MHz
-- Add OVTI5675 sensor entry
-- Add device_reprobe() call after fwnode attachment to fix probe
-  ordering race condition
-- Add C-PHY bus type selection via IPU_SENSOR_CONFIG_CPHY macro
-- Add DMI quirk entries for XPS 13 9340 and XPS 14 9440
-
-Patchset: cameras
----
- drivers/media/pci/intel/ipu-bridge.c | 84 ++++++++++++++++++++++++----
- 1 file changed, 74 insertions(+), 10 deletions(-)
-
 diff --git a/drivers/media/pci/intel/ipu-bridge.c b/drivers/media/pci/intel/ipu-bridge.c
 index a986e30..3aaea3b 100644
 --- a/drivers/media/pci/intel/ipu-bridge.c
@@ -2079,7 +2229,7 @@ index a986e30..3aaea3b 100644
 +	/* OmniVision OV13858 - Microsoft Surface Pro 10 rear camera */
 +	IPU_SENSOR_CONFIG("OVTID858", 4, 540000000),
 +	/* Sony IMX681 - Surface Pro 10 */
-+        IPU_SENSOR_CONFIG_CPHY("SONY0681", 1, 380800000),
++        IPU_SENSOR_CONFIG("SONY0681", 1, 380800000),
 +};
 +
 +/*

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1157,7 +1157,7 @@ new file mode 100644
 +/* Analog gain */
 +#define IMX681_REG_ANALOG_GAIN		CCI_REG16(0x0204)
 +#define IMX681_ANA_GAIN_MIN		0
-+#define IMX681_ANA_GAIN_MAX		1020	/* combined analog+digital */
++#define IMX681_ANA_GAIN_MAX		960	/* inverted in set_ctrl: hw=960-logical */
 +#define IMX681_ANA_GAIN_DEFAULT		0
 +
 +/* Digital gain */
@@ -1277,7 +1277,7 @@ new file mode 100644
 +	{ CCI_REG8(0x0104),  0x01 },		/* Group hold ON */
 +	{ CCI_REG24(0x033D), 0x000C69 },	/* Frame length = 3177 */
 +	{ CCI_REG24(0x0229), 0x000C61 },	/* Exposure = 3169 lines */
-+	{ CCI_REG16(0x0204), 0x0060 },		/* Analog gain = 96 */
++	{ CCI_REG16(0x0204), 0x0000 },		/* Analog gain = 0 (hw code 0 = 16x brightest) */
 +	{ CCI_REG16(0x020E), 0x0400 },		/* Digital gain = 4.0x */
 +	{ CCI_REG8(0x0104),  0x00 },		/* Group hold OFF */
 +};
@@ -1372,7 +1372,9 @@ new file mode 100644
 +		 * set analog to max and use digital gain for the rest.
 +		 * Digital gain register: 0x0100 = 1.0x, value = gain * 256.
 +		 */
-+		int ana_code = min(ctrl->val, 960);
++		/* Hardware register is inverted: code 0=16x, code 960=1x.
++		 * Invert so logical 0=1x, logical 960=16x (AGC ramps correctly). */
++		int ana_code = 960 - min(ctrl->val, 960);
 +		int dig_reg = IMX681_DIG_GAIN_MIN; /* 0x0100 = 1.0x */
 +
 +		if (ctrl->val > 960) {

--- a/patches/7.0/0013-cameras.patch
+++ b/patches/7.0/0013-cameras.patch
@@ -1291,7 +1291,7 @@ new file mode 100644
 +};
 +
 +static const u32 imx681_mbus_codes[] = {
-+	MEDIA_BUS_FMT_SBGGR10_1X10,
++	MEDIA_BUS_FMT_SRGGB10_1X10,
 +};
 +
 +/* Regulator supplies */
@@ -1473,7 +1473,7 @@ new file mode 100644
 +	format = v4l2_subdev_state_get_format(state, IMAGE_PAD);
 +	format->width = IMX681_WIDTH;
 +	format->height = IMX681_HEIGHT;
-+	format->code = MEDIA_BUS_FMT_SBGGR10_1X10;
++	format->code = MEDIA_BUS_FMT_SRGGB10_1X10;
 +	format->field = V4L2_FIELD_NONE;
 +	format->colorspace = V4L2_COLORSPACE_RAW;
 +	format->ycbcr_enc = V4L2_YCBCR_ENC_601;
@@ -1698,26 +1698,34 @@ new file mode 100644
 +{
 +	u64 val;
 +	int ret;
++	int tries;
 +
-+	ret = cci_read(imx681->cci, IMX681_REG_CHIP_ID, &val, NULL);
++	for (tries = 0; tries < 5; tries++) {
++		ret = cci_read(imx681->cci, IMX681_REG_CHIP_ID, &val, NULL);
++		if (ret) {
++			dev_warn(imx681->dev,
++				 "chip ID read failed (attempt %d/5): %d\n",
++				 tries + 1, ret);
++			msleep(100);
++			continue;
++		}
++		if (val == IMX681_CHIP_ID)
++			return 0;
++
++		dev_warn(imx681->dev,
++			 "chip ID 0x%04llx != 0x%04x (attempt %d/5), retrying\n",
++			 val, IMX681_CHIP_ID, tries + 1);
++		msleep(100);
++	}
++
++	/* All retries exhausted */
 +	if (ret) {
-+		dev_err(imx681->dev,
-+			"failed to read chip ID register 0x0016: %d\n", ret);
++		dev_err(imx681->dev, "chip ID read failed after 5 attempts: %d\n", ret);
 +		return ret;
 +	}
-+
-+	if (val != IMX681_CHIP_ID) {
-+		/* If sensor returns 0, it's not powered yet — defer probe */
-+		if (val == 0) {
-+			dev_dbg(imx681->dev, "chip ID 0x0000, sensor not ready, deferring\n");
-+			return -EPROBE_DEFER;
-+		}
-+		dev_err(imx681->dev, "chip ID mismatch: 0x%04llx != 0x%04x\n",
-+			val, IMX681_CHIP_ID);
-+		return -EIO;
-+	}
-+
-+	return 0;
++	dev_err(imx681->dev, "chip ID mismatch after 5 attempts: 0x%04llx != 0x%04x\n",
++		val, IMX681_CHIP_ID);
++	return -EPROBE_DEFER;
 +}
 +
 +static int imx681_init_controls(struct imx681 *imx681)

--- a/patches/7.0/0014-amd-gpio.patch
+++ b/patches/7.0/0014-amd-gpio.patch
@@ -1,0 +1,109 @@
+From 2ffa10c995b5823878f9b56f4d5eceb3a87d9cb4 Mon Sep 17 00:00:00 2001
+From: Sachi King <nakato@nakato.io>
+Date: Sat, 29 May 2021 17:47:38 +1000
+Subject: [PATCH] ACPI: Add quirk for Surface Laptop 4 AMD missing irq 7
+ override
+
+This patch is the work of Thomas Gleixner <tglx@linutronix.de> and is
+copied from:
+https://lore.kernel.org/lkml/87lf8ddjqx.ffs@nanos.tec.linutronix.de/
+
+This patch adds a quirk to the ACPI setup to patch in the the irq 7 pin
+setup that is missing in the laptops ACPI table.
+
+This patch was used for validation of the issue, and is not a proper
+fix, but is probably a better temporary hack than continuing to probe
+the Legacy PIC and run with the PIC in an unknown state.
+
+Patchset: amd-gpio
+---
+ arch/x86/kernel/acpi/boot.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/arch/x86/kernel/acpi/boot.c b/arch/x86/kernel/acpi/boot.c
+index d6138b2b6..67094184c 100644
+--- a/arch/x86/kernel/acpi/boot.c
++++ b/arch/x86/kernel/acpi/boot.c
+@@ -22,6 +22,7 @@
+ #include <linux/efi-bgrt.h>
+ #include <linux/serial_core.h>
+ #include <linux/pgtable.h>
++#include <linux/dmi.h>
+ 
+ #include <xen/xen.h>
+ 
+@@ -1175,6 +1176,17 @@ static void __init mp_config_acpi_legacy_irqs(void)
+ 	}
+ }
+ 
++static const struct dmi_system_id surface_quirk[] __initconst = {
++	{
++		.ident = "Microsoft Surface Laptop 4 (AMD)",
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
++			DMI_MATCH(DMI_PRODUCT_SKU, "Surface_Laptop_4_1952:1953")
++		},
++	},
++	{}
++};
++
+ /*
+  * Parse IOAPIC related entries in MADT
+  * returns 0 on success, < 0 on error
+@@ -1231,6 +1243,11 @@ static int __init acpi_parse_madt_ioapic_entries(void)
+ 		acpi_sci_ioapic_setup(acpi_gbl_FADT.sci_interrupt, 0, 0,
+ 				      acpi_gbl_FADT.sci_interrupt);
+ 
++	if (dmi_check_system(surface_quirk)) {
++		pr_warn("Surface hack: Override irq 7\n");
++		mp_override_legacy_irq(7, 3, 3, 7);
++	}
++
+ 	/* Fill in identity legacy mappings where no override */
+ 	mp_config_acpi_legacy_irqs();
+ 
+-- 
+2.53.0
+
+From 3b8b8afd11fb27fc4d120a260e0c0cbdf3d86b01 Mon Sep 17 00:00:00 2001
+From: Maximilian Luz <luzmaximilian@gmail.com>
+Date: Thu, 3 Jun 2021 14:04:26 +0200
+Subject: [PATCH] ACPI: Add AMD 13" Surface Laptop 4 model to irq 7 override
+ quirk
+
+The 13" version of the Surface Laptop 4 has the same problem as the 15"
+version, but uses a different SKU. Add that SKU to the quirk as well.
+
+Patchset: amd-gpio
+---
+ arch/x86/kernel/acpi/boot.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/arch/x86/kernel/acpi/boot.c b/arch/x86/kernel/acpi/boot.c
+index 67094184c..9c1d2883e 100644
+--- a/arch/x86/kernel/acpi/boot.c
++++ b/arch/x86/kernel/acpi/boot.c
+@@ -1178,12 +1178,19 @@ static void __init mp_config_acpi_legacy_irqs(void)
+ 
+ static const struct dmi_system_id surface_quirk[] __initconst = {
+ 	{
+-		.ident = "Microsoft Surface Laptop 4 (AMD)",
++		.ident = "Microsoft Surface Laptop 4 (AMD 15\")",
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
+ 			DMI_MATCH(DMI_PRODUCT_SKU, "Surface_Laptop_4_1952:1953")
+ 		},
+ 	},
++	{
++		.ident = "Microsoft Surface Laptop 4 (AMD 13\")",
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "Microsoft Corporation"),
++			DMI_MATCH(DMI_PRODUCT_SKU, "Surface_Laptop_4_1958:1959")
++		},
++	},
+ 	{}
+ };
+ 
+-- 
+2.53.0
+

--- a/patches/7.0/0015-rtc.patch
+++ b/patches/7.0/0015-rtc.patch
@@ -1,0 +1,111 @@
+From 5eabba9ccc2f5ffa4017887d669b7c0d4f05e793 Mon Sep 17 00:00:00 2001
+From: "Bart Groeneveld | GPX Solutions B.V" <bart@gpxbv.nl>
+Date: Mon, 5 Dec 2022 16:08:46 +0100
+Subject: [PATCH] acpi: allow usage of acpi_tad on HW-reduced platforms
+
+The specification [1] allows so-called HW-reduced platforms,
+which do not implement everything, especially the wakeup related stuff.
+
+In that case, it is still usable as a RTC. This is helpful for [2]
+and [3], which is about a device with no other working RTC,
+but it does have an HW-reduced TAD, which can be used as a RTC instead.
+
+[1]: https://uefi.org/specs/ACPI/6.5/09_ACPI_Defined_Devices_and_Device_Specific_Objects.html#time-and-alarm-device
+[2]: https://bugzilla.kernel.org/show_bug.cgi?id=212313
+[3]: https://github.com/linux-surface/linux-surface/issues/415
+
+Signed-off-by: Bart Groeneveld | GPX Solutions B.V. <bart@gpxbv.nl>
+Patchset: rtc
+---
+ drivers/acpi/acpi_tad.c | 36 ++++++++++++++++++++++++------------
+ 1 file changed, 24 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/acpi/acpi_tad.c b/drivers/acpi/acpi_tad.c
+index 6d870d97a..a19cd08e1 100644
+--- a/drivers/acpi/acpi_tad.c
++++ b/drivers/acpi/acpi_tad.c
+@@ -438,6 +438,14 @@ static ssize_t caps_show(struct device *dev, struct device_attribute *attr,
+ 
+ static DEVICE_ATTR_RO(caps);
+ 
++static struct attribute *acpi_tad_attrs[] = {
++	&dev_attr_caps.attr,
++	NULL,
++};
++static const struct attribute_group acpi_tad_attr_group = {
++	.attrs	= acpi_tad_attrs,
++};
++
+ static ssize_t ac_alarm_store(struct device *dev, struct device_attribute *attr,
+ 			      const char *buf, size_t count)
+ {
+@@ -486,15 +494,14 @@ static ssize_t ac_status_show(struct device *dev, struct device_attribute *attr,
+ 
+ static DEVICE_ATTR_RW(ac_status);
+ 
+-static struct attribute *acpi_tad_attrs[] = {
+-	&dev_attr_caps.attr,
++static struct attribute *acpi_tad_ac_attrs[] = {
+ 	&dev_attr_ac_alarm.attr,
+ 	&dev_attr_ac_policy.attr,
+ 	&dev_attr_ac_status.attr,
+ 	NULL,
+ };
+-static const struct attribute_group acpi_tad_attr_group = {
+-	.attrs	= acpi_tad_attrs,
++static const struct attribute_group acpi_tad_ac_attr_group = {
++	.attrs	= acpi_tad_ac_attrs,
+ };
+ 
+ static ssize_t dc_alarm_store(struct device *dev, struct device_attribute *attr,
+@@ -571,14 +578,19 @@ static void acpi_tad_remove(struct platform_device *pdev)
+ 	if (dd->capabilities & ACPI_TAD_RT)
+ 		sysfs_remove_group(&dev->kobj, &acpi_tad_time_attr_group);
+ 
++	if (dd->capabilities & ACPI_TAD_AC_WAKE)
++		sysfs_remove_group(&dev->kobj, &acpi_tad_ac_attr_group);
++
+ 	if (dd->capabilities & ACPI_TAD_DC_WAKE)
+ 		sysfs_remove_group(&dev->kobj, &acpi_tad_dc_attr_group);
+ 
+ 	sysfs_remove_group(&dev->kobj, &acpi_tad_attr_group);
+ 
+ 	scoped_guard(pm_runtime_noresume, dev) {
+-		acpi_tad_disable_timer(dev, ACPI_TAD_AC_TIMER);
+-		acpi_tad_clear_status(dev, ACPI_TAD_AC_TIMER);
++		if (dd->capabilities & ACPI_TAD_AC_WAKE) {
++			acpi_tad_disable_timer(dev, ACPI_TAD_AC_TIMER);
++			acpi_tad_clear_status(dev, ACPI_TAD_AC_TIMER);
++		}
+ 		if (dd->capabilities & ACPI_TAD_DC_WAKE) {
+ 			acpi_tad_disable_timer(dev, ACPI_TAD_DC_TIMER);
+ 			acpi_tad_clear_status(dev, ACPI_TAD_DC_TIMER);
+@@ -621,12 +633,6 @@ static int acpi_tad_probe(struct platform_device *pdev)
+ 		goto remove_handler;
+ 	}
+ 
+-	if (!acpi_has_method(handle, "_PRW")) {
+-		dev_info(dev, "Missing _PRW\n");
+-		ret = -ENODEV;
+-		goto remove_handler;
+-	}
+-
+ 	dd = devm_kzalloc(dev, sizeof(*dd), GFP_KERNEL);
+ 	if (!dd) {
+ 		ret = -ENOMEM;
+@@ -657,6 +663,12 @@ static int acpi_tad_probe(struct platform_device *pdev)
+ 	if (ret)
+ 		goto fail;
+ 
++	if (caps & ACPI_TAD_AC_WAKE) {
++		ret = sysfs_create_group(&dev->kobj, &acpi_tad_ac_attr_group);
++		if (ret)
++			goto fail;
++	}
++
+ 	if (caps & ACPI_TAD_DC_WAKE) {
+ 		ret = sysfs_create_group(&dev->kobj, &acpi_tad_dc_attr_group);
+ 		if (ret)
+-- 
+2.53.0
+

--- a/patches/7.0/0016-hid-surface.patch
+++ b/patches/7.0/0016-hid-surface.patch
@@ -1,0 +1,252 @@
+From ceceaa9e24416cdb4fa910ff6a2edcd83ec19d49 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ciar=C3=A1n=20Coffey?= <github@ccoffey.ie>
+Date: Fri, 10 Oct 2025 19:04:03 +0100
+Subject: [PATCH] HID: Add hid-surface driver to filter BTN_0 (FN key)
+
+The Surface Aggregator Module firmware incorrectly reports the FN key
+as BTN_0 (button 256) through runtime HID events. This button can get
+stuck in pressed state, flooding the input system and breaking focus
+tracking in KWin Wayland compositor.
+
+Add a new hid-surface driver that filters BTN_0 events using the event
+callback. The FN key should be handled as a hardware modifier and not
+reported to the OS.
+
+Tested on Surface Laptop 4 AMD with KDE Plasma Wayland. After the fix:
+- FN key combinations work correctly (volume, brightness)
+- Focus tracking no longer breaks
+- Mouse clicks work on all windows
+
+Fixes: https://github.com/linux-surface/linux-surface/issues/1851
+Patchset: hid-surface
+---
+ drivers/hid/Kconfig       |  8 ++++
+ drivers/hid/Makefile      |  1 +
+ drivers/hid/hid-surface.c | 90 +++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 99 insertions(+)
+ create mode 100644 drivers/hid/hid-surface.c
+
+diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
+index fb65f49b5..d31b751a8 100644
+--- a/drivers/hid/Kconfig
++++ b/drivers/hid/Kconfig
+@@ -1143,6 +1143,14 @@ config HID_SUNPLUS
+ 	help
+ 	Support for Sunplus wireless desktop.
+ 
++config HID_SURFACE
++	tristate "Microsoft Surface"
++	depends on SURFACE_AGGREGATOR
++	help
++	Say Y here to enable HID driver for Microsoft Surface integrated
++	keyboard and touchpad. This driver filters out erroneous BTN_0
++	(FN key) events that can cause input focus issues.
++
+ config HID_RMI
+ 	tristate "Synaptics RMI4 device support"
+ 	select RMI4_CORE
+diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
+index 3190ece25..4d2891879 100644
+--- a/drivers/hid/Makefile
++++ b/drivers/hid/Makefile
+@@ -174,6 +174,7 @@ obj-$(CONFIG_INTEL_ISH_HID)	+= intel-ish-hid/
+ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
+ 
+ obj-$(CONFIG_SURFACE_HID_CORE)  += surface-hid/
++obj-$(CONFIG_HID_SURFACE)	+= hid-surface.o
+ 
+ obj-$(CONFIG_INTEL_THC_HID)     += intel-thc-hid/
+ 
+diff --git a/drivers/hid/hid-surface.c b/drivers/hid/hid-surface.c
+new file mode 100644
+index 000000000..a171ea656
+--- /dev/null
++++ b/drivers/hid/hid-surface.c
+@@ -0,0 +1,90 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * HID driver for Microsoft Surface devices
++ *
++ * Copyright (c) 2025 Linux Surface Project
++ */
++
++#include <linux/device.h>
++#include <linux/hid.h>
++#include <linux/input.h>
++#include <linux/module.h>
++
++#include "hid-ids.h"
++
++/*
++ * The Surface Aggregator Module firmware incorrectly reports the FN key
++ * as BTN_0 (button 256). This button can get stuck in pressed state,
++ * flooding the input system and breaking focus tracking in some
++ * compositors. Filter out BTN_0 as FN should be handled as a hardware
++ * modifier, not reported to the OS.
++ */
++static int surface_input_mapping(struct hid_device *hdev, struct hid_input *hi,
++				  struct hid_field *field, struct hid_usage *usage,
++				  unsigned long **bit, int *max)
++{
++	/*
++	 * Filter BTN_0 during input mapping in case it appears in the
++	 * HID descriptor (defense in depth).
++	 */
++	if (usage->type == EV_KEY && usage->code == BTN_0)
++		return -1;  /* Don't map this usage */
++
++	return 0;  /* Use default mapping */
++}
++
++static int surface_event(struct hid_device *hdev, struct hid_field *field,
++			  struct hid_usage *usage, __s32 value)
++{
++	/*
++	 * The Surface Aggregator Module firmware reports the FN key as BTN_0
++	 * at runtime. This button can get stuck in pressed state, flooding
++	 * the input system and breaking focus tracking. Filter out these
++	 * events as FN should be a hardware modifier, not reported to the OS.
++	 */
++	if (usage->type == EV_KEY && usage->code == BTN_0)
++		return 1;  /* Event handled, don't process further */
++
++	return 0;  /* Process event normally */
++}
++
++static int surface_probe(struct hid_device *hdev, const struct hid_device_id *id)
++{
++	int ret;
++
++	ret = hid_parse(hdev);
++	if (ret) {
++		hid_err(hdev, "parse failed\n");
++		return ret;
++	}
++
++	ret = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
++	if (ret) {
++		hid_err(hdev, "hw start failed\n");
++		return ret;
++	}
++
++	return 0;
++}
++
++static const struct hid_device_id surface_devices[] = {
++	{ HID_DEVICE(BUS_HOST, HID_GROUP_GENERIC,
++		     USB_VENDOR_ID_MICROSOFT, 0x09AE) },  /* Surface Keyboard */
++	{ HID_DEVICE(BUS_HOST, HID_GROUP_GENERIC,
++		     USB_VENDOR_ID_MICROSOFT, 0x09AF) },  /* Surface Mouse/Touchpad */
++	{ }
++};
++MODULE_DEVICE_TABLE(hid, surface_devices);
++
++static struct hid_driver surface_driver = {
++	.name = "surface",
++	.id_table = surface_devices,
++	.probe = surface_probe,
++	.input_mapping = surface_input_mapping,
++	.event = surface_event,
++};
++module_hid_driver(surface_driver);
++
++MODULE_AUTHOR("Linux Surface Project");
++MODULE_DESCRIPTION("Microsoft Surface HID driver");
++MODULE_LICENSE("GPL");
+-- 
+2.53.0
+
+From 57d61aff0b53b089227f5a794363fec829114fc5 Mon Sep 17 00:00:00 2001
+From: LegendaryFire <tristan.balon@outlook.com>
+Date: Fri, 13 Mar 2026 10:16:37 +0100
+Subject: [PATCH] hid/multitouch: Prevent mode set on Surface Laptop Studio 2
+ touch pad
+
+Note: Is this still required with MT_QUIRK_KEEP_LATENCY_ON_CLOSE now
+being available?
+
+Patchset: hid-surface
+---
+ drivers/hid/hid-multitouch.c | 31 +++++++++++++++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+
+diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
+index c92ab7949..331e1553d 100644
+--- a/drivers/hid/hid-multitouch.c
++++ b/drivers/hid/hid-multitouch.c
+@@ -84,6 +84,7 @@ MODULE_LICENSE("GPL");
+ #define MT_QUIRK_KEEP_LATENCY_ON_CLOSE	BIT(25)
+ #define MT_QUIRK_HAS_TYPE_COVER_BACKLIGHT	BIT(26)
+ #define MT_QUIRK_HAS_TYPE_COVER_TABLET_MODE_SWITCH	BIT(27)
++#define MT_QUIRK_SKIP_MODESET_ON_HW_OPEN_CLOSE  BIT(28)
+ 
+ #define MT_INPUTMODE_TOUCHSCREEN	0x02
+ #define MT_INPUTMODE_TOUCHPAD		0x03
+@@ -249,6 +250,7 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app);
+ #define MT_CLS_YOGABOOK9I			0x0115
+ #define MT_CLS_EGALAX_P80H84			0x0116
+ #define MT_CLS_WIN_8_MS_SURFACE_TYPE_COVER	0x0117
++#define MT_CLS_SURFACE_TOUCHPAD                0x0118
+ #define MT_CLS_SIS				0x0457
+ 
+ #define MT_DEFAULT_MAXCONTACT	10
+@@ -479,6 +481,10 @@ static const struct mt_class mt_classes[] = {
+ 			MT_QUIRK_WIN8_PTP_BUTTONS,
+ 		.export_all_inputs = true
+ 	},
++	{ .name = MT_CLS_SURFACE_TOUCHPAD,
++		.quirks = MT_QUIRK_ALWAYS_VALID |
++			MT_QUIRK_SKIP_MODESET_ON_HW_OPEN_CLOSE
++	},
+ 	{ }
+ };
+ 
+@@ -2276,6 +2282,17 @@ static void mt_remove(struct hid_device *hdev)
+ 
+ static void mt_on_hid_hw_open(struct hid_device *hdev)
+ {
++	struct mt_device *td = hid_get_drvdata(hdev);
++
++	/*
++	 * Some devices (e.g. Surface Laptop Studio 2 touchpad) can get stuck
++	 * non-functional if we change touchpad reporting modes from the HID
++	 * open/close hooks. Avoid mode switching on hw_open/hw_close for
++	 * those devices.
++	 */
++	if (td && td->mtclass.quirks & MT_QUIRK_SKIP_MODESET_ON_HW_OPEN_CLOSE)
++		return;
++
+ 	mt_set_modes(hdev, HID_LATENCY_NORMAL, TOUCHPAD_REPORT_ALL);
+ }
+ 
+@@ -2283,6 +2300,15 @@ static void mt_on_hid_hw_close(struct hid_device *hdev)
+ {
+ 	struct mt_device *td = hid_get_drvdata(hdev);
+ 
++	/*
++	 * Some devices (e.g. Surface Laptop Studio 2 touchpad) can get stuck
++	 * non-functional if we change touchpad reporting modes from the HID
++	 * open/close hooks. Avoid mode switching on hw_open/hw_close for
++	 * those devices.
++	 */
++	if (td && td->mtclass.quirks & MT_QUIRK_SKIP_MODESET_ON_HW_OPEN_CLOSE)
++		return;
++
+ 	if (td->mtclass.quirks & MT_QUIRK_KEEP_LATENCY_ON_CLOSE)
+ 		mt_set_modes(hdev, HID_LATENCY_NORMAL, TOUCHPAD_REPORT_NONE);
+ 	else
+@@ -2740,6 +2766,11 @@ static const struct hid_device_id mt_devices[] = {
+ 		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY,
+ 			USB_VENDOR_ID_MICROSOFT, 0x09c0) },
+ 
++	/* Microsoft Surface touch pad */
++	{ .driver_data = MT_CLS_SURFACE_TOUCHPAD,
++		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY,
++			USB_VENDOR_ID_MICROSOFT, 0x0C46) },
++
+ 	/* Google MT devices */
+ 	{ .driver_data = MT_CLS_GOOGLE,
+ 		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY, USB_VENDOR_ID_GOOGLE,
+-- 
+2.53.0
+

--- a/patches/7.0/0017-dirtyfrag-xfrm-esp-avoid-in-place-decrypt-on-shared-skb-frags.patch
+++ b/patches/7.0/0017-dirtyfrag-xfrm-esp-avoid-in-place-decrypt-on-shared-skb-frags.patch
@@ -1,0 +1,103 @@
+From 8c4594b14b091d851114f02ac33235ee06a2b29e Mon Sep 17 00:00:00 2001
+From: Kuan-Ting Chen <h3xrabbit@gmail.com>
+Date: Mon, 4 May 2026 23:27:12 +0800
+Subject: [PATCH 1/8] xfrm: esp: avoid in-place decrypt on shared skb frags
+
+MSG_SPLICE_PAGES can attach pages from a pipe directly to an skb. TCP
+marks such skbs with SKBFL_SHARED_FRAG after skb_splice_from_iter(),
+so later paths that may modify packet data can first make a private
+copy. The IPv4/IPv6 datagram append paths did not set this flag when
+splicing pages into UDP skbs.
+
+That leaves an ESP-in-UDP packet made from shared pipe pages looking
+like an ordinary uncloned nonlinear skb. ESP input then takes the no-COW
+fast path for uncloned skbs without a frag_list and decrypts in place
+over data that is not owned privately by the skb.
+
+Mark IPv4/IPv6 datagram splice frags with SKBFL_SHARED_FRAG, matching
+TCP. Also make ESP input fall back to skb_cow_data() when the flag is
+present, so ESP does not decrypt externally backed frags in place.
+Private nonlinear skb frags still use the existing fast path.
+
+This intentionally does not change ESP output. In esp_output_head(),
+the path that appends the ESP trailer to existing skb tailroom without
+calling skb_cow_data() is not reachable for nonlinear skbs:
+skb_tailroom() returns zero when skb->data_len is nonzero, while ESP
+tailen is positive. Thus ESP output will either use the separate
+destination-frag path or fall back to skb_cow_data().
+
+Fixes: cac2661c53f3 ("esp4: Avoid skb_cow_data whenever possible")
+Fixes: 03e2a30f6a27 ("esp6: Avoid skb_cow_data whenever possible")
+Fixes: 7da0dde68486 ("ip, udp: Support MSG_SPLICE_PAGES")
+Fixes: 6d8192bd69bb ("ip6, udp6: Support MSG_SPLICE_PAGES")
+Reported-by: Hyunwoo Kim <imv4bel@gmail.com>
+Reported-by: Kuan-Ting Chen <h3xrabbit@gmail.com>
+Tested-by: Hyunwoo Kim <imv4bel@gmail.com>
+Cc: stable@vger.kernel.org
+Signed-off-by: Kuan-Ting Chen <h3xrabbit@gmail.com>
+Signed-off-by: Steffen Klassert <steffen.klassert@secunet.com>
+(cherry picked from commit f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4)
+---
+ net/ipv4/esp4.c       | 3 ++-
+ net/ipv4/ip_output.c  | 2 ++
+ net/ipv6/esp6.c       | 3 ++-
+ net/ipv6/ip6_output.c | 2 ++
+ 4 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/net/ipv4/esp4.c b/net/ipv4/esp4.c
+index 2c922afadb8f..ba3743ea78cb 100644
+--- a/net/ipv4/esp4.c
++++ b/net/ipv4/esp4.c
+@@ -870,7 +870,8 @@ static int esp_input(struct xfrm_state *x, struct sk_buff *skb)
+ 			nfrags = 1;
+ 
+ 			goto skip_cow;
+-		} else if (!skb_has_frag_list(skb)) {
++		} else if (!skb_has_frag_list(skb) &&
++			   !skb_has_shared_frag(skb)) {
+ 			nfrags = skb_shinfo(skb)->nr_frags;
+ 			nfrags++;
+ 
+diff --git a/net/ipv4/ip_output.c b/net/ipv4/ip_output.c
+index ff11d3a85a36..7c005263262f 100644
+--- a/net/ipv4/ip_output.c
++++ b/net/ipv4/ip_output.c
+@@ -1233,6 +1233,8 @@ static int __ip_append_data(struct sock *sk,
+ 			if (err < 0)
+ 				goto error;
+ 			copy = err;
++			if (!(flags & MSG_NO_SHARED_FRAGS))
++				skb_shinfo(skb)->flags |= SKBFL_SHARED_FRAG;
+ 			wmem_alloc_delta += copy;
+ 		} else if (!zc) {
+ 			int i = skb_shinfo(skb)->nr_frags;
+diff --git a/net/ipv6/esp6.c b/net/ipv6/esp6.c
+index e75da98f5283..116582d6985f 100644
+--- a/net/ipv6/esp6.c
++++ b/net/ipv6/esp6.c
+@@ -912,7 +912,8 @@ static int esp6_input(struct xfrm_state *x, struct sk_buff *skb)
+ 			nfrags = 1;
+ 
+ 			goto skip_cow;
+-		} else if (!skb_has_frag_list(skb)) {
++		} else if (!skb_has_frag_list(skb) &&
++			   !skb_has_shared_frag(skb)) {
+ 			nfrags = skb_shinfo(skb)->nr_frags;
+ 			nfrags++;
+ 
+diff --git a/net/ipv6/ip6_output.c b/net/ipv6/ip6_output.c
+index f904739e99b9..f5ca0267e770 100644
+--- a/net/ipv6/ip6_output.c
++++ b/net/ipv6/ip6_output.c
+@@ -1777,6 +1777,8 @@ static int __ip6_append_data(struct sock *sk,
+ 			if (err < 0)
+ 				goto error;
+ 			copy = err;
++			if (!(flags & MSG_NO_SHARED_FRAGS))
++				skb_shinfo(skb)->flags |= SKBFL_SHARED_FRAG;
+ 			wmem_alloc_delta += copy;
+ 		} else if (!zc) {
+ 			int i = skb_shinfo(skb)->nr_frags;
+-- 
+2.53.0
+

--- a/patches/7.0/0018-dirtyfrag-rxrpc-Fix-potential-UAF-after-skb_unshare-failure.patch
+++ b/patches/7.0/0018-dirtyfrag-rxrpc-Fix-potential-UAF-after-skb_unshare-failure.patch
@@ -1,0 +1,185 @@
+From c863821f44c64505df5851090919237a089bcf65 Mon Sep 17 00:00:00 2001
+From: David Howells <dhowells@redhat.com>
+Date: Wed, 22 Apr 2026 17:14:32 +0100
+Subject: [PATCH 2/8] rxrpc: Fix potential UAF after skb_unshare() failure
+
+If skb_unshare() fails to unshare a packet due to allocation failure in
+rxrpc_input_packet(), the skb pointer in the parent (rxrpc_io_thread())
+will be NULL'd out.  This will likely cause the call to
+trace_rxrpc_rx_done() to oops.
+
+Fix this by moving the unsharing down to where rxrpc_input_call_event()
+calls rxrpc_input_call_packet().  There are a number of places prior to
+that where we ignore DATA packets for a variety of reasons (such as the
+call already being complete) for which an unshare is then avoided.
+
+And with that, rxrpc_input_packet() doesn't need to take a pointer to the
+pointer to the packet, so change that to just a pointer.
+
+Fixes: 2d1faf7a0ca3 ("rxrpc: Simplify skbuff accounting in receive path")
+Closes: https://sashiko.dev/#/patchset/20260408121252.2249051-1-dhowells%40redhat.com
+Signed-off-by: David Howells <dhowells@redhat.com>
+cc: Marc Dionne <marc.dionne@auristor.com>
+cc: Jeffrey Altman <jaltman@auristor.com>
+cc: Simon Horman <horms@kernel.org>
+cc: linux-afs@lists.infradead.org
+cc: stable@kernel.org
+Link: https://patch.msgid.link/20260422161438.2593376-4-dhowells@redhat.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+(cherry picked from commit 1f2740150f904bfa60e4bad74d65add3ccb5e7f8)
+---
+ include/trace/events/rxrpc.h |  4 ++--
+ net/rxrpc/ar-internal.h      |  1 -
+ net/rxrpc/call_event.c       | 19 ++++++++++++++++++-
+ net/rxrpc/io_thread.c        | 24 ++----------------------
+ net/rxrpc/skbuff.c           |  9 ---------
+ 5 files changed, 22 insertions(+), 35 deletions(-)
+
+diff --git a/include/trace/events/rxrpc.h b/include/trace/events/rxrpc.h
+index 869f97c9bf73..8a338f370de9 100644
+--- a/include/trace/events/rxrpc.h
++++ b/include/trace/events/rxrpc.h
+@@ -161,8 +161,6 @@
+ 	E_(rxrpc_call_poke_timer_now,		"Timer-now")
+ 
+ #define rxrpc_skb_traces \
+-	EM(rxrpc_skb_eaten_by_unshare,		"ETN unshare  ") \
+-	EM(rxrpc_skb_eaten_by_unshare_nomem,	"ETN unshar-nm") \
+ 	EM(rxrpc_skb_get_call_rx,		"GET call-rx  ") \
+ 	EM(rxrpc_skb_get_conn_secured,		"GET conn-secd") \
+ 	EM(rxrpc_skb_get_conn_work,		"GET conn-work") \
+@@ -188,6 +186,7 @@
+ 	EM(rxrpc_skb_put_purge,			"PUT purge    ") \
+ 	EM(rxrpc_skb_put_purge_oob,		"PUT purge-oob") \
+ 	EM(rxrpc_skb_put_response,		"PUT response ") \
++	EM(rxrpc_skb_put_response_copy,		"PUT resp-cpy ") \
+ 	EM(rxrpc_skb_put_rotate,		"PUT rotate   ") \
+ 	EM(rxrpc_skb_put_unknown,		"PUT unknown  ") \
+ 	EM(rxrpc_skb_see_conn_work,		"SEE conn-work") \
+@@ -196,6 +195,7 @@
+ 	EM(rxrpc_skb_see_recvmsg_oob,		"SEE recvm-oob") \
+ 	EM(rxrpc_skb_see_reject,		"SEE reject   ") \
+ 	EM(rxrpc_skb_see_rotate,		"SEE rotate   ") \
++	EM(rxrpc_skb_see_unshare_nomem,		"SEE unshar-nm") \
+ 	E_(rxrpc_skb_see_version,		"SEE version  ")
+ 
+ #define rxrpc_local_traces \
+diff --git a/net/rxrpc/ar-internal.h b/net/rxrpc/ar-internal.h
+index 36d6ca0d1089..41b3fb28c59c 100644
+--- a/net/rxrpc/ar-internal.h
++++ b/net/rxrpc/ar-internal.h
+@@ -1486,7 +1486,6 @@ int rxrpc_server_keyring(struct rxrpc_sock *, sockptr_t, int);
+ void rxrpc_kernel_data_consumed(struct rxrpc_call *, struct sk_buff *);
+ void rxrpc_new_skb(struct sk_buff *, enum rxrpc_skb_trace);
+ void rxrpc_see_skb(struct sk_buff *, enum rxrpc_skb_trace);
+-void rxrpc_eaten_skb(struct sk_buff *, enum rxrpc_skb_trace);
+ void rxrpc_get_skb(struct sk_buff *, enum rxrpc_skb_trace);
+ void rxrpc_free_skb(struct sk_buff *, enum rxrpc_skb_trace);
+ void rxrpc_purge_queue(struct sk_buff_head *);
+diff --git a/net/rxrpc/call_event.c b/net/rxrpc/call_event.c
+index fec59d9338b9..cc8f9dfa44e8 100644
+--- a/net/rxrpc/call_event.c
++++ b/net/rxrpc/call_event.c
+@@ -332,7 +332,24 @@ bool rxrpc_input_call_event(struct rxrpc_call *call)
+ 
+ 			saw_ack |= sp->hdr.type == RXRPC_PACKET_TYPE_ACK;
+ 
+-			rxrpc_input_call_packet(call, skb);
++			if (sp->hdr.securityIndex != 0 &&
++			    skb_cloned(skb)) {
++				/* Unshare the packet so that it can be
++				 * modified by in-place decryption.
++				 */
++				struct sk_buff *nskb = skb_copy(skb, GFP_ATOMIC);
++
++				if (nskb) {
++					rxrpc_new_skb(nskb, rxrpc_skb_new_unshared);
++					rxrpc_input_call_packet(call, nskb);
++					rxrpc_free_skb(nskb, rxrpc_skb_put_call_rx);
++				} else {
++					/* OOM - Drop the packet. */
++					rxrpc_see_skb(skb, rxrpc_skb_see_unshare_nomem);
++				}
++			} else {
++				rxrpc_input_call_packet(call, skb);
++			}
+ 			rxrpc_free_skb(skb, rxrpc_skb_put_call_rx);
+ 			did_receive = true;
+ 		}
+diff --git a/net/rxrpc/io_thread.c b/net/rxrpc/io_thread.c
+index e939ecf417c4..6ff30afbc085 100644
+--- a/net/rxrpc/io_thread.c
++++ b/net/rxrpc/io_thread.c
+@@ -192,13 +192,12 @@ static bool rxrpc_extract_abort(struct sk_buff *skb)
+ /*
+  * Process packets received on the local endpoint
+  */
+-static bool rxrpc_input_packet(struct rxrpc_local *local, struct sk_buff **_skb)
++static bool rxrpc_input_packet(struct rxrpc_local *local, struct sk_buff *skb)
+ {
+ 	struct rxrpc_connection *conn;
+ 	struct sockaddr_rxrpc peer_srx;
+ 	struct rxrpc_skb_priv *sp;
+ 	struct rxrpc_peer *peer = NULL;
+-	struct sk_buff *skb = *_skb;
+ 	bool ret = false;
+ 
+ 	skb_pull(skb, sizeof(struct udphdr));
+@@ -244,25 +243,6 @@ static bool rxrpc_input_packet(struct rxrpc_local *local, struct sk_buff **_skb)
+ 			return rxrpc_bad_message(skb, rxrpc_badmsg_zero_call);
+ 		if (sp->hdr.seq == 0)
+ 			return rxrpc_bad_message(skb, rxrpc_badmsg_zero_seq);
+-
+-		/* Unshare the packet so that it can be modified for in-place
+-		 * decryption.
+-		 */
+-		if (sp->hdr.securityIndex != 0) {
+-			skb = skb_unshare(skb, GFP_ATOMIC);
+-			if (!skb) {
+-				rxrpc_eaten_skb(*_skb, rxrpc_skb_eaten_by_unshare_nomem);
+-				*_skb = NULL;
+-				return just_discard;
+-			}
+-
+-			if (skb != *_skb) {
+-				rxrpc_eaten_skb(*_skb, rxrpc_skb_eaten_by_unshare);
+-				*_skb = skb;
+-				rxrpc_new_skb(skb, rxrpc_skb_new_unshared);
+-				sp = rxrpc_skb(skb);
+-			}
+-		}
+ 		break;
+ 
+ 	case RXRPC_PACKET_TYPE_CHALLENGE:
+@@ -493,7 +473,7 @@ int rxrpc_io_thread(void *data)
+ 			switch (skb->mark) {
+ 			case RXRPC_SKB_MARK_PACKET:
+ 				skb->priority = 0;
+-				if (!rxrpc_input_packet(local, &skb))
++				if (!rxrpc_input_packet(local, skb))
+ 					rxrpc_reject_packet(local, skb);
+ 				trace_rxrpc_rx_done(skb->mark, skb->priority);
+ 				rxrpc_free_skb(skb, rxrpc_skb_put_input);
+diff --git a/net/rxrpc/skbuff.c b/net/rxrpc/skbuff.c
+index 3bcd6ee80396..e2169d1a14b5 100644
+--- a/net/rxrpc/skbuff.c
++++ b/net/rxrpc/skbuff.c
+@@ -46,15 +46,6 @@ void rxrpc_get_skb(struct sk_buff *skb, enum rxrpc_skb_trace why)
+ 	skb_get(skb);
+ }
+ 
+-/*
+- * Note the dropping of a ref on a socket buffer by the core.
+- */
+-void rxrpc_eaten_skb(struct sk_buff *skb, enum rxrpc_skb_trace why)
+-{
+-	int n = atomic_inc_return(&rxrpc_n_rx_skbs);
+-	trace_rxrpc_skb(skb, 0, n, why);
+-}
+-
+ /*
+  * Note the destruction of a socket buffer.
+  */
+-- 
+2.53.0
+

--- a/patches/7.0/0019-dirtyfrag-rxrpc-Fix-rxrpc_input_call_event-to-only-unshare-DAT.patch
+++ b/patches/7.0/0019-dirtyfrag-rxrpc-Fix-rxrpc_input_call_event-to-only-unshare-DAT.patch
@@ -1,0 +1,44 @@
+From 53e3b2bcd7d1a1fb428d0883a05b54bb0d366b82 Mon Sep 17 00:00:00 2001
+From: David Howells <dhowells@redhat.com>
+Date: Thu, 23 Apr 2026 21:09:06 +0100
+Subject: [PATCH 3/8] rxrpc: Fix rxrpc_input_call_event() to only unshare DATA
+ packets
+
+Fix rxrpc_input_call_event() to only unshare DATA packets and not ACK,
+ABORT, etc..
+
+And with that, rxrpc_input_packet() doesn't need to take a pointer to the
+pointer to the packet, so change that to just a pointer.
+
+Fixes: 1f2740150f90 ("rxrpc: Fix potential UAF after skb_unshare() failure")
+Closes: https://sashiko.dev/#/patchset/20260422161438.2593376-4-dhowells@redhat.com
+Signed-off-by: David Howells <dhowells@redhat.com>
+cc: Marc Dionne <marc.dionne@auristor.com>
+cc: Jeffrey Altman <jaltman@auristor.com>
+cc: Simon Horman <horms@kernel.org>
+cc: linux-afs@lists.infradead.org
+cc: stable@kernel.org
+Link: https://patch.msgid.link/20260423200909.3049438-2-dhowells@redhat.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+(cherry picked from commit 55b2984c96c37f909bbfe8851f13152693951382)
+---
+ net/rxrpc/call_event.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/net/rxrpc/call_event.c b/net/rxrpc/call_event.c
+index cc8f9dfa44e8..fdd683261226 100644
+--- a/net/rxrpc/call_event.c
++++ b/net/rxrpc/call_event.c
+@@ -332,7 +332,8 @@ bool rxrpc_input_call_event(struct rxrpc_call *call)
+ 
+ 			saw_ack |= sp->hdr.type == RXRPC_PACKET_TYPE_ACK;
+ 
+-			if (sp->hdr.securityIndex != 0 &&
++			if (sp->hdr.type == RXRPC_PACKET_TYPE_DATA &&
++			    sp->hdr.securityIndex != 0 &&
+ 			    skb_cloned(skb)) {
+ 				/* Unshare the packet so that it can be
+ 				 * modified by in-place decryption.
+-- 
+2.53.0
+

--- a/patches/7.0/0020-dirtyfrag-rxrpc-Fix-use-of-wrong-skb-when-comparing-queued-RES.patch
+++ b/patches/7.0/0020-dirtyfrag-rxrpc-Fix-use-of-wrong-skb-when-comparing-queued-RES.patch
@@ -1,0 +1,72 @@
+From 94973b24d4136293be23603a914967747da0c6a7 Mon Sep 17 00:00:00 2001
+From: Alok Tiwari <alok.a.tiwari@oracle.com>
+Date: Wed, 8 Apr 2026 13:12:34 +0100
+Subject: [PATCH 4/8] rxrpc: Fix use of wrong skb when comparing queued RESP
+ challenge serial
+
+In rxrpc_post_response(), the code should be comparing the challenge serial
+number from the cached response before deciding to switch to a newer
+response, but looks at the newer packet private data instead, rendering the
+comparison always false.
+
+Fix this by switching to look at the older packet.
+
+Fix further[1] to substitute the new packet in place of the old one if
+newer and also to release whichever we don't use.
+
+Fixes: 5800b1cf3fd8 ("rxrpc: Allow CHALLENGEs to the passed to the app for a RESPONSE")
+Signed-off-by: Alok Tiwari <alok.a.tiwari@oracle.com>
+Signed-off-by: David Howells <dhowells@redhat.com>
+Reviewed-by: Jeffrey Altman <jaltman@auristor.com>
+cc: Marc Dionne <marc.dionne@auristor.com>
+cc: Simon Horman <horms@kernel.org>
+cc: linux-afs@lists.infradead.org
+cc: stable@kernel.org
+Link: https://sashiko.dev/#/patchset/20260319150150.4189381-1-dhowells%40redhat.com [1]
+Link: https://patch.msgid.link/20260408121252.2249051-7-dhowells@redhat.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+(cherry picked from commit b33f5741bb187db8ff32e8f5b96def77cc94dfca)
+---
+ include/trace/events/rxrpc.h | 1 +
+ net/rxrpc/conn_event.c       | 5 +++--
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/include/trace/events/rxrpc.h b/include/trace/events/rxrpc.h
+index 8a338f370de9..94f804ec8831 100644
+--- a/include/trace/events/rxrpc.h
++++ b/include/trace/events/rxrpc.h
+@@ -183,6 +183,7 @@
+ 	EM(rxrpc_skb_put_input,			"PUT input    ") \
+ 	EM(rxrpc_skb_put_jumbo_subpacket,	"PUT jumbo-sub") \
+ 	EM(rxrpc_skb_put_oob,			"PUT oob      ") \
++	EM(rxrpc_skb_put_old_response,		"PUT old-resp ") \
+ 	EM(rxrpc_skb_put_purge,			"PUT purge    ") \
+ 	EM(rxrpc_skb_put_purge_oob,		"PUT purge-oob") \
+ 	EM(rxrpc_skb_put_response,		"PUT response ") \
+diff --git a/net/rxrpc/conn_event.c b/net/rxrpc/conn_event.c
+index 98ad9b51ca2c..c50cbfc5a313 100644
+--- a/net/rxrpc/conn_event.c
++++ b/net/rxrpc/conn_event.c
+@@ -557,11 +557,11 @@ void rxrpc_post_response(struct rxrpc_connection *conn, struct sk_buff *skb)
+ 	spin_lock_irq(&local->lock);
+ 	old = conn->tx_response;
+ 	if (old) {
+-		struct rxrpc_skb_priv *osp = rxrpc_skb(skb);
++		struct rxrpc_skb_priv *osp = rxrpc_skb(old);
+ 
+ 		/* Always go with the response to the most recent challenge. */
+ 		if (after(sp->resp.challenge_serial, osp->resp.challenge_serial))
+-			conn->tx_response = old;
++			conn->tx_response = skb;
+ 		else
+ 			old = skb;
+ 	} else {
+@@ -569,4 +569,5 @@ void rxrpc_post_response(struct rxrpc_connection *conn, struct sk_buff *skb)
+ 	}
+ 	spin_unlock_irq(&local->lock);
+ 	rxrpc_poke_conn(conn, rxrpc_conn_get_poke_response);
++	rxrpc_free_skb(old, rxrpc_skb_put_old_response);
+ }
+-- 
+2.53.0
+

--- a/patches/7.0/0021-dirtyfrag-rxrpc-only-handle-RESPONSE-during-service-challenge.patch
+++ b/patches/7.0/0021-dirtyfrag-rxrpc-only-handle-RESPONSE-during-service-challenge.patch
@@ -1,0 +1,79 @@
+From 662e6d8b63299d3c0d2a57bdf73e39210ea8a424 Mon Sep 17 00:00:00 2001
+From: Wang Jie <jiewang2024@lzu.edu.cn>
+Date: Wed, 8 Apr 2026 13:12:48 +0100
+Subject: [PATCH 5/8] rxrpc: only handle RESPONSE during service challenge
+
+Only process RESPONSE packets while the service connection is still in
+RXRPC_CONN_SERVICE_CHALLENGING. Check that state under state_lock before
+running response verification and security initialization, then use a local
+secured flag to decide whether to queue the secured-connection work after
+the state transition. This keeps duplicate or late RESPONSE packets from
+re-running the setup path and removes the unlocked post-transition state
+test.
+
+Fixes: 17926a79320a ("[AF_RXRPC]: Provide secure RxRPC sockets for use by userspace and kernel both")
+Reported-by: Yifan Wu <yifanwucs@gmail.com>
+Reported-by: Juefei Pu <tomapufckgml@gmail.com>
+Co-developed-by: Yuan Tan <yuantan098@gmail.com>
+Signed-off-by: Yuan Tan <yuantan098@gmail.com>
+Suggested-by: Xin Liu <bird@lzu.edu.cn>
+Signed-off-by: Jie Wang <jiewang2024@lzu.edu.cn>
+Signed-off-by: Yang Yang <n05ec@lzu.edu.cn>
+Signed-off-by: David Howells <dhowells@redhat.com>
+cc: Marc Dionne <marc.dionne@auristor.com>
+cc: Jeffrey Altman <jaltman@auristor.com>
+cc: Simon Horman <horms@kernel.org>
+cc: linux-afs@lists.infradead.org
+cc: stable@kernel.org
+Link: https://patch.msgid.link/20260408121252.2249051-21-dhowells@redhat.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+(cherry picked from commit c43ffdcfdbb5567b1f143556df8a04b4eeea041c)
+---
+ net/rxrpc/conn_event.c | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/net/rxrpc/conn_event.c b/net/rxrpc/conn_event.c
+index c50cbfc5a313..9a41ec708aeb 100644
+--- a/net/rxrpc/conn_event.c
++++ b/net/rxrpc/conn_event.c
+@@ -247,6 +247,7 @@ static int rxrpc_process_event(struct rxrpc_connection *conn,
+ 			       struct sk_buff *skb)
+ {
+ 	struct rxrpc_skb_priv *sp = rxrpc_skb(skb);
++	bool secured = false;
+ 	int ret;
+ 
+ 	if (conn->state == RXRPC_CONN_ABORTED)
+@@ -262,6 +263,13 @@ static int rxrpc_process_event(struct rxrpc_connection *conn,
+ 		return ret;
+ 
+ 	case RXRPC_PACKET_TYPE_RESPONSE:
++		spin_lock_irq(&conn->state_lock);
++		if (conn->state != RXRPC_CONN_SERVICE_CHALLENGING) {
++			spin_unlock_irq(&conn->state_lock);
++			return 0;
++		}
++		spin_unlock_irq(&conn->state_lock);
++
+ 		ret = conn->security->verify_response(conn, skb);
+ 		if (ret < 0)
+ 			return ret;
+@@ -272,11 +280,13 @@ static int rxrpc_process_event(struct rxrpc_connection *conn,
+ 			return ret;
+ 
+ 		spin_lock_irq(&conn->state_lock);
+-		if (conn->state == RXRPC_CONN_SERVICE_CHALLENGING)
++		if (conn->state == RXRPC_CONN_SERVICE_CHALLENGING) {
+ 			conn->state = RXRPC_CONN_SERVICE;
++			secured = true;
++		}
+ 		spin_unlock_irq(&conn->state_lock);
+ 
+-		if (conn->state == RXRPC_CONN_SERVICE) {
++		if (secured) {
+ 			/* Offload call state flipping to the I/O thread.  As
+ 			 * we've already received the packet, put it on the
+ 			 * front of the queue.
+-- 
+2.53.0
+

--- a/patches/7.0/0022-dirtyfrag-rxrpc-Fix-conn-level-packet-handling-to-unshare-RESP.patch
+++ b/patches/7.0/0022-dirtyfrag-rxrpc-Fix-conn-level-packet-handling-to-unshare-RESP.patch
@@ -1,0 +1,79 @@
+From a7f61c028f5fda7e1da489288a36d632a61ace5a Mon Sep 17 00:00:00 2001
+From: David Howells <dhowells@redhat.com>
+Date: Wed, 22 Apr 2026 17:14:33 +0100
+Subject: [PATCH 6/8] rxrpc: Fix conn-level packet handling to unshare RESPONSE
+ packets
+
+The security operations that verify the RESPONSE packets decrypt bits of it
+in place - however, the sk_buff may be shared with a packet sniffer, which
+would lead to the sniffer seeing an apparently corrupt packet (actually
+decrypted).
+
+Fix this by handing a copy of the packet off to the specific security
+handler if the packet was cloned.
+
+Fixes: 17926a79320a ("[AF_RXRPC]: Provide secure RxRPC sockets for use by userspace and kernel both")
+Closes: https://sashiko.dev/#/patchset/20260408121252.2249051-1-dhowells%40redhat.com
+Signed-off-by: David Howells <dhowells@redhat.com>
+cc: Marc Dionne <marc.dionne@auristor.com>
+cc: Jeffrey Altman <jaltman@auristor.com>
+cc: Simon Horman <horms@kernel.org>
+cc: linux-afs@lists.infradead.org
+cc: stable@kernel.org
+Link: https://patch.msgid.link/20260422161438.2593376-5-dhowells@redhat.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+(cherry picked from commit 24481a7f573305706054c59e275371f8d0fe919f)
+---
+ net/rxrpc/conn_event.c | 29 ++++++++++++++++++++++++++++-
+ 1 file changed, 28 insertions(+), 1 deletion(-)
+
+diff --git a/net/rxrpc/conn_event.c b/net/rxrpc/conn_event.c
+index 9a41ec708aeb..aee977291d90 100644
+--- a/net/rxrpc/conn_event.c
++++ b/net/rxrpc/conn_event.c
+@@ -240,6 +240,33 @@ static void rxrpc_call_is_secure(struct rxrpc_call *call)
+ 		rxrpc_notify_socket(call);
+ }
+ 
++static int rxrpc_verify_response(struct rxrpc_connection *conn,
++				 struct sk_buff *skb)
++{
++	int ret;
++
++	if (skb_cloned(skb)) {
++		/* Copy the packet if shared so that we can do in-place
++		 * decryption.
++		 */
++		struct sk_buff *nskb = skb_copy(skb, GFP_NOFS);
++
++		if (nskb) {
++			rxrpc_new_skb(nskb, rxrpc_skb_new_unshared);
++			ret = conn->security->verify_response(conn, nskb);
++			rxrpc_free_skb(nskb, rxrpc_skb_put_response_copy);
++		} else {
++			/* OOM - Drop the packet. */
++			rxrpc_see_skb(skb, rxrpc_skb_see_unshare_nomem);
++			ret = -ENOMEM;
++		}
++	} else {
++		ret = conn->security->verify_response(conn, skb);
++	}
++
++	return ret;
++}
++
+ /*
+  * connection-level Rx packet processor
+  */
+@@ -270,7 +297,7 @@ static int rxrpc_process_event(struct rxrpc_connection *conn,
+ 		}
+ 		spin_unlock_irq(&conn->state_lock);
+ 
+-		ret = conn->security->verify_response(conn, skb);
++		ret = rxrpc_verify_response(conn, skb);
+ 		if (ret < 0)
+ 			return ret;
+ 
+-- 
+2.53.0
+

--- a/patches/7.0/0023-dirtyfrag-rxrpc-Fix-re-decryption-of-RESPONSE-packets.patch
+++ b/patches/7.0/0023-dirtyfrag-rxrpc-Fix-re-decryption-of-RESPONSE-packets.patch
@@ -1,0 +1,76 @@
+From 98be347c5f2564c13fc8def0ecb2ed0cca54a11a Mon Sep 17 00:00:00 2001
+From: David Howells <dhowells@redhat.com>
+Date: Thu, 23 Apr 2026 21:09:07 +0100
+Subject: [PATCH 7/8] rxrpc: Fix re-decryption of RESPONSE packets
+
+If a RESPONSE packet gets a temporary failure during processing, it may end
+up in a partially decrypted state - and then get requeued for a retry.
+
+Fix this by just discarding the packet; we will send another CHALLENGE
+packet and thereby elicit a further response.  Similarly, discard an
+incoming CHALLENGE packet if we get an error whilst generating a RESPONSE;
+the server will send another CHALLENGE.
+
+Fixes: 17926a79320a ("[AF_RXRPC]: Provide secure RxRPC sockets for use by userspace and kernel both")
+Closes: https://sashiko.dev/#/patchset/20260422161438.2593376-4-dhowells@redhat.com
+Signed-off-by: David Howells <dhowells@redhat.com>
+cc: Marc Dionne <marc.dionne@auristor.com>
+cc: Jeffrey Altman <jaltman@auristor.com>
+cc: Simon Horman <horms@kernel.org>
+cc: linux-afs@lists.infradead.org
+cc: stable@kernel.org
+Link: https://patch.msgid.link/20260423200909.3049438-3-dhowells@redhat.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+(cherry picked from commit 0422e7a4883f25101903f3e8105c0808aa5f4ce9)
+---
+ include/trace/events/rxrpc.h |  1 -
+ net/rxrpc/conn_event.c       | 14 ++------------
+ 2 files changed, 2 insertions(+), 13 deletions(-)
+
+diff --git a/include/trace/events/rxrpc.h b/include/trace/events/rxrpc.h
+index 94f804ec8831..eb8150afd6df 100644
+--- a/include/trace/events/rxrpc.h
++++ b/include/trace/events/rxrpc.h
+@@ -284,7 +284,6 @@
+ 	EM(rxrpc_conn_put_unidle,		"PUT unidle  ") \
+ 	EM(rxrpc_conn_put_work,			"PUT work    ") \
+ 	EM(rxrpc_conn_queue_challenge,		"QUE chall   ") \
+-	EM(rxrpc_conn_queue_retry_work,		"QUE retry-wk") \
+ 	EM(rxrpc_conn_queue_rx_work,		"QUE rx-work ") \
+ 	EM(rxrpc_conn_see_new_service_conn,	"SEE new-svc ") \
+ 	EM(rxrpc_conn_see_reap_service,		"SEE reap-svc") \
+diff --git a/net/rxrpc/conn_event.c b/net/rxrpc/conn_event.c
+index aee977291d90..a2130d25aaa9 100644
+--- a/net/rxrpc/conn_event.c
++++ b/net/rxrpc/conn_event.c
+@@ -389,7 +389,6 @@ void rxrpc_process_delayed_final_acks(struct rxrpc_connection *conn, bool force)
+ static void rxrpc_do_process_connection(struct rxrpc_connection *conn)
+ {
+ 	struct sk_buff *skb;
+-	int ret;
+ 
+ 	if (test_and_clear_bit(RXRPC_CONN_EV_CHALLENGE, &conn->events))
+ 		rxrpc_secure_connection(conn);
+@@ -398,17 +397,8 @@ static void rxrpc_do_process_connection(struct rxrpc_connection *conn)
+ 	 * connection that each one has when we've finished with it */
+ 	while ((skb = skb_dequeue(&conn->rx_queue))) {
+ 		rxrpc_see_skb(skb, rxrpc_skb_see_conn_work);
+-		ret = rxrpc_process_event(conn, skb);
+-		switch (ret) {
+-		case -ENOMEM:
+-		case -EAGAIN:
+-			skb_queue_head(&conn->rx_queue, skb);
+-			rxrpc_queue_conn(conn, rxrpc_conn_queue_retry_work);
+-			break;
+-		default:
+-			rxrpc_free_skb(skb, rxrpc_skb_put_conn_work);
+-			break;
+-		}
++		rxrpc_process_event(conn, skb);
++		rxrpc_free_skb(skb, rxrpc_skb_put_conn_work);
+ 	}
+ }
+ 
+-- 
+2.53.0
+

--- a/patches/7.0/0024-dirtyfrag-rxrpc-Also-unshare-DATA-RESPONSE-packets-when-paged-.patch
+++ b/patches/7.0/0024-dirtyfrag-rxrpc-Also-unshare-DATA-RESPONSE-packets-when-paged-.patch
@@ -1,0 +1,55 @@
+From 606cb2021745a1206f43a24b6c795c187e01df6f Mon Sep 17 00:00:00 2001
+From: Hyunwoo Kim <imv4bel@gmail.com>
+Date: Fri, 8 May 2026 15:42:28 +0900
+Subject: [PATCH 8/8 v2] rxrpc: Also unshare DATA/RESPONSE packets when paged
+ frags are present
+
+The DATA-packet handler in rxrpc_input_call_event() and the RESPONSE
+handler in rxrpc_verify_response() copy the skb to a linear one before
+calling into the security ops only when skb_cloned() is true.  An skb
+that is not cloned but still carries paged fragments (skb->data_len != 0)
+falls through to the in-place decryption path, which binds the frag
+pages directly into the AEAD/skcipher SGL via skb_to_sgvec().
+
+Extend the gate so that any skb with non-linear data is also copied,
+ensuring the security handler always operates on a fully linear skb.
+The OOM/trace handling already in place is reused.
+
+Fixes: d0d5c0cd1e71 ("rxrpc: Use skb_unshare() rather than skb_cow_data()")
+Cc: stable@vger.kernel.org
+Signed-off-by: Hyunwoo Kim <imv4bel@gmail.com>
+Link: https://lore.kernel.org/netdev/af2ZMmJ4Oa0tscfC@v4bel/T/#t
+---
+ net/rxrpc/call_event.c | 2 +-
+ net/rxrpc/conn_event.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/net/rxrpc/call_event.c b/net/rxrpc/call_event.c
+index fdd683261226..a6ad5ff6ec5f 100644
+--- a/net/rxrpc/call_event.c
++++ b/net/rxrpc/call_event.c
+@@ -334,7 +334,7 @@ bool rxrpc_input_call_event(struct rxrpc_call *call)
+ 
+ 			if (sp->hdr.type == RXRPC_PACKET_TYPE_DATA &&
+ 			    sp->hdr.securityIndex != 0 &&
+-			    skb_cloned(skb)) {
++			    (skb_cloned(skb) || skb_is_nonlinear(skb))) {
+ 				/* Unshare the packet so that it can be
+ 				 * modified by in-place decryption.
+ 				 */
+diff --git a/net/rxrpc/conn_event.c b/net/rxrpc/conn_event.c
+index a2130d25aaa9..632cbeff1f5d 100644
+--- a/net/rxrpc/conn_event.c
++++ b/net/rxrpc/conn_event.c
+@@ -245,7 +245,7 @@ static int rxrpc_verify_response(struct rxrpc_connection *conn,
+ {
+ 	int ret;
+ 
+-	if (skb_cloned(skb)) {
++	if (skb_cloned(skb) || skb_is_nonlinear(skb)) {
+ 		/* Copy the packet if shared so that we can do in-place
+ 		 * decryption.
+ 		 */
+-- 
+2.53.0
+


### PR DESCRIPTION
This PR adds patches/7.0/ based on the 6.19 patch set, with the following
additions to 0013-cameras.patch for Microsoft Surface Pro 10 (Meteor Lake):

**New driver:**
- Sony IMX681 sensor driver supporting both Surface Pro 10 (MTL, 380.8 MHz
  C-PHY) and Surface Pro 11 (LNL, 969.6 MHz D-PHY) with platform-specific
  PLL selection at stream-on time

**ipu-bridge:**
- SONY0681 entry with C-PHY bus type and dual link frequencies
- OVTID858 (OV13858) rear camera entry
- device_reprobe() to fix probe ordering race condition

**INT3472:**
- GPIO type 0x08 (DVDD) and 0x10 (DOVDD) support with proper named
  constants, replacing the SP9 magic number workaround
- CLK_IS_CRITICAL and always-on regulator constraints

**OV13858:**
- Reset GPIO handling for SP10

Tested on Surface Pro 10 for Business (MSHW0520/MSHW0521), Ubuntu 26.04,
kernel 7.0.0-15-generic. Both sensors probe successfully. Rear camera
produces frames (ISP tuning pending). Front camera probes but produces
black frames pending C-PHY support in ipu6-isys-dwc-phy.c.