### PR TITLE
[RFC] cameras: ov8865: enable optional pwr1 supply on Surface Pro 7+

### DIFF
--- a/patches/6.19/0014-ov8865-pwr1.patch
+++ b/patches/6.19/0014-ov8865-pwr1.patch
@@ -1,0 +1,103 @@
+From 6f9898c60ea6a1ed07d67c111b55d900dfdbb8ca Mon Sep 17 00:00:00 2001
+From: Joseph V. Lavigne <jlavig88@gmail.com>
+Date: Mon, 13 Jul 2026 19:40:00 -0500
+Subject: [PATCH RFC] media: i2c: ov8865: support an optional pwr1 supply
+
+The rear OV8865 camera on the Microsoft Surface Pro 7+ is described by
+ACPI together with an INT3472 GPIO regulator named "pwr1". The current
+OV8865 driver requests AVDD, DVDD and DOVDD only, leaving that extra rail
+unused.
+
+With pwr1 disabled the sensor does not acknowledge its first I2C
+transaction. Runtime resume fails while writing the software-reset
+register with -EREMOTEIO, and the DW9719 VCM cannot be instantiated.
+Increasing the power-up delay and retrying the reset five times does not
+change the failure.
+
+Request pwr1 as an optional regulator and sequence it around the existing
+OV8865 supplies. This keeps the change inert on platforms which do not
+provide that supply.
+
+On a Surface Pro 7+ with linux-surface 6.19.8-surface-3, enabling pwr1
+removes the -121 reset failure, allows the DW9719 VCM to instantiate and
+produces stable captures through libcamera:
+
+  3264x2448 SBGGR10: 15 fps
+  1280x720 ABGR8888: 30 fps
+
+This is submitted as RFC because maintainers may prefer to map the
+firmware rail to one of the standard OV8865 supply names in INT3472
+platform code instead of exposing pwr1 directly to the sensor driver.
+
+Link: https://github.com/linux-surface/linux-surface/issues/1702
+Signed-off-by: Joseph V. Lavigne <jlavig88@gmail.com>
+---
+ drivers/media/i2c/ov8865.c | 34 +++++++++++++++++++++++++++++++---
+ 1 file changed, 31 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/media/i2c/ov8865.c b/drivers/media/i2c/ov8865.c
+index a8586df14..5fbca9fea 100644
+--- a/drivers/media/i2c/ov8865.c
++++ b/drivers/media/i2c/ov8865.c
+@@ -1092,6 +1092,7 @@ struct ov8865_sensor {
+ 	struct regulator *avdd;
+ 	struct regulator *dvdd;
+ 	struct regulator *dovdd;
++	struct regulator *pwr1;
+ 
+ 	unsigned long extclk_rate;
+ 	const struct ov8865_pll_configs *pll_configs;
+@@ -2125,11 +2126,22 @@ static int ov8865_sensor_power(struct ov8865_sensor *sensor, bool on)
+ 		gpiod_set_value_cansleep(sensor->reset, 1);
+ 		gpiod_set_value_cansleep(sensor->powerdown, 1);
+ 
++		if (sensor->pwr1) {
++			ret = regulator_enable(sensor->pwr1);
++			if (ret) {
++				dev_err(sensor->dev,
++					"failed to enable PWR1 regulator\n");
++				return ret;
++			}
++		}
++
+ 		ret = regulator_enable(sensor->dovdd);
+ 		if (ret) {
+ 			dev_err(sensor->dev,
+ 				"failed to enable DOVDD regulator\n");
+-			return ret;
++			goto disable_pwr1;
+ 		}
+ 
+ 		ret = regulator_enable(sensor->avdd);
+@@ -2170,6 +2182,9 @@ disable_avdd:
+ 		regulator_disable(sensor->avdd);
+ disable_dovdd:
+ 		regulator_disable(sensor->dovdd);
++disable_pwr1:
++		if (sensor->pwr1)
++			regulator_disable(sensor->pwr1);
+ 	}
+ 
+ 	return ret;
+@@ -3027,6 +3042,19 @@ static int ov8865_probe(struct i2c_client *client)
+ 		return dev_err_probe(dev, PTR_ERR(sensor->avdd),
+ 				     "cannot get AVDD (analog) regulator\n");
+ 
++	/* Optional platform-specific sensor power rail. */
++	sensor->pwr1 = devm_regulator_get_optional(dev, "pwr1");
++	if (IS_ERR(sensor->pwr1)) {
++		ret = PTR_ERR(sensor->pwr1);
++
++		if (ret == -ENODEV) {
++			sensor->pwr1 = NULL;
++		} else {
++			return dev_err_probe(dev, ret,
++					     "cannot get optional PWR1 regulator\n");
++		}
++	}
++
+ 	/* Graph Endpoint */
+ 
+ 	handle = fwnode_graph_get_next_endpoint(dev_fwnode(dev), NULL);
+-- 
+2.50.1

