### PR TITLE
cameras: ov5693: make the IPU6 Surface front cameras stream (Pro 8/9, Go 4)

### DIFF
--- a/patches/6.19/0013-cameras.patch
+++ b/patches/6.19/0013-cameras.patch
@@ -1066,7 +1066,7 @@ From b7ea7a2658e1c92afcfe0092f5d4e909fabeb5ef Mon Sep 17 00:00:00 2001
 From: Arsalan Naeem <naeemarsalan@gmail.com>
 Date: Thu, 11 Jun 2026 17:30:22 -0400
 Subject: [PATCH] media: i2c: ov5693: program MIPI_CTRL00 for IPU6 (Surface Pro
- 8 front camera)
+ 8/9 and Go 4 front cameras)
 
 The mainline ov5693 driver never writes MIPI_CTRL00 (register 0x4800),
 leaving it at its 0x00 power-on default. That default is accepted by the
@@ -1082,6 +1082,13 @@ Writing MIPI_CTRL00 = 0x2d before stream-on -- the value the vendor
 clock-lane behaviour the IPU6 expects, and the front camera then streams
 (verified at ~28 fps via libcamera on a Surface Pro 8, kernel 6.19).
 
+The same write has since been confirmed to fix the identical symptom on
+the other IPU6 Surface devices that use this sensor as the front camera:
+the Surface Go 4 (ov5693 at INT33BE, ~28.6 fps) and the Surface Pro 9
+(ov5693 at OVTI5693; that ACPI HID is already added by the "Add camera
+support for Surface Pro 9" patch earlier in this patchset, so no match
+table change is needed here).
+
 The value was reverse-engineered from the Surface Pro 8 Windows ov5693.sys
 register table; its exact bit meaning is taken from the vendor driver
 rather than a datasheet. It is written unconditionally, so it should be
@@ -1089,6 +1096,8 @@ checked on the IPU3 Surface devices (Pro 5/6/7) before this is relied
 upon there.
 
 Link: https://github.com/linux-surface/linux-surface/issues/1893
+Link: https://github.com/linux-surface/linux-surface/issues/2154
+Link: https://github.com/linux-surface/linux-surface/issues/1892
 Patchset: cameras
 Signed-off-by: Arsalan Naeem <naeemarsalan@gmail.com>
 ---
@@ -1118,10 +1127,10 @@ index 4cc796b..83c2ea9 100644
 +	 * Program MIPI_CTRL00 (CSI-2 clock-lane control) before starting the
 +	 * stream. The 0x00 power-on default is accepted by the IPU3 ISP (where
 +	 * this sensor is used on the Surface Pro 5-7) but leaves the IPU6 D-PHY
