### PR TITLE
contrib: add S0ix suspend tweaks for the Surface Pro 7+

### DIFF
--- a/contrib/s0ix-sp7plus/50-nvme-runtime-pm.rules
+++ b/contrib/s0ix-sp7plus/50-nvme-runtime-pm.rules
@@ -1,0 +1,9 @@
+# Allow the NVMe SSD to use runtime power management.
+#
+# The KIOXIA BG4 shipped in the Surface Pro 7+ defaults to power/control="on",
+# which keeps the PCIe link out of its low-power states while idle.
+#
+# The vendor/device ids below match the KIOXIA BG4. Check your own SSD with
+#   lspci -nn | grep -i nvme
+# and adjust the ids, or match on the PCI slot instead.
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x1e0f", ATTR{device}=="0x0001", ATTR{power/control}="auto"

--- a/contrib/s0ix-sp7plus/99-log-wakeup
+++ b/contrib/s0ix-sp7plus/99-log-wakeup
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Log what woke the machine up, and how much of the suspend was actually
+# spent in hardware sleep (S0ix).
+#
+# systemd runs sleep hooks as:  $1 = pre|post   $2 = suspend|hibernate|...
+# Install as /usr/lib/systemd/system-sleep/99-log-wakeup (chmod +x).
+#
+# Nothing here may fail hard: a sleep hook that exits non-zero can interfere
+# with the suspend cycle, so every read is guarded.
+
+LOG=/var/log/wake-diagnostics.log
+
+case "$1" in
+  pre)
+    echo "=== $(date '+%F %T') SUSPEND ($2) ===" >> "$LOG"
+    ;;
+  post)
+    {
+      echo "=== $(date '+%F %T') RESUME ($2) ==="
+
+      # Which IRQ woke us. This file holds a bare IRQ number.
+      irq=$(cat /sys/power/pm_wakeup_irq 2>/dev/null)
+      echo "  wake IRQ: ${irq:-(not available)}"
+      if [ -n "$irq" ]; then
+        grep -E "^\s*${irq}:" /proc/interrupts 2>/dev/null | sed 's/^/    /'
+      fi
+
+      # Wakeup sources that have registered wakeups (column 4 = wakeup_count).
+      # Note this counter is cumulative since boot, not per cycle -- compare
+      # across resumes to see which source is growing.
+      echo "  --- wakeup sources with wakeup_count > 0 ---"
+      awk 'NR==1 || ($4+0)>0 {print "    " $0}' \
+          /sys/kernel/debug/wakeup_sources 2>/dev/null | head -12
+
+      # Time the hardware really spent in S0ix during the last cycle.
+      # /sys/power/suspend_stats/last_hw_sleep exists since kernel 6.9 and is
+      # readable without debugfs.
+      hw=$(cat /sys/power/suspend_stats/last_hw_sleep 2>/dev/null)
+      if [ -n "$hw" ]; then
+        echo "  hardware sleep: ${hw} us ($((hw / 1000000)) s)"
+      else
+        echo "  hardware sleep: (not available)"
+      fi
+      echo
+    } >> "$LOG"
+    ;;
+esac
+
+exit 0

--- a/contrib/s0ix-sp7plus/99-log-wakeup
+++ b/contrib/s0ix-sp7plus/99-log-wakeup
@@ -50,22 +50,31 @@ case "$1" in
 
       wall=0
       [ -r "$RUN/t.pre" ] && wall=$(( $(date +%s) - $(cat "$RUN/t.pre") ))
-      hw=$(cat /sys/power/suspend_stats/last_hw_sleep 2>/dev/null)
-      hw_s=$(( ${hw:-0} / 1000000 ))
       echo "  suspended for : ${wall} s"
-      echo "  hardware sleep: ${hw_s} s"
-      # hw_s > wall means the counter did not advance for this cycle, i.e. the
-      # machine never reached hardware sleep. Signal, not noise.
-      if [ "$wall" -gt 0 ] && [ "$hw_s" -gt "$wall" ]; then
-        echo "  S0ix residency: NONE (counter stale: never reached hw sleep)"
-      elif [ "$wall" -gt 0 ] && [ "$hw_s" -gt 0 ]; then
-        echo "  S0ix residency: $(( hw_s * 100 / wall ))%"
-      fi
 