--- a/patches/6.19/README-sp7plus-ov8865-pwr1.md
+++ b/patches/6.19/README-sp7plus-ov8865-pwr1.md
@@ -1,0 +1,58 @@
+# Surface Pro 7+ OV8865 `pwr1` test evidence
+
+This file accompanies the RFC patch in `0014-ov8865-pwr1.patch`.
+
+## Tested hardware and software
+
+- Microsoft Surface Pro 7+
+- Intel Tiger Lake IPU6 (`8086:9a19`)
+- Rear sensor: OmniVision OV8865 (`INT347A:00`)
+- Kernel: `6.19.8-surface-3`
+- libcamera: `0.7.0`
+
+## Failure before the patch
+
+The INT3472 layer exposed a regulator named `INT3472:01-pwr1`, but it had
+zero users and remained disabled. The OV8865 runtime-resume path failed on
+the first I2C software-reset write:
+
+```text
+ov8865 i2c-INT347A:00: failed to perform sw reset
+ov8865 i2c-INT347A:00: Error -121 runtime-resuming sensor, cannot instantiate VCM
+```
+
+Increasing the power-up delay and retrying the reset five times still
+returned `-121` on every attempt.
+
+## Result after the patch
+
+```text
+int3472-discrete INT3472:01:   con_id=pwr1, flags=0x0
+ov8865 i2c-INT347A:00: using optional pwr1 regulator
+ov8865 i2c-INT347A:00: Instantiated dw9719 VCM
+```
+
+Raw capture:
+
+```text
+3264x2448-SBGGR10/RAW
+15.00 fps
+10/10 frames captured
+bytesused: 15980544
+```
+
+Processed capture:
+
+```text
+1280x720-ABGR8888/sRGB
+30.0 fps
+30/30 frames captured
+bytesused: 3686400
+```
+
+## Front camera
+
+The OV5693 front camera also works on this device after programming
+MIPI register `0x4800` to `0x2d` before stream-on, as proposed in
+linux-surface PR #2171. On this Surface Pro 7+ it captures 1296x972
+SBGGR10 at approximately 28.7 fps.


### PR DESCRIPTION
# Surface Pro 7+ OV8865 `pwr1` test evidence

This file accompanies the RFC patch in `0014-ov8865-pwr1.patch`.

## Tested hardware and software

- Microsoft Surface Pro 7+
- Intel Tiger Lake IPU6 (`8086:9a19`)
- Rear sensor: OmniVision OV8865 (`INT347A:00`)
- Kernel: `6.19.8-surface-3`
- libcamera: `0.7.0`

## Failure before the patch

The INT3472 layer exposed a regulator named `INT3472:01-pwr1`, but it had
zero users and remained disabled. The OV8865 runtime-resume path failed on
the first I2C software-reset write:

```text
ov8865 i2c-INT347A:00: failed to perform sw reset
ov8865 i2c-INT347A:00: Error -121 runtime-resuming sensor, cannot instantiate VCM
```

Increasing the power-up delay and retrying the reset five times still
returned `-121` on every attempt.

## Result after the patch

```text
int3472-discrete INT3472:01:   con_id=pwr1, flags=0x0
ov8865 i2c-INT347A:00: using optional pwr1 regulator
ov8865 i2c-INT347A:00: Instantiated dw9719 VCM
```

Raw capture:

```text
3264x2448-SBGGR10/RAW
15.00 fps
10/10 frames captured
bytesused: 15980544
```

Processed capture:

```text
1280x720-ABGR8888/sRGB
30.0 fps
30/30 frames captured
bytesused: 3686400
```

## Front camera

The OV5693 front camera also works on this device after programming
MIPI register `0x4800` to `0x2d` before stream-on, as proposed in
linux-surface PR #2171. On this Surface Pro 7+ it captures 1296x972
SBGGR10 at approximately 28.7 fps.
