### PR TITLE
contrib: Add Surface Pro 10 suspend/resume fixes

### DIFF
--- a/contrib/surface-pro-10/99-surface-pro-10-wakeup.rules
+++ b/contrib/surface-pro-10/99-surface-pro-10-wakeup.rules
@@ -1,0 +1,2 @@
+# Enable wakeup for Intel THC0 (Surface Pro 10 touchscreen/cover wake)
+ACTION=="add", KERNEL=="0000:00:10.0", SUBSYSTEM=="pci", ATTR{power/wakeup}="enabled"

--- a/contrib/surface-pro-10/README.md
+++ b/contrib/surface-pro-10/README.md
@@ -1,0 +1,35 @@
+# Surface Pro 10 (Meteor Lake) - Suspend/Resume Fixes
+
+## Installation
+
+Copy the udev rule for lid-open wake:
+
+    sudo cp 99-surface-pro-10-wakeup.rules /etc/udev/rules.d/
+    sudo udevadm control --reload-rules
+
+Install the button fix service:
+
+    sudo cp surface-pro-10-buttons.service /etc/systemd/system/
+    sudo systemctl enable --now surface-pro-10-buttons.service
+
+## Kernel Parameters
+
+Add to your kernel command line (e.g. in /etc/default/grub):
+
+    i915.enable_psr2_sel_fetch=0
+
+This fixes s2idle suspend/resume freezes caused by PSR2 selective fetch
+failures on the Meteor Lake display pipeline.
+
+## Issues Fixed
+
+- s2idle suspend freeze (system never resumes after lid close)
+- Power/volume buttons unreliable after boot (prevents wake)
+- Lid open not waking system from suspend
+- Kernel panic on resume caused by surface-quickspi hook unloading intel_thc
+
+## Notes
+
+The surface-quickspi sleep hook must NOT be used on Surface Pro 10 as it
+causes an xhci kernel panic on resume by unloading intel_thc while USB
+is active.

--- a/contrib/surface-pro-10/surface-pro-10-buttons.service
+++ b/contrib/surface-pro-10/surface-pro-10-buttons.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Reload soc_button_array to fix Surface Pro 10 buttons
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/rmmod soc_button_array
+ExecStartPost=/sbin/modprobe soc_button_array
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- udev rule to enable THC0 wakeup for lid-open wake
- systemd service to reload soc_button_array for reliable buttons
- README documenting i915.enable_psr2_sel_fetch=0 kernel parameter
- Documents surface-quickspi hook incompatibility causing xhci panic

Fixes s2idle suspend freeze on Surface Pro 10 (Meteor Lake/IPU6).