-      # Independent corroboration from the PMC counter.
+      # Residency is computed from the PMC slp_s0 counter, which the driver
+      # accumulates in 64 bits and does not wrap.
       if [ -s "$RUN/slp.pre" ] && [ -s "$RUN/slp.post" ]; then
         a=$(cat "$RUN/slp.pre"); b=$(cat "$RUN/slp.post")
-        echo "  slp_s0 delta  : $(( (b - a) / 1000000 )) s"
+        slp=$(( (b - a) / 1000000 ))
+        echo "  in S0ix       : ${slp} s"
+        [ "$wall" -gt 0 ] && [ "$slp" -gt 0 ] && \
+          echo "  S0ix residency: $(( slp * 100 / wall ))%"
+      fi
+
+      # NOTE: /sys/power/suspend_stats/last_hw_sleep is derived from a 32-bit
+      # microsecond counter and wraps every 2^32 us (4295 s / 71.6 min). For
+      # any longer suspend it reports (actual mod 4295 s), which understates
+      # the truth badly -- a 10 h suspend at full residency reads as ~8%.
+      # Logged for reference only; never compute residency from it.
+      hw=$(cat /sys/power/suspend_stats/last_hw_sleep 2>/dev/null)
+      hw_s=$(( ${hw:-0} / 1000000 ))
+      if [ "$wall" -gt 4294 ]; then
+        echo "  last_hw_sleep : ${hw_s} s (wrapped, see note in script)"
+      elif [ "$hw_s" -gt "$wall" ]; then
+        echo "  last_hw_sleep : ${hw_s} s (stale: did not advance this cycle)"
+      else
+        echo "  last_hw_sleep : ${hw_s} s"
       fi
 
       # Which substate absorbed the time. S0i3.x is the deep one that matters.

--- a/contrib/s0ix-sp7plus/99-log-wakeup
+++ b/contrib/s0ix-sp7plus/99-log-wakeup
@@ -1,45 +1,80 @@
 #!/usr/bin/env bash
-# Log what woke the machine up, and how much of the suspend was actually
-# spent in hardware sleep (S0ix).
+# Wake + S0ix residency diagnostics for Tiger Lake Surface devices.
+#   $1 = pre|post   $2 = suspend|hibernate|...
+# Install: /usr/lib/systemd/system-sleep/99-log-wakeup  (chmod +x)
 #
-# systemd runs sleep hooks as:  $1 = pre|post   $2 = suspend|hibernate|...
-# Install as /usr/lib/systemd/system-sleep/99-log-wakeup (chmod +x).
-#
-# Nothing here may fail hard: a sleep hook that exits non-zero can interfere
-# with the suspend cycle, so every read is guarded.
+# Nothing may fail hard: a sleep hook exiting non-zero can disturb suspend.
 
 LOG=/var/log/wake-diagnostics.log
+RUN=/run/s0ix-diag
+PMC=/sys/kernel/debug/pmc_core
+mkdir -p "$RUN" 2>/dev/null
 
 case "$1" in
   pre)