-+	 * (Surface Pro 8) unable to lock onto the link: the sensor streams yet
-+	 * the receiver gets no CSI-2 data and capture times out. 0x2d matches
-+	 * the value the vendor (Windows) driver writes and lets the IPU6
-+	 * receive frames.
++	 * (Surface Pro 8/9, Surface Go 4) unable to lock onto the link: the
++	 * sensor streams yet the receiver gets no CSI-2 data and capture times
++	 * out. 0x2d matches the value the vendor (Windows) driver writes and
++	 * lets the IPU6 receive frames.
 +	 */
 +	if (enable)
 +		cci_write(ov5693->regmap, OV5693_MIPI_CTRL00_REG,

--- a/patches/6.19/0013-cameras.patch
+++ b/patches/6.19/0013-cameras.patch
@@ -1061,3 +1061,75 @@ index f5456330b..3418ff475 100644
 -- 
 2.53.0
 
+
+From b7ea7a2658e1c92afcfe0092f5d4e909fabeb5ef Mon Sep 17 00:00:00 2001
+From: Arsalan Naeem <naeemarsalan@gmail.com>
+Date: Thu, 11 Jun 2026 17:30:22 -0400
+Subject: [PATCH] media: i2c: ov5693: program MIPI_CTRL00 for IPU6 (Surface Pro
+ 8 front camera)
+
+The mainline ov5693 driver never writes MIPI_CTRL00 (register 0x4800),
+leaving it at its 0x00 power-on default. That default is accepted by the
+IPU3 ISP, where this sensor is used as the front camera on the Surface
+Pro 5/6/7, so the sensor works there. On the Surface Pro 8 the same
+sensor is wired to an IPU6 whose MIPI D-PHY does not lock onto the link
+with MIPI_CTRL00 == 0x00: the sensor reports streaming and the PHY powers
+up, but the receiver never gets any CSI-2 packets and capture times out
+("stream stop time out", zero packets, no SOT/CRC errors).
+
+Writing MIPI_CTRL00 = 0x2d before stream-on -- the value the vendor
+(Windows) driver programs for this module -- configures the CSI-2
+clock-lane behaviour the IPU6 expects, and the front camera then streams
+(verified at ~28 fps via libcamera on a Surface Pro 8, kernel 6.19).
+
+The value was reverse-engineered from the Surface Pro 8 Windows ov5693.sys
+register table; its exact bit meaning is taken from the vendor driver
+rather than a datasheet. It is written unconditionally, so it should be
+checked on the IPU3 Surface devices (Pro 5/6/7) before this is relied
+upon there.
+
+Link: https://github.com/linux-surface/linux-surface/issues/1893
+Patchset: cameras
+Signed-off-by: Arsalan Naeem <naeemarsalan@gmail.com>
+---
+ drivers/media/i2c/ov5693.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/drivers/media/i2c/ov5693.c b/drivers/media/i2c/ov5693.c
+index 4cc796b..83c2ea9 100644
+--- a/drivers/media/i2c/ov5693.c
++++ b/drivers/media/i2c/ov5693.c
+@@ -110,6 +110,10 @@
+ #define OV5693_MIN_CROP_WIDTH			2
+ #define OV5693_MIN_CROP_HEIGHT			2
+ 
++/* MIPI control */
++#define OV5693_MIPI_CTRL00_REG			CCI_REG8(0x4800)
++#define OV5693_MIPI_CTRL00_IPU6			0x2d
++
+ /* Test Pattern */
+ #define OV5693_TEST_PATTERN_REG			CCI_REG8(0x5e00)
+ #define OV5693_TEST_PATTERN_ENABLE		BIT(7)
+@@ -611,6 +615,19 @@ static int ov5693_enable_streaming(struct ov5693_device *ov5693, bool enable)
+ {
+ 	int ret = 0;
+ 
++	/*
++	 * Program MIPI_CTRL00 (CSI-2 clock-lane control) before starting the
++	 * stream. The 0x00 power-on default is accepted by the IPU3 ISP (where
++	 * this sensor is used on the Surface Pro 5-7) but leaves the IPU6 D-PHY
++	 * (Surface Pro 8) unable to lock onto the link: the sensor streams yet
++	 * the receiver gets no CSI-2 data and capture times out. 0x2d matches
++	 * the value the vendor (Windows) driver writes and lets the IPU6
++	 * receive frames.
++	 */
++	if (enable)
++		cci_write(ov5693->regmap, OV5693_MIPI_CTRL00_REG,
++			  OV5693_MIPI_CTRL00_IPU6, &ret);
++
+ 	cci_write(ov5693->regmap, OV5693_SW_STREAM_REG,
+ 		  enable ? OV5693_START_STREAMING : OV5693_STOP_STREAMING,
+ 		  &ret);
+-- 
+2.54.0
+


### PR DESCRIPTION
## What

Adds one commit to the `cameras` patchset (`patches/6.19/0013-cameras.patch`) that programs `MIPI_CTRL00` (register `0x4800`) `= 0x2d` before stream-on in the `ov5693` driver. With this, the front camera streams on IPU6 on:

- **Surface Pro 8** (`ov5693` at `INT33BE`) — verified by me, ~28 fps via libcamera, real image out (the SP8 case in #1893)
- **Surface Go 4** (`ov5693` at `INT33BE`) — confirmed by @Fugu0141 ([comment](https://github.com/linux-surface/linux-surface/pull/2171#issuecomment-4701721291)), ~28.6 fps (#2154)
- **Surface Pro 9** (`ov5693` at `OVTI5693`) — confirmed by @femito1 ([comment](https://github.com/linux-surface/linux-surface/pull/2171#issuecomment-4915338332)) (front-camera part of #1892)

**No ACPI match-table change is needed for the Pro 9 in this repo:** the `OVTI5693` HID is already added by the "Add camera support for Surface Pro 9" patch earlier in this same patchset (#1867, shipped in every 6.19 release since `6.19.7-1`) — both in `ov5693_acpi_match[]` and in `ipu-bridge.c`. Mainline v6.19 has neither, so the HID does still need to go to linux-media separately (@femito1 is planning to send that).

## Why it was broken

Mainline `ov5693.c` never writes `MIPI_CTRL00`, leaving it at the `0x00` power-on default. That default is fine on the **IPU3** Surface devices (Pro 5/6/7), where this sensor already works. On the IPU6 devices the same sensor is wired to an **IPU6**, and with `0x4800 == 0x00` the D-PHY never locks: the sensor reports streaming, the PHY powers up, but the receiver gets **zero CSI-2 packets** (no SOT/CRC errors at all) and capture ends in `stream stop time out`. Writing `0x2d` configures the clock-lane behaviour the IPU6 expects and frames flow.

## How it was found

Reverse-engineered from the Surface Pro 8 Windows driver (`ov5693.sys` register table) — `0x2d` is the value Windows programs. Diffing the Windows init against mainline made `MIPI_CTRL00` the obvious omission, and setting it alone fixes streaming.

## Honest caveats (feedback very welcome)

I want to be upfront — parts of this were experimental / AI-assisted and I'd really appreciate review:

- **Not tested on IPU3 (SP5/6/7).** The write is currently **unconditional**, and those devices use the same driver with the `0x00` default today. It should be confirmed there before merge — or gated if it regresses them.
- The `0x2d` **bit meaning is taken from the vendor driver, not a datasheet** — I know empirically it works, not the precise semantics of every bit.
- There's a **residual, rate-limited CSI-2 FIFO-overflow** message during capture on the SP8; frames still flow fine. Windows also writes companion registers (`0x4806/0x4816/0x4831/0x4d00/0x4d01`); `0x2d` alone is sufficient to stream so I left them out, but they (or an IPU6-side watermark tweak) may clean up the overflow.
- Only added to `patches/6.19/`. Happy to reformat, split, target the `linux-surface/kernel` tree instead, or propagate to other version dirs — whatever you prefer.

## Refs

- Fixes the SP8 case in #1893
- Fixes #2154 — Surface Go 4, same `ov5693` on IPU6 (confirmed in-thread)
- Helps #1892 — Surface Pro 9 front `ov5693` (confirmed in-thread; binds via the `OVTI5693` HID already in this patchset from #1867)

Verified on: Surface Pro 8, `kernel-surface 6.19.8-3`, Fedora 44, libcamera 0.7.1 — plus the Go 4 and Pro 9 confirmations linked above.
