### PR TITLE
patches/6.19: int3472: map Surface Pro 7+ ov8865 DVDD supply pin

### DIFF
--- a/patches/6.19/0013-cameras.patch
+++ b/patches/6.19/0013-cameras.patch
@@ -1061,3 +1061,53 @@ index f5456330b..3418ff475 100644
 -- 
 2.53.0
 
+From a1b2c3d4e5f60718293a4b5c6d7e8f9012345678 Mon Sep 17 00:00:00 2001
+From: luqqas96 <282232570+luqqas96@users.noreply.github.com>
+Date: Fri, 21 Aug 2026 16:36:55 +0000
+Subject: [PATCH] platform/x86: int3472: Map Surface Pro 7+ ov8865 DVDD supply pin
+
+On the Microsoft Surface Pro 7+, the INT3472:01 device declares the rear
+ov8865 sensor's DVDD rail as GPIO type 0x08 on pin 0xaf.
+
+Mainline discrete.c has no case for type 0x08, leaving the supply unregistered.
+In this tree, type 0x08 was tentatively mapped to "pwr1", which no sensor
+driver requests, leaving the regulator disabled (users=0) and causing the
+sensor to fail runtime resume and software reset with Error -121 (EREMOTEIO).
+
+Sweeping GPIO states during unbind/bind cycles and testing via DSDT override
+confirms that this pin is functionally the sensor's digital supply (DVDD).
+Mapping HID INT347A type 0x08 to INT3472_GPIO_TYPE_HANDSHAKE ("dvdd") in
+int3472_gpio_map[] allows the existing regulator registration path to provide
+the supply as "dvdd" without modifying the ov8865 driver or relying on
+out-of-tree supply names.
+
+Link: https://github.com/linux-surface/linux-surface/pull/2201
+Link: https://github.com/linux-surface/linux-surface/issues/1702
+Signed-off-by: luqqas96 <282232570+luqqas96@users.noreply.github.com>
+Patchset: cameras
+---
+ drivers/platform/x86/intel/int3472/discrete.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/drivers/platform/x86/intel/int3472/discrete.c b/drivers/platform/x86/intel/int3472/discrete.c
+index 20962e8ac..c2349887b 100644
+--- a/drivers/platform/x86/intel/int3472/discrete.c
++++ b/drivers/platform/x86/intel/int3472/discrete.c
+@@ -160,6 +160,13 @@ static const struct int3472_gpio_map int3472_gpio_map[] = {
+ 		.type_from = INT3472_GPIO_TYPE_HANDSHAKE,
+ 		.type_to = INT3472_GPIO_TYPE_HANDSHAKE,
+ 		.con_id = "dvdd",
+ 		.enable_time_us = 45 * USEC_PER_MSEC,
+ 	},
++	{	/* Surface Pro 7+ declares the ov8865 dvdd pin as type 0x08 */
++		.hid = "INT347A",
++		.type_from = 0x08,
++		.type_to = INT3472_GPIO_TYPE_HANDSHAKE,
++		.con_id = "dvdd",
++		.enable_time_us = GPIO_REGULATOR_ENABLE_TIME,
++	},
+ };
+-- 
+2.53.0
+
+


### PR DESCRIPTION
## What

This PR adds an entry to `int3472_gpio_map[]` in `patches/6.19/0013-cameras.patch` to map the Surface Pro 7+ rear camera's (`ov8865` / `INT347A:00`) digital power supply pin (`0xaf`, declared in DSDT as type `0x08`) to `INT3472_GPIO_TYPE_HANDSHAKE` with supply name `dvdd`.

With this mapping, the rear camera on the **Surface Pro 7+** powers up and streams reliably (**1280x720 @ ~30 fps** and **3264x2448 RAW @ 15 fps**).

## Why

On the Surface Pro 7+, the ACPI `INT3472:01` device declares the rear sensor's digital supply as GPIO type `0x08` on pin `0xaf`.

1. **Mainline status:** In mainline kernel `discrete.c`, type `0x08` has no `case` statement and falls through to `unknown`, so no regulator is ever registered.
2. **Current linux-surface status:** In this tree's `0013-cameras.patch`, type `0x08` was tentatively mapped to the supply name `pwr1`. Because no sensor driver requests `pwr1`, the resulting regulator stays disabled (`users=0`) and the sensor never receives digital power:

```text
ov8865 i2c-INT347A:00: supply dvdd not found, using dummy regulator
int3472-discrete INT3472:01: GPIO type 0x08 detected on pin 0xaf
int3472-discrete INT3472:01:   con_id=pwr1, flags=0x0
ov8865 i2c-INT347A:00: failed to perform sw reset
ov8865 i2c-INT347A:00: Error -121 runtime-resuming sensor, cannot instantiate VCM
```

3. **Previous RFC approach (#2201):** PR #2201 proposed adding an optional `pwr1` supply request into `ov8865.c`. However, `pwr1` is an out-of-tree name specific to `0013-cameras.patch` and cannot be upstreamed to mainline.

## Solution

The pin **is** the sensor's DVDD rail. Mapping the firmware's type `0x08` to `INT3472_GPIO_TYPE_HANDSHAKE` (which provides `dvdd`) keyed on the sensor HID `INT347A` in `int3472_gpio_map[]` solves the problem cleanly:

```c
	{	/* Surface Pro 7+ declares the ov8865 dvdd pin as type 0x08 */
		.hid = "INT347A",
		.type_from = 0x08,
		.type_to = INT3472_GPIO_TYPE_HANDSHAKE,
		.con_id = "dvdd",
		.enable_time_us = GPIO_REGULATOR_ENABLE_TIME,
	},
```

### Advantages:
- **No changes to `ov8865.c`:** The driver continues requesting standard `dvdd`.
- **Precedent:** Follows the existing mapping architecture used for `OVTI08F4` in `discrete.c`.
- **Targeted:** Keyed specifically on HID `INT347A`, so Pro 9 (`OVTI5693` / `OVTID858`) remains untouched.
- **Mainline clean:** Can be sent directly upstream to `platform-driver-x86`.

## Verification

Tested on **Microsoft Surface Pro 7+** (Intel Tiger Lake IPU6 `8086:9a19`, Fedora 44, kernel `6.19.8-3.surface.fc43`, libcamera 0.7.1):
- `ov8865 i2c-INT347A:00: Instantiated dw9719 VCM`
- Stream capture: 1280x720 @ 30 fps (30/30 frames) and 3264x2448 RAW @ 15 fps (10/10 frames).
- Software reset and runtime-PM errors completely resolved.

## Refs
- Supersedes / solves the root cause discussed in #2201
- Resolves rear camera issue on SP7+ reported in #1702