-    echo "=== $(date '+%F %T') SUSPEND ($2) ===" >> "$LOG"
+    date +%s > "$RUN/t.pre"
+    cat "$PMC/slp_s0_residency_usec" 2>/dev/null > "$RUN/slp.pre"
+    cat "$PMC/substate_residencies"  2>/dev/null > "$RUN/sub.pre"
+    {
+      echo "=== $(date '+%F %T') SUSPEND ($2) ==="
+      # LTR = latency tolerance each IP block advertises. A low value means
+      # "service me within N ns", which keeps the SoC out of deep S0ix
+      # substates. NOTE: read here the system is still awake, so these are
+      # awake-state values -- indicative, not proof of what blocks suspend.
+      echo "  --- LTR: IP blocks advertising a latency requirement ---"
+      awk '{ l=$0; name=""; ns=0; sn=0
+        if (match(l,/PMC[0-9]+:[A-Za-z0-9_]+/)) { name=substr(l,RSTART,RLENGTH); sub(/^PMC[0-9]+:/,"",name) }
+        if (match(l,/Non-Snoop\(ns\): *[0-9]+/)) { t=substr(l,RSTART,RLENGTH); sub(/[^0-9]*/,"",t); ns=t+0
+           l=substr(l,1,RSTART-1) substr(l,RSTART+RLENGTH) }
+        if (match(l,/Snoop\(ns\): *[0-9]+/))     { t=substr(l,RSTART,RLENGTH); sub(/[^0-9]*/,"",t); sn=t+0 }
+        if (name!="" && (ns>0 || sn>0)) printf "    %-18s non-snoop=%-9d snoop=%-9d (ns)\n", name, ns, sn
+      }' "$PMC/ltr_show" 2>/dev/null
+    } >> "$LOG"
     ;;
+
   post)
+    cat "$PMC/slp_s0_residency_usec" 2>/dev/null > "$RUN/slp.post"
+    cat "$PMC/substate_residencies"  2>/dev/null > "$RUN/sub.post"
     {
       echo "=== $(date '+%F %T') RESUME ($2) ==="
 
-      # Which IRQ woke us. This file holds a bare IRQ number.
       irq=$(cat /sys/power/pm_wakeup_irq 2>/dev/null)
       echo "  wake IRQ: ${irq:-(not available)}"
-      if [ -n "$irq" ]; then
-        grep -E "^\s*${irq}:" /proc/interrupts 2>/dev/null | sed 's/^/    /'
-      fi
+      [ -n "$irq" ] && grep -E "^\s*${irq}:" /proc/interrupts 2>/dev/null | sed 's/^/    /'
 
-      # Wakeup sources that have registered wakeups (column 4 = wakeup_count).
-      # Note this counter is cumulative since boot, not per cycle -- compare
-      # across resumes to see which source is growing.
+      # Column 4 is wakeup_count: times this source aborted suspend or woke
+      # the system. Cumulative since boot -- compare across resumes.
       echo "  --- wakeup sources with wakeup_count > 0 ---"
       awk 'NR==1 || ($4+0)>0 {print "    " $0}' \
           /sys/kernel/debug/wakeup_sources 2>/dev/null | head -12
 
-      # Time the hardware really spent in S0ix during the last cycle.
-      # /sys/power/suspend_stats/last_hw_sleep exists since kernel 6.9 and is
-      # readable without debugfs.
+      wall=0
+      [ -r "$RUN/t.pre" ] && wall=$(( $(date +%s) - $(cat "$RUN/t.pre") ))
       hw=$(cat /sys/power/suspend_stats/last_hw_sleep 2>/dev/null)
-      if [ -n "$hw" ]; then
-        echo "  hardware sleep: ${hw} us ($((hw / 1000000)) s)"
-      else
-        echo "  hardware sleep: (not available)"
+      hw_s=$(( ${hw:-0} / 1000000 ))
+      echo "  suspended for : ${wall} s"
+      echo "  hardware sleep: ${hw_s} s"
+      # hw_s > wall means the counter did not advance for this cycle, i.e. the
+      # machine never reached hardware sleep. Signal, not noise.
+      if [ "$wall" -gt 0 ] && [ "$hw_s" -gt "$wall" ]; then
+        echo "  S0ix residency: NONE (counter stale: never reached hw sleep)"
+      elif [ "$wall" -gt 0 ] && [ "$hw_s" -gt 0 ]; then
+        echo "  S0ix residency: $(( hw_s * 100 / wall ))%"
+      fi
+
+      # Independent corroboration from the PMC counter.
+      if [ -s "$RUN/slp.pre" ] && [ -s "$RUN/slp.post" ]; then
+        a=$(cat "$RUN/slp.pre"); b=$(cat "$RUN/slp.post")
+        echo "  slp_s0 delta  : $(( (b - a) / 1000000 )) s"
+      fi
+
+      # Which substate absorbed the time. S0i3.x is the deep one that matters.
+      if [ -s "$RUN/sub.pre" ] && [ -s "$RUN/sub.post" ]; then
+        echo "  --- substate residency delta ---"
+        awk 'NR==FNR { if ($2 ~ /^[0-9]+$/) a[$1]=$2; next }
+             ($2 ~ /^[0-9]+$/) && ($1 in a) {
+               d=($2-a[$1])/1000000; if (d>0) printf "    %-10s %d s\n", $1, d }' \
+            "$RUN/sub.pre" "$RUN/sub.post"
       fi
       echo
     } >> "$LOG"

--- a/contrib/s0ix-sp7plus/99-no-wakeup-als.rules
+++ b/contrib/s0ix-sp7plus/99-no-wakeup-als.rules
@@ -1,0 +1,10 @@
+# Disable wakeup on the APDS9960 ambient light / proximity sensor.
+#
+# On the Surface Pro 7+ this sensor (ACPI id MSHW0184) is wakeup-enabled by
+# default. Its GPIO line sits on the Tiger Lake pin controller (INT34C5:00),
+# and proximity events are treated as system wake events -- so the device can
+# wake itself up while closed, even with adaptive brightness disabled.
+#
+# Adjust or drop this rule if you actually use the ambient light sensor for
+# adaptive brightness and do not mind the wakeups.
+ACTION=="add", SUBSYSTEM=="i2c", KERNEL=="i2c-MSHW0184:00", ATTR{power/wakeup}="disabled"

--- a/contrib/s0ix-sp7plus/README.md
+++ b/contrib/s0ix-sp7plus/README.md
@@ -78,23 +78,52 @@ Writing a name to `/proc/acpi/wakeup` toggles it rather than setting it, so
 the unit checks the current state first and is safe to run repeatedly. Drop
 the `TXHC` line if you do wake the machine from Thunderbolt devices.
 
-## 4. Diagnosing wakeups
+## 4. Diagnosing wakeups and S0ix residency
 
 `99-log-wakeup` is a `systemd-sleep` hook that appends one entry per
-suspend/resume cycle to `/var/log/wake-diagnostics.log`: the wake IRQ and its
-`/proc/interrupts` line, wakeup sources with a non-zero `wakeup_count`, and
-how long the hardware actually stayed in S0ix.
+suspend/resume cycle to `/var/log/wake-diagnostics.log`.
 
 ```bash
-sudo cp 99-log-wakeup /usr/lib/systemd/system-sleep/
-sudo chmod +x /usr/lib/systemd/system-sleep/99-log-wakeup
+sudo install -m 755 99-log-wakeup /usr/lib/systemd/system-sleep/
 ```
 
-The interesting number is `hardware sleep` versus the wall-clock time between
-the `SUSPEND` and `RESUME` lines. If the machine was suspended for eight hours
-but only slept for one, something is keeping the SoC out of S0ix -- that is a
-different problem from being woken up, and this log is how you tell them
-apart.
+A cycle looks like this:
+
+```
+=== 2026-09-01 22:20:05 SUSPEND (suspend) ===
+  --- LTR: IP blocks advertising a latency requirement ---
+    XHCI               non-snoop=0         snoop=499712    (ns)
+    AGGREGATED_SYSTEM  non-snoop=0         snoop=1047552   (ns)
+=== 2026-09-01 22:20:15 RESUME (suspend) ===
+  wake IRQ: 14
+      14:  10  ...  IR-IO-APIC  14-fasteoi  INT34C5:00
+  suspended for : 10 s
+  hardware sleep: 9 s
+  S0ix residency: 90%
+  slp_s0 delta  : 9 s
+  --- substate residency delta ---
+    S0i3.0     9 s
+```
+
+Two different failures show up here, and they are easy to confuse:
+
+**Something is waking you up.** The `wake IRQ` line and the wakeup-source
+table name the culprit. Note that `wakeup_count` is cumulative since boot, so
+compare it across resumes rather than reading it as a per-cycle value.
+
+**Something is stopping you from staying asleep.** Compare `S0ix residency`
+against the wall-clock time. A machine suspended for eight hours that only
+reached hardware sleep for one is not being woken up -- it is failing to stay
+in S0ix, and no amount of chasing wake sources will fix that. `slp_s0 delta`
+corroborates the number from an independent PMC counter, and the substate
+delta shows whether the time went to the deep state (`S0i3.x`) or a shallow
+one.
+
+The `LTR` block is the first place to look for the second failure. Each IP
+block advertises how long it tolerates being unattended; a block asking for
+tens of microseconds keeps the SoC out of substates whose exit latency is
+measured in milliseconds. These values are sampled while the system is still
+awake, so treat them as a lead rather than proof.
 
 The log is not rotated; add a `/etc/logrotate.d/` snippet if you intend to
 leave it installed long-term.
@@ -119,8 +148,13 @@ no measured "before" column to compare against.
 ### Known limitation
 
 Long suspends still show poor S0ix residency: on an overnight suspend the
-hardware reached S0ix for roughly one hour out of ten. The wake loop is fixed,
-but something on this platform still limits sustained hardware sleep, and the
-cause is not identified yet. If you are chasing battery drain during suspend,
-install the hook in section 4 first and check that number before assuming
-wakeups are to blame.
+hardware reached S0ix for roughly one hour out of ten. Short suspends are
+fine, and the substate delta shows the time does go to `S0i3.0`, so the SoC
+reaches the deep state and then keeps leaving it -- without generating a
+system wakeup, which is why the wake log looks clean while the battery drains.
+
+The wake loop is fixed; this is a separate, still unexplained problem. The
+`LTR` block logged at suspend time is the most promising lead, but I have not
+confirmed a culprit, so this README does not name one. If you are chasing
+battery drain during suspend, install the hook in section 4 first and check
+the residency number before assuming wakeups are to blame.

--- a/contrib/s0ix-sp7plus/README.md
+++ b/contrib/s0ix-sp7plus/README.md
@@ -97,12 +97,12 @@ A cycle looks like this:
 === 2026-09-01 22:20:15 RESUME (suspend) ===
   wake IRQ: 14
       14:  10  ...  IR-IO-APIC  14-fasteoi  INT34C5:00
-  suspended for : 10 s
-  hardware sleep: 9 s
-  S0ix residency: 90%
-  slp_s0 delta  : 9 s
+  suspended for : 34315 s
+  in S0ix       : 34293 s
+  S0ix residency: 99%
+  last_hw_sleep : 4228 s (wrapped, see note in script)
   --- substate residency delta ---
-    S0i3.0     9 s
+    S0i3.0     34267 s
 ```
 
 Two different failures show up here, and they are easy to confuse:
@@ -113,11 +113,19 @@ compare it across resumes rather than reading it as a per-cycle value.
 
 **Something is stopping you from staying asleep.** Compare `S0ix residency`
 against the wall-clock time. A machine suspended for eight hours that only
-reached hardware sleep for one is not being woken up -- it is failing to stay
-in S0ix, and no amount of chasing wake sources will fix that. `slp_s0 delta`
-corroborates the number from an independent PMC counter, and the substate
-delta shows whether the time went to the deep state (`S0i3.x`) or a shallow
-one.
+spent one in S0ix is not being woken up -- it is failing to stay asleep, and
+no amount of chasing wake sources will fix that. The substate delta shows
+whether the time went to the deep state (`S0i3.x`) or a shallow one.
+
+Measure this with the PMC `slp_s0_residency_usec` counter, which is what the
+residency line above uses. **Do not use
+`/sys/power/suspend_stats/last_hw_sleep` for this.** It is derived from a
+32-bit microsecond counter that wraps every 2^32 us -- 4295 s, or 71.6
+minutes -- so for any longer suspend it reports `actual mod 71.6 min`. On this
+machine a 9.5 h suspend at 99.9% residency reads as 4228 s there, which looks
+like a catastrophic 12%. Two overnight cycles matched the wrap prediction to
+within 0.3 s. The hook logs the value for reference and flags it once the
+suspend exceeds the wrap period.
 
 The `LTR` block is the first place to look for the second failure. Each IP
 block advertises how long it tolerates being unattended; a block asking for
@@ -130,31 +138,34 @@ leave it installed long-term.
 
 ## Results
 
-Measured over 114 suspend/resume cycles across 15 days of daily use, with all
-of the above applied:
+Measured over 114 suspend/resume cycles across 15 days of daily use, plus two
+~10 h cycles instrumented with the PMC counter, all with the tweaks above
+applied:
 
 | | Result |
 |---|---|
-| Cycles where the machine suspended but failed to sleep | 2 of 114 |
-| Hardware sleep residency, short suspends (minutes) | 99-100% |
-| Hardware sleep residency, long suspends (> 2 h) | 10-48% |
-| Longest single hardware sleep observed | ~1.16 h |
+| S0ix residency, suspends of 2-70 min (38 cycles) | 100% median, 98% worst |
+| Cycles in that set that failed to reach S0ix | 0 |
+| S0ix residency, two consecutive ~10 h suspends | 99.94% |
+| Substate the time went to | `S0i3.0` (the deep one) |
 
 Before the ALS fix the device could not stay suspended for more than a few
-seconds at a time; that behaviour is gone. These numbers are from the fixed
-configuration only -- the original failure was not instrumented, so there is
-no measured "before" column to compare against.
+seconds at a time; that behaviour is gone. The original failure was not
+instrumented, so there is no measured "before" column to compare against.
 
-### Known limitation
+Note the first row stops at 70 minutes. Those cycles were logged with
+`last_hw_sleep`, which is only trustworthy below the 71.6 minute wrap
+described in section 4; 27 of the 114 cycles ran longer and are not
+interpretable from that counter. The two 10 h figures come from
+`slp_s0_residency_usec` instead, which does not wrap.
 
-Long suspends still show poor S0ix residency: on an overnight suspend the
-hardware reached S0ix for roughly one hour out of ten. Short suspends are
-fine, and the substate delta shows the time does go to `S0i3.0`, so the SoC
-reaches the deep state and then keeps leaving it -- without generating a
-system wakeup, which is why the wake log looks clean while the battery drains.
+### A note on measuring this
 
-The wake loop is fixed; this is a separate, still unexplained problem. The
-`LTR` block logged at suspend time is the most promising lead, but I have not
-confirmed a culprit, so this README does not name one. If you are chasing
-battery drain during suspend, install the hook in section 4 first and check
-the residency number before assuming wakeups are to blame.
+An earlier revision of this file reported poor S0ix residency on long
+suspends. That was wrong, and the cause is worth repeating: it was the
+`last_hw_sleep` wrap described in section 4, not a hardware problem. Measured
+against the PMC counter, two consecutive ~10 h suspends both reached 99.94%
+residency.
+
+If you are diagnosing suspend battery drain on one of these machines, check
+which counter your numbers come from before concluding anything.

--- a/contrib/s0ix-sp7plus/README.md
+++ b/contrib/s0ix-sp7plus/README.md
@@ -1,0 +1,126 @@
+# S0ix / suspend tweaks for the Surface Pro 7+
+
+Configuration bits that improve `s2idle` (S0ix) behaviour on the **Surface
+Pro 7+** (Tiger Lake-UP3). The wakeup fix in particular is the important one:
+without it the device wakes itself up repeatedly while suspended.
+
+Everything here was tested on a Surface Pro 7+ running Fedora with kernel
+`6.19.8-3.surface`. Most of it is not Pro 7+ specific and should apply to
+other Tiger Lake Surface devices, but the device ids differ -- check them
+before copying (see the comments in each file).
+
+| File | Goes to |
+|---|---|
+| `99-no-wakeup-als.rules` | `/etc/udev/rules.d/` |
+| `50-nvme-runtime-pm.rules` | `/etc/udev/rules.d/` |
+| `disable-wake-sources.service` | `/etc/systemd/system/` |
+| `99-log-wakeup` | `/usr/lib/systemd/system-sleep/` (must be executable) |
+
+Treat these as examples: read the comments and adapt them rather than copying
+them blindly.
+
+## 1. Spurious wakeups from the ambient light sensor
+
+**Symptom.** The device wakes itself a few seconds after suspending, over and
+over, draining the battery in a closed bag. `/sys/power/pm_wakeup_irq` reports
+IRQ 14, which on this machine is `INT34C5:00` -- the Tiger Lake pin
+controller.
+
+**Cause.** The APDS9960 ambient light / proximity sensor (`i2c-MSHW0184:00`)
+has wakeup enabled by default. Its interrupt reaches the system through the
+pin controller and is treated as a wake event, so proximity changes wake the
+machine. Disabling adaptive brightness in the desktop environment does not
+help, because the sensor is still armed at the kernel level.
+
+**Fix.** Install `99-no-wakeup-als.rules`, then reboot or run:
+
+```bash
+sudo udevadm control --reload
+sudo udevadm trigger --subsystem-match=i2c
+```
+
+Verify:
+
+```bash
+cat /sys/bus/i2c/devices/i2c-MSHW0184:00/power/wakeup   # -> disabled
+```
+
+Note that IRQ 14 is shared: the pin controller also carries legitimate wake
+sources, so seeing IRQ 14 as the wake reason after this fix is normal and
+expected. What goes away is the runaway wake loop.
+
+## 2. NVMe runtime power management
+
+The KIOXIA BG4 in this machine comes up with `power/control=on`, which keeps
+the PCIe link from entering its low-power states while idle. Install
+`50-nvme-runtime-pm.rules` and check with:
+
+```bash
+cat /sys/bus/pci/devices/0000:01:00.0/power/control   # -> auto
+```
+
+The vendor/device ids in the rule are specific to that SSD; the Pro 7+ shipped
+with more than one model, so confirm yours with `lspci -nn | grep -i nvme`.
+
+## 3. Unnecessary ACPI wake sources
+
+`PEG0` (the PCIe bridge to the NVMe) and `TXHC` (the Thunderbolt 4 controller)
+are wakeup-enabled by default. Neither is useful on a tablet with no external
+Thunderbolt peripherals:
+
+```bash
+sudo cp disable-wake-sources.service /etc/systemd/system/
+sudo systemctl enable --now disable-wake-sources.service
+grep -E 'PEG0|TXHC' /proc/acpi/wakeup    # -> both *disabled
+```
+
+Writing a name to `/proc/acpi/wakeup` toggles it rather than setting it, so
+the unit checks the current state first and is safe to run repeatedly. Drop
+the `TXHC` line if you do wake the machine from Thunderbolt devices.
+
+## 4. Diagnosing wakeups
+
+`99-log-wakeup` is a `systemd-sleep` hook that appends one entry per
+suspend/resume cycle to `/var/log/wake-diagnostics.log`: the wake IRQ and its
+`/proc/interrupts` line, wakeup sources with a non-zero `wakeup_count`, and
+how long the hardware actually stayed in S0ix.
+
+```bash
+sudo cp 99-log-wakeup /usr/lib/systemd/system-sleep/
+sudo chmod +x /usr/lib/systemd/system-sleep/99-log-wakeup
+```
+
+The interesting number is `hardware sleep` versus the wall-clock time between
+the `SUSPEND` and `RESUME` lines. If the machine was suspended for eight hours
+but only slept for one, something is keeping the SoC out of S0ix -- that is a
+different problem from being woken up, and this log is how you tell them
+apart.
+
+The log is not rotated; add a `/etc/logrotate.d/` snippet if you intend to
+leave it installed long-term.
+
+## Results
+
+Measured over 114 suspend/resume cycles across 15 days of daily use, with all
+of the above applied:
+
+| | Result |
+|---|---|
+| Cycles where the machine suspended but failed to sleep | 2 of 114 |
+| Hardware sleep residency, short suspends (minutes) | 99-100% |
+| Hardware sleep residency, long suspends (> 2 h) | 10-48% |
+| Longest single hardware sleep observed | ~1.16 h |
+
+Before the ALS fix the device could not stay suspended for more than a few
+seconds at a time; that behaviour is gone. These numbers are from the fixed
+configuration only -- the original failure was not instrumented, so there is
+no measured "before" column to compare against.
+
+### Known limitation
+
+Long suspends still show poor S0ix residency: on an overnight suspend the
+hardware reached S0ix for roughly one hour out of ten. The wake loop is fixed,
+but something on this platform still limits sustained hardware sleep, and the
+cause is not identified yet. If you are chasing battery drain during suspend,
+install the hook in section 4 first and check that number before assuming
+wakeups are to blame.

--- a/contrib/s0ix-sp7plus/disable-wake-sources.service
+++ b/contrib/s0ix-sp7plus/disable-wake-sources.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Disable unnecessary ACPI wake sources for S0ix
+After=multi-user.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Writing a device name to /proc/acpi/wakeup *toggles* it, so each line first
+# checks that the source is still enabled. This keeps the unit idempotent.
+#
+# PEG0: PCIe bridge towards the NVMe SSD -- nothing behind it needs to wake
+#       the machine.
+# TXHC: Thunderbolt 4 controller -- only useful if you wake the device from
+#       an external Thunderbolt peripheral. Drop this line if you do.
+ExecStart=/bin/bash -c 'grep -q "PEG0.*enabled" /proc/acpi/wakeup && echo PEG0 > /proc/acpi/wakeup || true'
+ExecStart=/bin/bash -c 'grep -q "TXHC.*enabled" /proc/acpi/wakeup && echo TXHC > /proc/acpi/wakeup || true'
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The Surface Pro 7+ wakes itself up repeatedly while suspended. The cause is the APDS9960 ambient light / proximity sensor (`MSHW0184`), which is wakeup-enabled by default; its interrupt reaches the system through the Tiger Lake pin controller (`INT34C5:00`, IRQ 14), so proximity changes are treated as wake events. Disabling adaptive brightness in the desktop does not help, since the sensor is still armed at the kernel level.

This adds a `contrib/s0ix-sp7plus/` entry with the udev rule that fixes it, two smaller suspend tweaks, and a diagnostic hook:

- `99-no-wakeup-als.rules` — the ALS wakeup fix (the important one)
- `50-nvme-runtime-pm.rules` — lets the KIOXIA BG4 use runtime PM
- `disable-wake-sources.service` — disables the PEG0 / TXHC ACPI wake sources
- `99-log-wakeup` — a `systemd-sleep` hook logging the wake IRQ, the S0ix residency of each cycle, the substate breakdown, and the LTR values each IP block advertises
- `README.md` — symptoms, causes, install steps and verification commands

With all of it applied: 100% median S0ix residency across 38 suspends of 2–70 minutes with no failures, and 99.94% across two consecutive ~10 h suspends.

### One thing worth flagging beyond this PR

While measuring the above I found that `/sys/power/suspend_stats/last_hw_sleep` is unusable for long suspends on this platform. It is derived from a 32-bit microsecond counter and wraps every 2^32 us — 4295 s, or 71.6 minutes — so any longer suspend reports `actual mod 71.6 min`. A 9.5 h suspend at 99.94% residency reads as 4228 s there, which looks like a 12% failure. Two overnight cycles matched the wrap prediction to within 0.3 s:

| wall clock | `slp_s0_residency_usec` delta | `last_hw_sleep` | predicted `delta mod 2^32 us` |
|---|---|---|---|
| 34315 s | 34293 s (99.94%) | 4228 s | 4228.2 s |
| 37385 s | 37363 s (99.94%) | 3003 s | 3003.3 s |

I had drawn exactly the wrong conclusion from it before catching this, so the README documents the trap and the hook computes residency from `slp_s0_residency_usec` instead. If this is a genuine kernel-side bug rather than something specific to this machine, it probably deserves a report of its own — happy to open one separately if that is useful.

Device ids are commented in each file so users on other Tiger Lake Surface devices can check theirs before copying.